### PR TITLE
fix: drop usage of host network in config daemon

### DIFF
--- a/config/daemon/daemon.yaml
+++ b/config/daemon/daemon.yaml
@@ -17,7 +17,6 @@ spec:
       labels:
         control-plane: nic-configuration-daemon
     spec:
-      hostNetwork: true
       hostPID: true
       priorityClassName: system-node-critical
       containers:

--- a/deployment/nic-configuration-operator-chart/templates/config-daemon.yaml
+++ b/deployment/nic-configuration-operator-chart/templates/config-daemon.yaml
@@ -24,7 +24,6 @@ spec:
       nodeSelector: {{- toYaml .Values.operator.nodeSelector | nindent 8 }}
       serviceAccountName: {{ include "nic-configuration-operator.serviceAccountName" . }}
       terminationGracePeriodSeconds: 10
-      hostNetwork: true
       hostPID: true
       priorityClassName: system-node-critical
       containers:


### PR DESCRIPTION
config daemon uses a controller manager that tries to listen on some common ports which aren't always available in the host network context. The change was tested by QA and doesn't have an effect on the daemon's functionality.