### PR TITLE
Disable metrics and health checks ports in config daemon

### DIFF
--- a/cmd/nic-configuration-daemon/main.go
+++ b/cmd/nic-configuration-daemon/main.go
@@ -12,6 +12,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/Mellanox/nic-configuration-operator/api/v1alpha1"
 	"github.com/Mellanox/nic-configuration-operator/internal/controller"
@@ -36,6 +37,9 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,
+		// Setting bind address to 0 disables the health probe / metrics server
+		HealthProbeBindAddress: "0",
+		Metrics:                metricsserver.Options{BindAddress: "0"},
 	})
 	if err != nil {
 		log.Log.Error(err, "unable to create manager")


### PR DESCRIPTION
We don't use metrics and health checks endpoints in the config daemon, and they use common 8080/8081 ports by default, which might be taken on a busy node. Since we have to use host network inside the pod, this might result in a crash loop while waiting for the port to free up

The solution is to disable metrics and health checks until we need them