### PR TITLE
fix: Skip MAX_ACC_OUT_READ on the broken FW versions

### DIFF
--- a/cmd/nic-configuration-daemon/main.go
+++ b/cmd/nic-configuration-daemon/main.go
@@ -69,7 +69,7 @@ func main() {
 	}
 
 	hostUtils := host.NewHostUtils()
-	hostManager := host.NewHostManager(nodeName, hostUtils)
+	hostManager := host.NewHostManager(nodeName, hostUtils, mgr.GetEventRecorderFor("NicDeviceReconciler"))
 	maintenanceManager := maintenance.New(mgr.GetClient(), hostUtils, nodeName, namespace)
 
 	if err := initNicFwMap(namespace); err != nil {

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -52,6 +52,7 @@ const (
 	NvParamTrue               = "1"
 	NvParamLinkTypeInfiniband = "1"
 	NvParamLinkTypeEthernet   = "2"
+	NvParamZero               = "0"
 
 	SriovEnabledParam        = "SRIOV_EN"
 	SriovNumOfVfsParam       = "NUM_OF_VFS"

--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/Mellanox/nic-configuration-operator/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/Mellanox/nic-configuration-operator/api/v1alpha1"
@@ -327,6 +328,6 @@ func (h hostManager) DiscoverOfedVersion() (string, error) {
 	return h.hostUtils.GetOfedVersion()
 }
 
-func NewHostManager(nodeName string, hostUtils HostUtils) HostManager {
-	return hostManager{nodeName: nodeName, hostUtils: hostUtils, configValidation: newConfigValidation(hostUtils)}
+func NewHostManager(nodeName string, hostUtils HostUtils, eventRecorder record.EventRecorder) HostManager {
+	return hostManager{nodeName: nodeName, hostUtils: hostUtils, configValidation: newConfigValidation(hostUtils, eventRecorder)}
 }


### PR DESCRIPTION
According to the PRM, setting MAX_ACC_OUT_READ to zero enables the auto mode,
which applies the best suitable optimizations.
However, there is a bug in certain FW versions, where the zero value is not available.
In this case, until the fix is available, skipping this parameter and emitting a warning
