### PR TITLE
fix: make qos field in the RoceOptimized sections optional

### DIFF
--- a/api/v1alpha1/nicconfigurationtemplate_types.go
+++ b/api/v1alpha1/nicconfigurationtemplate_types.go
@@ -59,7 +59,7 @@ type RoceOptimizedSpec struct {
 	// Optimize RoCE
 	Enabled bool `json:"enabled"`
 	// Quality of Service settings
-	Qos *QosSpec `json:"qos"`
+	Qos *QosSpec `json:"qos,omitempty"`
 }
 
 // GpuDirectOptimizedSpec specifies GPU Direct optimization settings

--- a/config/crd/bases/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
+++ b/config/crd/bases/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
@@ -164,7 +164,6 @@ spec:
                         type: object
                     required:
                     - enabled
-                    - qos
                     type: object
                 required:
                 - linkType

--- a/config/crd/bases/configuration.net.nvidia.com_nicdevices.yaml
+++ b/config/crd/bases/configuration.net.nvidia.com_nicdevices.yaml
@@ -143,7 +143,6 @@ spec:
                             type: object
                         required:
                         - enabled
-                        - qos
                         type: object
                     required:
                     - linkType

--- a/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
+++ b/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
@@ -164,7 +164,6 @@ spec:
                         type: object
                     required:
                     - enabled
-                    - qos
                     type: object
                 required:
                 - linkType

--- a/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicdevices.yaml
+++ b/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicdevices.yaml
@@ -143,7 +143,6 @@ spec:
                             type: object
                         required:
                         - enabled
-                        - qos
                         type: object
                     required:
                     - linkType


### PR DESCRIPTION
If not specified, trust will be set to dscp and pfc to 0,0,0,1,0,0,0,0