### PR TITLE
fix: reboot the system if the fw reset failed

### DIFF
--- a/pkg/host/host_test.go
+++ b/pkg/host/host_test.go
@@ -858,7 +858,7 @@ var _ = Describe("HostManager", func() {
 						mockConfigValidation.AssertExpectations(GinkgoT())
 					})
 
-					It("should return error if ResetNicFirmware fails", func() {
+					It("should request reboot if ResetNicFirmware fails", func() {
 						nvConfig := types.NvConfigQuery{
 							CurrentConfig:  map[string][]string{"param1": {"value1"}},
 							NextBootConfig: map[string][]string{"param1": {"value1"}},
@@ -873,8 +873,8 @@ var _ = Describe("HostManager", func() {
 						mockHostUtils.On("ResetNicFirmware", ctx, pciAddress).Return(resetFirmwareErr)
 
 						reboot, err := manager.ApplyDeviceNvSpec(ctx, device)
-						Expect(reboot).To(BeFalse())
-						Expect(err).To(MatchError(resetFirmwareErr))
+						Expect(reboot).To(BeTrue())
+						Expect(err).To(BeNil())
 
 						mockHostUtils.AssertExpectations(GinkgoT())
 						mockConfigValidation.AssertExpectations(GinkgoT())


### PR DESCRIPTION
We attempt a fw reset after enabling ADVANCED_PCI_SETTINGS to softly reset the device's fw and enable the hidden mstconfig parameters. We do it to avoid an unnecessary reboot. However, if the fw reset doesn't succeed, we don't have other options.