### PR TITLE
fix: validate if nv config update applied after reboot

### DIFF
--- a/cmd/nic-configuration-daemon/main.go
+++ b/cmd/nic-configuration-daemon/main.go
@@ -68,8 +68,10 @@ func main() {
 		}
 	}
 
+	eventRecorder := mgr.GetEventRecorderFor("NicDeviceReconciler")
+
 	hostUtils := host.NewHostUtils()
-	hostManager := host.NewHostManager(nodeName, hostUtils, mgr.GetEventRecorderFor("NicDeviceReconciler"))
+	hostManager := host.NewHostManager(nodeName, hostUtils, eventRecorder)
 	maintenanceManager := maintenance.New(mgr.GetClient(), hostUtils, nodeName, namespace)
 
 	if err := initNicFwMap(namespace); err != nil {
@@ -90,6 +92,7 @@ func main() {
 		NamespaceName:      namespace,
 		HostManager:        hostManager,
 		MaintenanceManager: maintenanceManager,
+		EventRecorder:      eventRecorder,
 	}
 	err = nicDeviceReconciler.SetupWithManager(mgr, true)
 	if err != nil {

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -30,6 +30,7 @@ const (
 	RuntimeConfigUpdateFailedReason     = "RuntimeConfigUpdateFailed"
 	UpdateSuccessfulReason              = "UpdateSuccessful"
 	SpecValidationFailed                = "SpecValidationFailed"
+	FirmwareError                       = "FirmwareError"
 
 	DeviceConfigSpecEmptyReason = "DeviceConfigSpecEmpty"
 	DeviceFwMatchReason         = "DeviceFirmwareConfigMatch"
@@ -79,4 +80,6 @@ const (
 
 	SupportedNicFirmwareConfigmap = "supported-nic-firmware"
 	Mlx5ModuleVersionPath         = "/sys/bus/pci/drivers/mlx5_core/module/version"
+
+	FwConfigNotAppliedAfterRebootErrorMsg = "firmware configuration failed to apply after reboot"
 )

--- a/pkg/host/mocks/HostUtils.go
+++ b/pkg/host/mocks/HostUtils.go
@@ -9,6 +9,8 @@ import (
 
 	pci "github.com/jaypipes/ghw/pkg/pci"
 
+	time "time"
+
 	types "github.com/Mellanox/nic-configuration-operator/pkg/types"
 )
 
@@ -50,6 +52,34 @@ func (_m *HostUtils) GetFirmwareVersionAndPSID(pciAddr string) (string, string, 
 	}
 
 	return r0, r1, r2
+}
+
+// GetHostUptimeSeconds provides a mock function with given fields:
+func (_m *HostUtils) GetHostUptimeSeconds() (time.Duration, error) {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetHostUptimeSeconds")
+	}
+
+	var r0 time.Duration
+	var r1 error
+	if rf, ok := ret.Get(0).(func() (time.Duration, error)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() time.Duration); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(time.Duration)
+	}
+
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // GetInterfaceName provides a mock function with given fields: pciAddr


### PR DESCRIPTION
There might be a case where FW config didn't apply after a reboot because of some error in FW. In this case
we don't want the node to be kept in a reboot loop (FW configured -> reboot -> Config was not applied -> FW configured -> etc.).
To break the reboot loop, we should compare the last time the status was changed to PendingReboot to the node's uptime.
If the node started after the status was changed, we assume the node was rebooted and the config couldn't apply.
In this case, we indicate the error to the user with the status change and emit an error event.