### PR TITLE
fix for a flaky test

### DIFF
--- a/internal/controller/nicconfigurationtemplate_controller_test.go
+++ b/internal/controller/nicconfigurationtemplate_controller_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"slices"
 	"sync"
 	"time"
 
@@ -58,7 +59,9 @@ func getMatchedDevicesFromStatus(ctx context.Context, name string, namespace str
 	return func() []string {
 		templateObj := &v1alpha1.NicConfigurationTemplate{}
 		Expect(client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, templateObj)).To(Succeed())
-		return templateObj.Status.NicDevices
+		devices := templateObj.Status.NicDevices
+		slices.Sort(devices)
+		return devices
 	}
 }
 


### PR DESCRIPTION
order of devices in this test is not guaranteed, making it sporadically fail during slice matching. Sort the slice before the check