### PR TITLE
switch from mstconfig tool to mlxconfig

### DIFF
--- a/pkg/host/utils.go
+++ b/pkg/host/utils.go
@@ -374,21 +374,21 @@ func (h *hostUtils) GetRDMADeviceName(pciAddr string) string {
 	return rdmaDevices[0]
 }
 
-// queryMSTConfig runs a query on mstconfig to parse out default, current and nextboot configurations
+// queryMLXConfig runs a query on mlxconfig to parse out default, current and nextboot configurations
 // might run recursively to expand array parameters' values
-func (h *hostUtils) queryMSTConfig(ctx context.Context, query types.NvConfigQuery, pciAddr string, additionalParameter string) error {
-	log.Log.Info(fmt.Sprintf("mstconfig -d %s query %s", pciAddr, additionalParameter)) //TODO change verbosity
+func (h *hostUtils) queryMLXConfig(ctx context.Context, query types.NvConfigQuery, pciAddr string, additionalParameter string) error {
+	log.Log.Info(fmt.Sprintf("mlxconfig -d %s query %s", pciAddr, additionalParameter)) //TODO change verbosity
 	valueInBracketsRegex := regexp.MustCompile(`^(.*?)\(([^)]*)\)$`)
 
 	var cmd execUtils.Cmd
 	if additionalParameter == "" {
-		cmd = h.execInterface.CommandContext(ctx, "mstconfig", "-d", pciAddr, "-e", "query")
+		cmd = h.execInterface.CommandContext(ctx, "mlxconfig", "-d", pciAddr, "-e", "query")
 	} else {
-		cmd = h.execInterface.CommandContext(ctx, "mstconfig", "-d", pciAddr, "-e", "query", additionalParameter)
+		cmd = h.execInterface.CommandContext(ctx, "mlxconfig", "-d", pciAddr, "-e", "query", additionalParameter)
 	}
 	output, err := cmd.Output()
 	if err != nil {
-		log.Log.Error(err, "queryMSTConfig(): Failed to run mstconfig", "output", string(output))
+		log.Log.Error(err, "queryMLXConfig(): Failed to run mlxconfig", "output", string(output))
 		return err
 	}
 
@@ -442,7 +442,7 @@ func (h *hostUtils) queryMSTConfig(ctx context.Context, query types.NvConfigQuer
 
 			// If the parameter value is an array, we want to extract values for all indices
 			if strings.HasPrefix(defaultVal, arrayPrefix) {
-				err = h.queryMSTConfig(ctx, query, pciAddr, paramName+strings.TrimPrefix(defaultVal, arrayPrefix))
+				err = h.queryMLXConfig(ctx, query, pciAddr, paramName+strings.TrimPrefix(defaultVal, arrayPrefix))
 				if err != nil {
 					return err
 				}
@@ -486,9 +486,9 @@ func (h *hostUtils) QueryNvConfig(ctx context.Context, pciAddr string) (types.Nv
 
 	query := types.NewNvConfigQuery()
 
-	err := h.queryMSTConfig(ctx, query, pciAddr, "")
+	err := h.queryMLXConfig(ctx, query, pciAddr, "")
 	if err != nil {
-		log.Log.Error(err, "Failed to parse mstconfig query output", "device", pciAddr)
+		log.Log.Error(err, "Failed to parse mlxconfig query output", "device", pciAddr)
 	}
 
 	return query, err
@@ -498,10 +498,10 @@ func (h *hostUtils) QueryNvConfig(ctx context.Context, pciAddr string) (types.Nv
 func (h *hostUtils) SetNvConfigParameter(pciAddr string, paramName string, paramValue string) error {
 	log.Log.Info("HostUtils.SetNvConfigParameter()", "pciAddr", pciAddr, "paramName", paramName, "paramValue", paramValue)
 
-	cmd := h.execInterface.Command("mstconfig", "-d", pciAddr, "--yes", "set", paramName+"="+paramValue)
+	cmd := h.execInterface.Command("mlxconfig", "-d", pciAddr, "--yes", "set", paramName+"="+paramValue)
 	_, err := cmd.Output()
 	if err != nil {
-		log.Log.Error(err, "SetNvConfigParameter(): Failed to run mstconfig")
+		log.Log.Error(err, "SetNvConfigParameter(): Failed to run mlxconfig")
 		return err
 	}
 	return nil
@@ -511,10 +511,10 @@ func (h *hostUtils) SetNvConfigParameter(pciAddr string, paramName string, param
 func (h *hostUtils) ResetNvConfig(pciAddr string) error {
 	log.Log.Info("HostUtils.ResetNvConfig()", "pciAddr", pciAddr)
 
-	cmd := h.execInterface.Command("mstconfig", "-d", pciAddr, "--yes", "reset")
+	cmd := h.execInterface.Command("mlxconfig", "-d", pciAddr, "--yes", "reset")
 	_, err := cmd.Output()
 	if err != nil {
-		log.Log.Error(err, "ResetNvConfig(): Failed to run mstconfig")
+		log.Log.Error(err, "ResetNvConfig(): Failed to run mlxconfig")
 		return err
 	}
 	return nil

--- a/pkg/host/utils_test.go
+++ b/pkg/host/utils_test.go
@@ -300,7 +300,7 @@ var _ = Describe("HostUtils", func() {
 			Expect(speed).To(Equal(-1))
 		})
 	})
-	Describe("queryMSTConfig", func() {
+	Describe("queryMLXConfig", func() {
 		var (
 			h        *hostUtils
 			fakeExec *execTesting.FakeExec
@@ -310,7 +310,7 @@ var _ = Describe("HostUtils", func() {
 			fakeExec = &execTesting.FakeExec{}
 
 			// Prepare the fake commands and their outputs
-			// First command: mstconfig -d 0000:03:00.0 q
+			// First command: mlxconfig -d 0000:03:00.0 q
 			cmd1 := &execTesting.FakeCmd{}
 			cmd1.OutputScript = append(cmd1.OutputScript,
 				func() ([]byte, []byte, error) {
@@ -330,7 +330,7 @@ The '*' shows parameters with next value different from default/current value.
 				},
 			)
 
-			// Second command: mstconfig -d 0000:03:00.0 q ESWITCH_HAIRPIN_DESCRIPTORS[0..7]
+			// Second command: mlxconfig -d 0000:03:00.0 q ESWITCH_HAIRPIN_DESCRIPTORS[0..7]
 			cmd2 := &execTesting.FakeCmd{}
 			cmd2.OutputScript = append(cmd2.OutputScript,
 				func() ([]byte, []byte, error) {
@@ -351,12 +351,12 @@ Configurations:                              Default         Current         Nex
 
 			fakeExec.CommandScript = []execTesting.FakeCommandAction{
 				func(cmd string, args ...string) exec.Cmd {
-					Expect(cmd).To(Equal("mstconfig"))
+					Expect(cmd).To(Equal("mlxconfig"))
 					Expect(args).To(Equal([]string{"-d", pciAddress, "-e", "query"}))
 					return cmd1
 				},
 				func(cmd string, args ...string) exec.Cmd {
-					Expect(cmd).To(Equal("mstconfig"))
+					Expect(cmd).To(Equal("mlxconfig"))
 					Expect(args).To(Equal([]string{"-d", pciAddress, "-e", "query", "ESWITCH_HAIRPIN_DESCRIPTORS[0..7]"}))
 					return cmd2
 				},
@@ -367,7 +367,7 @@ Configurations:                              Default         Current         Nex
 			}
 		})
 
-		It("should parse mstconfig output correctly", func() {
+		It("should parse mlxconfig output correctly", func() {
 			query, err := h.QueryNvConfig(context.TODO(), pciAddress)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -409,7 +409,7 @@ Device type:    ConnectX4
 
 			fakeExec.CommandScript = []execTesting.FakeCommandAction{
 				func(cmd string, args ...string) exec.Cmd {
-					Expect(cmd).To(Equal("mstconfig"))
+					Expect(cmd).To(Equal("mlxconfig"))
 					Expect(args).To(Equal([]string{"-d", pciAddress, "-e", "query"}))
 					return cmd1
 				},
@@ -425,18 +425,18 @@ Device type:    ConnectX4
 			Expect(query.NextBootConfig).To(BeEmpty())
 		})
 
-		It("should return error if mstconfig command fails", func() {
+		It("should return error if mlxconfig command fails", func() {
 			// Set the command to return an error
 			cmd1 := &execTesting.FakeCmd{}
 			cmd1.OutputScript = append(cmd1.OutputScript,
 				func() ([]byte, []byte, error) {
-					return nil, nil, fmt.Errorf("mstconfig error")
+					return nil, nil, fmt.Errorf("mlxconfig error")
 				},
 			)
 
 			fakeExec.CommandScript = []execTesting.FakeCommandAction{
 				func(cmd string, args ...string) exec.Cmd {
-					Expect(cmd).To(Equal("mstconfig"))
+					Expect(cmd).To(Equal("mlxconfig"))
 					Expect(args).To(Equal([]string{"-d", pciAddress, "-e", "query"}))
 					return cmd1
 				},
@@ -446,7 +446,7 @@ Device type:    ConnectX4
 
 			_, err := h.QueryNvConfig(context.TODO(), pciAddress)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("mstconfig error"))
+			Expect(err.Error()).To(Equal("mlxconfig error"))
 		})
 	})
 	Describe("GetMaxReadRequestSize", func() {


### PR DESCRIPTION
mstconfig is a version of the mlxconfig tool,
distributed via the package manager. That means it only receives the necessary security fixes and might not feature the up-to-date functionality (e.g. support for new NICs). Instead of that, let's switch to using the mlxconfig, which is distributed as part of the MLNX_OFED packages. That way, we are always using the newest version.

We already install mlxconfig as part of MFT package in the config daemon image.

In the future, we can add a CI job that would periodically query the latest version from the ofed repo and update the tools versions accordingly.