### PR TITLE
Refactor controller tests for stability and readability

### DIFF
--- a/internal/controller/nicdevice_controller.go
+++ b/internal/controller/nicdevice_controller.go
@@ -76,7 +76,11 @@ type nicDeviceConfigurationStatus struct {
 
 // Reconcile reconciles the NicConfigurationTemplate object
 func (r *NicDeviceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	// Get only the devices with non-empty spec to reconcile
+	// Only handle node-policy-sync-event
+	if req.Name != nicDeviceSyncEventName || req.Namespace != "" {
+		return reconcile.Result{}, nil
+	}
+
 	configStatuses, err := r.getDevices(ctx)
 	if err != nil {
 		log.Log.Error(err, "failed to get devices to reconcile")

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controller
 
 import (
-	"context"
 	"fmt"
 	"path/filepath"
 	"runtime"
@@ -26,11 +25,8 @@ import (
 	"github.com/Mellanox/nic-configuration-operator/pkg/ncolog"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -42,11 +38,10 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-const namespaceName = "nic-configuration-operator"
-
 var cfg *rest.Config
-var k8sClient client.Client
 var testEnv *envtest.Environment
+
+const nodeName = "test-node"
 
 func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -80,17 +75,6 @@ var _ = BeforeSuite(func() {
 	Expect(cfg).NotTo(BeNil())
 
 	err = configurationnetv1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	//+kubebuilder:scaffold:scheme
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
-
-	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
-		Name: namespaceName,
-	}}
-	err = k8sClient.Create(context.Background(), ns)
 	Expect(err).NotTo(HaveOccurred())
 })
 

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -1,0 +1,83 @@
+/*
+2024 NVIDIA CORPORATION & AFFILIATES
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"sync"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/Mellanox/nic-configuration-operator/api/v1alpha1"
+)
+
+func createManager() manager.Manager {
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:     scheme.Scheme,
+		Metrics:    metricsserver.Options{BindAddress: "0"},
+		Controller: config.Controller{SkipNameValidation: ptr.To(true)},
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(mgr).NotTo(BeNil())
+
+	err = mgr.GetCache().IndexField(context.Background(), &v1alpha1.NicDevice{}, "status.node", func(o client.Object) []string {
+		return []string{o.(*v1alpha1.NicDevice).Status.Node}
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	return mgr
+}
+
+// returns namespace name
+func createNodeAndRandomNamespace(ctx context.Context, client client.Client) string {
+	node := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}
+	Expect(client.Create(ctx, node)).To(Succeed())
+
+	namespaceName := "nic-configuration-operator-" + rand.String(6)
+	ns := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: namespaceName,
+	}}
+	Expect(client.Create(context.Background(), ns)).To(Succeed())
+
+	return namespaceName
+}
+
+func startManager(manager manager.Manager, ctx context.Context, wg *sync.WaitGroup) {
+	wg.Add(1)
+	go func() {
+		defer GinkgoRecover()
+		defer wg.Done()
+		Expect(manager.Start(ctx)).To(Succeed())
+		log.Log.Info("started manager for test", "test", GinkgoT().Name())
+	}()
+
+	if !manager.GetCache().WaitForCacheSync(ctx) {
+		log.Log.Error(nil, "caches did not sync")
+	}
+}


### PR DESCRIPTION
* Extract common util functions into a separate file
* Fix race conditions by waiting for manager cache to sync in the beginning of the tests
* Add a condition to NicDeviceReconciler to only reconcile specific events from the event handler