### PR TITLE
chore: change base image to doca-host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,19 @@ COPY ./ ./
 #RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/maintenance-manager/main.go
 RUN --mount=type=cache,target=/go/pkg/mod/ GO_GCFLAGS=${GCFLAGS} make build-manager
 
-FROM quay.io/centos/centos:stream9
+FROM nvcr.io/nvidia/doca/doca:2.10.0-full-rt-host
 
-RUN yum -y install mstflint && yum clean all
+ARG TARGETARCH
+ENV MFT_VERSION=4.29.0-131
+
+ARG PACKAGES="dpkg-dev=1.21.1ubuntu2.3 mstflint=4.21.0+1-1ubuntu0.1~22.04.1"
+
+# enable deb-src repos
+RUN sed -i 's/^# deb-src/deb-src/g' /etc/apt/sources.list /etc/apt/sources.list.d/*
+
+RUN apt-get update -y
+RUN apt-get install -y --no-install-recommends ${PACKAGES}
+RUN apt-get source ${PACKAGES}
 
 WORKDIR /
 COPY --from=builder /workspace/build/manager .
@@ -33,4 +43,4 @@ USER 65532:65532
 
 ENTRYPOINT ["/manager"]
 
-LABEL org.opencontainers.image.source=https://github.com/Mellanox/nic-configuration-operator
+LABEL org.opencontainers.image.source=https://nvcr.io/nvidia/cloud-native/nic-configuration-operator

--- a/Dockerfile.nic-configuration-daemon
+++ b/Dockerfile.nic-configuration-daemon
@@ -22,35 +22,32 @@ COPY ./ ./
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN --mount=type=cache,target=/go/pkg/mod/ GO_GCFLAGS=${GCFLAGS} make build-daemon
 
-FROM quay.io/centos/centos:stream9
+FROM nvcr.io/nvidia/doca/doca:2.10.0-full-rt-host
+
 ARG TARGETARCH
-ENV RHEL_VERSION=9.4
-ENV OFED_PACKAGE_MAJOR_VERSION=24.07
-ENV OFED_PACKAGE_MINOR_VERSION=0.6.1.0
 ENV MFT_VERSION=4.29.0-131
-ENV MLNX_TOOLS_VERSION=0.2407061
 
-RUN yum -y install hwdata mstflint wget pciutils procps-ng kmod systemd && yum clean all
+ARG PACKAGES="dpkg-dev=1.21.1ubuntu2.3 curl=7.81.0-1ubuntu1.20 systemd-sysv=249.11-0ubuntu3.15 mstflint=4.21.0+1-1ubuntu0.1~22.04.1"
 
-RUN ARCH_SUFFIX="${TARGETARCH}" \
-    && ARCH_SUFFIX="${ARCH_SUFFIX//amd64/x86_64}" \
-    && ARCH_SUFFIX="${ARCH_SUFFIX//arm64/aarch64}" \
-    && wget https://linux.mellanox.com/public/repo/mlnx_ofed/${OFED_PACKAGE_MAJOR_VERSION}-${OFED_PACKAGE_MINOR_VERSION}/rhel${RHEL_VERSION}/${ARCH_SUFFIX}/mlnx-tools-${OFED_PACKAGE_MAJOR_VERSION}-${MLNX_TOOLS_VERSION}.${ARCH_SUFFIX}.rpm \
-    && rpm -i mlnx-tools-${OFED_PACKAGE_MAJOR_VERSION}-${MLNX_TOOLS_VERSION}.${ARCH_SUFFIX}.rpm \
-    && rm mlnx-tools-${OFED_PACKAGE_MAJOR_VERSION}-${MLNX_TOOLS_VERSION}.${ARCH_SUFFIX}.rpm
+# enable deb-src repos
+RUN sed -i 's/^# deb-src/deb-src/g' /etc/apt/sources.list /etc/apt/sources.list.d/*
 
-RUN ARCH_SUFFIX1="${TARGETARCH}" \
-    && ARCH_SUFFIX1="${ARCH_SUFFIX1//amd64/x86_64}" \
-    && ARCH_SUFFIX1="${ARCH_SUFFIX1//arm64/aarch64}" \
-    && ARCH_SUFFIX2="${TARGETARCH}" \
-    && ARCH_SUFFIX2="${ARCH_SUFFIX2//amd64/x86_64}" \
-    && wget https://linux.mellanox.com/public/repo/mlnx_ofed/${OFED_PACKAGE_MAJOR_VERSION}-${OFED_PACKAGE_MINOR_VERSION}/rhel${RHEL_VERSION}/${ARCH_SUFFIX1}/mft-${MFT_VERSION}.${ARCH_SUFFIX2}.rpm \
-    && rpm -i mft-${MFT_VERSION}.${ARCH_SUFFIX2}.rpm \
-    && rm mft-${MFT_VERSION}.${ARCH_SUFFIX2}.rpm
+RUN apt-get update -y
+RUN apt-get install -y --no-install-recommends ${PACKAGES}
+RUN apt-get source ${PACKAGES}
+
+RUN case ${TARGETARCH} in \
+        amd64) ARCH=x86_64 ;; \
+        arm64) ARCH=arm64 ;; \
+        *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
+    esac && \
+    curl -fsSL https://www.mellanox.com/downloads/MFT/mft-${MFT_VERSION}-${ARCH}-deb.tgz | tar -xz -C /tmp && \
+    cd /tmp/mft-${MFT_VERSION}-${ARCH}-deb && \
+    ./install.sh --without-kernel
 
 WORKDIR /
 COPY --from=builder /workspace/build/nic-configuration-daemon .
 
 ENTRYPOINT ["/nic-configuration-daemon"]
 
-LABEL org.opencontainers.image.source=https://github.com/Mellanox/nic-configuration-daemon
+LABEL org.opencontainers.image.source=https://nvcr.io/nvidia/cloud-native/nic-configuration-daemon


### PR DESCRIPTION
Switching to doca-host enables us to use the DMS.
Additionally, doca-host base image is approved for NGC, which will make our life easier in the future.