### PR TITLE
chore: downgrade doca to 2.9.2 to enable arm build + copy sources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ COPY ./ ./
 #RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/maintenance-manager/main.go
 RUN --mount=type=cache,target=/go/pkg/mod/ GO_GCFLAGS=${GCFLAGS} make build-manager
 
-FROM nvcr.io/nvidia/doca/doca:2.10.0-full-rt-host
+FROM nvcr.io/nvidia/doca/doca:2.9.2-full-rt-host
 
 ARG TARGETARCH
 ENV MFT_VERSION=4.29.0-131
@@ -56,6 +56,9 @@ RUN apt-get source ${PACKAGES}
 WORKDIR /
 COPY --from=builder /workspace/build/manager .
 USER 65532:65532
+
+# Copy sources to the container
+ADD . /workspace
 
 ENTRYPOINT ["/manager"]
 

--- a/Dockerfile.nic-configuration-daemon
+++ b/Dockerfile.nic-configuration-daemon
@@ -22,7 +22,7 @@ COPY ./ ./
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN --mount=type=cache,target=/go/pkg/mod/ GO_GCFLAGS=${GCFLAGS} make build-daemon
 
-FROM nvcr.io/nvidia/doca/doca:2.10.0-full-rt-host
+FROM nvcr.io/nvidia/doca/doca:2.9.2-full-rt-host
 
 ARG TARGETARCH
 ENV MFT_VERSION=4.29.0-131
@@ -47,6 +47,9 @@ RUN case ${TARGETARCH} in \
 
 WORKDIR /
 COPY --from=builder /workspace/build/nic-configuration-daemon .
+
+# Copy sources to the container
+ADD . /workspace
 
 ENTRYPOINT ["/nic-configuration-daemon"]
 


### PR DESCRIPTION
doca 2.10.0 image doesn't have a version for arm which breaks our builds