### PR TITLE
fix: verify FW version burned on the device prior to burn

### DIFF
--- a/pkg/firmware/mocks/FirmwareUtils.go
+++ b/pkg/firmware/mocks/FirmwareUtils.go
@@ -97,12 +97,40 @@ func (_m *FirmwareUtils) GetFWVersionsFromBFB(bfbPath string) (map[string]string
 	return r0, r1
 }
 
-// GetFirmwareVersionAndPSID provides a mock function with given fields: firmwareBinaryPath
-func (_m *FirmwareUtils) GetFirmwareVersionAndPSID(firmwareBinaryPath string) (string, string, error) {
+// GetBurnedFirmwareVersionFromDevice provides a mock function with given fields: pciAddress
+func (_m *FirmwareUtils) GetBurnedFirmwareVersionFromDevice(pciAddress string) (string, error) {
+	ret := _m.Called(pciAddress)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBurnedFirmwareVersionFromDevice")
+	}
+
+	var r0 string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (string, error)); ok {
+		return rf(pciAddress)
+	}
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		r0 = rf(pciAddress)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(pciAddress)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetFirmwareVersionAndPSIDFromFWBinary provides a mock function with given fields: firmwareBinaryPath
+func (_m *FirmwareUtils) GetFirmwareVersionAndPSIDFromFWBinary(firmwareBinaryPath string) (string, string, error) {
 	ret := _m.Called(firmwareBinaryPath)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetFirmwareVersionAndPSID")
+		panic("no return value specified for GetFirmwareVersionAndPSIDFromFWBinary")
 	}
 
 	var r0 string

--- a/pkg/firmware/provisioning.go
+++ b/pkg/firmware/provisioning.go
@@ -298,7 +298,7 @@ func (f firmwareProvisioner) AddFirmwareBinariesToCacheByMetadata(cacheName stri
 
 		sourcePath := filepath.Join(firmwareBinariesDir, entry.Name())
 
-		version, psid, err := f.utils.GetFirmwareVersionAndPSID(sourcePath)
+		version, psid, err := f.utils.GetFirmwareVersionAndPSIDFromFWBinary(sourcePath)
 		if err != nil {
 			log.Log.Error(err, "failed to get firmware binary version and PSID", "cacheName", cacheName, "file", entry.Name())
 			return err

--- a/pkg/firmware/provisioning_test.go
+++ b/pkg/firmware/provisioning_test.go
@@ -263,10 +263,10 @@ var _ = Describe("FirmwareProvisioner", func() {
 			binFileB := path.Join(cacheDir, "fwB.bin")
 			Expect(os.WriteFile(binFileB, []byte("dummy content"), 0644)).To(Succeed())
 
-			fwUtilsMock.On("GetFirmwareVersionAndPSID", binFileA).
-				Return("1.2.3", "PSID123", nil).Once()
-			fwUtilsMock.On("GetFirmwareVersionAndPSID", binFileB).
-				Return("3.2.1", "PSID321", nil).Once()
+			fwUtilsMock.On("GetFirmwareVersionAndPSIDFromFWBinary", binFileA).
+				Return("1.0.0", "MT_123", nil).Once()
+			fwUtilsMock.On("GetFirmwareVersionAndPSIDFromFWBinary", binFileB).
+				Return("2.0.0", "MT_456", nil).Once()
 
 			err := fwProv.AddFirmwareBinariesToCacheByMetadata(cacheName)
 			Expect(err).NotTo(HaveOccurred())
@@ -277,9 +277,9 @@ var _ = Describe("FirmwareProvisioner", func() {
 			_, err = os.Stat(binFileB)
 			Expect(err).To(MatchError(os.ErrNotExist))
 
-			_, err = os.Stat(path.Join(cacheDir, "1.2.3", "PSID123", "fwA.bin"))
+			_, err = os.Stat(path.Join(cacheDir, "1.0.0", "MT_123", "fwA.bin"))
 			Expect(err).NotTo(HaveOccurred())
-			_, err = os.Stat(path.Join(cacheDir, "3.2.1", "PSID321", "fwB.bin"))
+			_, err = os.Stat(path.Join(cacheDir, "2.0.0", "MT_456", "fwB.bin"))
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -288,7 +288,7 @@ var _ = Describe("FirmwareProvisioner", func() {
 				binFileA := path.Join(cacheDir, "fwA.bin")
 				Expect(os.WriteFile(binFileA, []byte("dummy content"), 0644)).To(Succeed())
 
-				fwUtilsMock.On("GetFirmwareVersionAndPSID", mock.AnythingOfType("string")).
+				fwUtilsMock.On("GetFirmwareVersionAndPSIDFromFWBinary", mock.AnythingOfType("string")).
 					Return("", "", errors.New("parse error")).Once()
 
 				err := fwProv.AddFirmwareBinariesToCacheByMetadata(cacheName)


### PR DESCRIPTION
This will allow to skip subsequent FW burns if the mlxfwreset failed after the first one.