### PR TITLE
Support FW_RESET_AFTER_CONFIG_UPDATE feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,3 +236,8 @@ To indicate when NIC configuration is in progress to the pods that depend on it,
 To use this mechanism, the next pods in the pipeline can add `nvidia.com/operator.nic-configuration.wait=false` to their node label selectors. That way, they will automatically be evicted from the node when the NICs are being configured.
 
 The NIC Configuration Daemon itself relies on the `network.nvidia.com/operator.mofed.wait=false` label to be present on the node as it requires the DOCA-OFED driver to be running for some of the configurations.
+
+## Feature flags
+Feature flags can be enabled via environment variables in the helm chart or NVIDIA Network Operator's NicClusterPolicy.
+Supported flags:
+* `FW_RESET_AFTER_CONFIG_UPDATE`=`true`: explicitely reset the NIC's Firmware before the reboot and after updating its non-volatile configuration. Might be required on DGX servers where configuration update is not successfully applied after the warm reboot.

--- a/deployment/nic-configuration-operator-chart/templates/config-daemon.yaml
+++ b/deployment/nic-configuration-operator-chart/templates/config-daemon.yaml
@@ -43,6 +43,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- if .Values.configDaemon.env }}
+            {{- toYaml .Values.configDaemon.env | nindent 12 }}
+            {{- end }}
             {{- if .Values.logLevel}}
             - name: LOG_LEVEL
               value: {{ .Values.logLevel }}

--- a/deployment/nic-configuration-operator-chart/values.yaml
+++ b/deployment/nic-configuration-operator-chart/values.yaml
@@ -50,6 +50,11 @@ configDaemon:
     name: nic-configuration-operator-daemon
     # -- image tag to use for the config daemon image
     tag: latest
+  # -- environment variables for the config daemon
+  # env:
+    # -- feature gate to enable FW reset after nv config update
+    # - name: FW_RESET_AFTER_CONFIG_UPDATE
+    #   value: "true"
   # -- node selector for the config daemon
   nodeSelector:
     network.nvidia.com/operator.mofed.wait: "false"

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -141,4 +141,6 @@ const (
 	NodeNicConfigurationWaitLabel = "network.nvidia.com/operator.nic-configuration.wait"
 	LabelValueTrue                = "true"
 	LabelValueFalse               = "false"
+
+	FEATURE_GATE_FW_RESET_AFTER_CONFIG_UPDATE = "FW_RESET_AFTER_CONFIG_UPDATE"
 )


### PR DESCRIPTION
This flag will enable fw reset after applying nv config. This is required on some DGX server where a warm reboot is not enough to apply the configuration successfully