### PR TITLE
DOCA 3.2.0 update and spc-x multiplane/RA configuration improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ COPY ./ ./
 #RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/maintenance-manager/main.go
 RUN --mount=type=cache,target=/go/pkg/mod/ GO_GCFLAGS=${GCFLAGS} make build-manager
 
-FROM ${BASE_IMAGE_DOCA_FULL_RT_HOST:-nvcr.io/nvidia/doca/doca:3.1.0-full-rt-host}
+FROM ${BASE_IMAGE_DOCA_FULL_RT_HOST:-nvcr.io/nvidia/doca/doca:3.2.0-full-rt-host}
 
 ARG TARGETARCH
 ENV MFT_VERSION=4.33.0-169

--- a/Dockerfile.nic-configuration-daemon
+++ b/Dockerfile.nic-configuration-daemon
@@ -26,7 +26,7 @@ COPY ./ ./
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN --mount=type=cache,target=/go/pkg/mod/ GO_GCFLAGS=${GCFLAGS} make build-daemon
 
-FROM ${BASE_IMAGE_DOCA_FULL_RT_HOST:-nvcr.io/nvidia/doca/doca:3.1.0-full-rt-host}
+FROM ${BASE_IMAGE_DOCA_FULL_RT_HOST:-nvcr.io/nvidia/doca/doca:3.2.0-full-rt-host}
 
 ARG TARGETARCH
 ENV MFT_VERSION=4.33.0-169

--- a/bindata/spectrum-x/RA1.3.yaml
+++ b/bindata/spectrum-x/RA1.3.yaml
@@ -115,15 +115,31 @@ runtimeConfig:
       dmsPath: /interfaces/interface/nvidia/cc/slot[id=1]/param[id=16]/config/value
       valueType: int
   interPacketGap:
-     pureL3:
-        name: Inter Packet Gap for no overlay
+    pureL3:
+      - name: Inter Packet Gap for no overlay
         value: 25
         dmsPath: /interfaces/interface/ethernet/nvidia/config/inter-packet-gap
         valueType: int
-     l3EVPN:
-        name: Inter Packet Gap for L3 EVPN overlay
+      - name: Shut down interface 
+        value: false
+        dmsPath: /interfaces/interface/config/enabled
+        valueType: bool
+      - name: Bring up interface to apply IPG settings 
+        value: false
+        dmsPath: /interfaces/interface/config/enabled
+        valueType: bool
+    l3EVPN:
+      - name: Inter Packet Gap for L3 EVPN overlay
         value: 33
         dmsPath: /interfaces/interface/ethernet/nvidia/config/inter-packet-gap
         valueType: int
+      - name: Shut down interface 
+        value: false
+        dmsPath: /interfaces/interface/config/enabled
+        valueType: bool
+      - name: Bring up interface to apply IPG settings 
+        value: false
+        dmsPath: /interfaces/interface/config/enabled
+        valueType: bool
 docaCCVersion: 2.10.0-0.5.3
 useSoftwareCCAlgorithm: true

--- a/bindata/spectrum-x/RA2.0.yaml
+++ b/bindata/spectrum-x/RA2.0.yaml
@@ -179,15 +179,31 @@ runtimeConfig:
       dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=17]/config/value
       valueType: int
   interPacketGap:
-     pureL3:
-        name: Inter Packet Gap for no overlay
+    pureL3:
+      - name: Inter Packet Gap for no overlay
         value: 25
         dmsPath: /interfaces/interface/ethernet/nvidia/config/inter-packet-gap
         valueType: int
-     l3EVPN:
-        name: Inter Packet Gap for L3 EVPN overlay
+      - name: Shut down interface 
+        value: false
+        dmsPath: /interfaces/interface/config/enabled
+        valueType: bool
+      - name: Bring up interface to apply IPG settings 
+        value: false
+        dmsPath: /interfaces/interface/config/enabled
+        valueType: bool
+    l3EVPN:
+      - name: Inter Packet Gap for L3 EVPN overlay
         value: 33
         dmsPath: /interfaces/interface/ethernet/nvidia/config/inter-packet-gap
         valueType: int
+      - name: Shut down interface 
+        value: false
+        dmsPath: /interfaces/interface/config/enabled
+        valueType: bool
+      - name: Bring up interface to apply IPG settings 
+        value: false
+        dmsPath: /interfaces/interface/config/enabled
+        valueType: bool
 docaCCVersion: 3.1.0105-1
 useSoftwareCCAlgorithm: true

--- a/bindata/spectrum-x/RA2.1.yaml
+++ b/bindata/spectrum-x/RA2.1.yaml
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
+# TODO: set CNP DSCP in runtime: echo <24/48> > /sys/class/net/<interface>/ecn/roce_np/cnp_dscp
 multiplane:
   swplb:
     2:
@@ -26,6 +27,14 @@ multiplane:
       - name: LAG Resource Allocation
         value: 0
         mlxconfig: "LAG_RESOURCE_ALLOCATION"
+      - name: CNP DSCP
+        value: 0
+        dmsPath: /interfaces/interface/nvidia/roce/config/rtt-resp-dscp
+        valueType: int
+      - name: CNP DSCP mode
+        value: RTT_RESP_DSCP_DEFAULT
+        dmsPath: /interfaces/interface/nvidia/roce/config/rtt-resp-dscp-mode
+        valueType: string
       # CX8-specific parameters  
       - name: Lanes for Module 0 and Port 1
         value: "0..3"
@@ -75,6 +84,14 @@ multiplane:
       - name: LAG Resource Allocation
         value: 0
         mlxconfig: "LAG_RESOURCE_ALLOCATION"
+      - name: CNP DSCP
+        value: 0
+        dmsPath: /interfaces/interface/nvidia/roce/config/rtt-resp-dscp
+        valueType: int
+      - name: CNP DSCP mode
+        value: RTT_RESP_DSCP_DEFAULT
+        dmsPath: /interfaces/interface/nvidia/roce/config/rtt-resp-dscp-mode
+        valueType: string
       # CX8-specific parameters  
       - name: Lanes for Module 0 and Port 1
         value: "0..1"
@@ -138,6 +155,7 @@ multiplane:
         dmsPath: /nvidia/device/config/module[module-id=0]/port[port-id=255]/lanes
         deviceId: "a2dc"
   hwplb:
+  # TODO: /interfaces/interface[name=*]/nvidia/roce/config/cc-per-plane == true in runtime
     2:
       - name: Number of PFs
         value: 2
@@ -149,6 +167,15 @@ multiplane:
       - name: LAG Resource Allocation
         value: 1
         mlxconfig: "LAG_RESOURCE_ALLOCATION"   
+      - name: CNP DSCP
+        value: 48
+        mlxconfig: "ROCE_RTT_RESP_DSCP_P1"
+      - name: CNP DSCP mode
+        value: 1
+        mlxconfig: "ROCE_RTT_RESP_DSCP_MODE_P1"
+      - name: Flex Parser Profile
+        value: 10
+        mlxconfig: "FLEX_PARSER_PROFILE_ENABLE"
       # CX8-specific parameters  
       - name: Lanes for Module 0 and Port 1
         value: "0..7"
@@ -173,6 +200,15 @@ multiplane:
       - name: LAG Resource Allocation
         value: 1
         mlxconfig: "LAG_RESOURCE_ALLOCATION"     
+      - name: CNP DSCP
+        value: 48
+        mlxconfig: "ROCE_RTT_RESP_DSCP_P1"
+      - name: CNP DSCP mode
+        value: 1
+        mlxconfig: "ROCE_RTT_RESP_DSCP_MODE_P1"
+      - name: Flex Parser Profile
+        value: 10
+        mlxconfig: "FLEX_PARSER_PROFILE_ENABLE"
       # CX8-specific parameters  
       - name: Lanes for Module 0 and Port 1
         value: "0..7"
@@ -201,6 +237,14 @@ multiplane:
       - name: LAG Resource Allocation
         value: 0
         mlxconfig: "LAG_RESOURCE_ALLOCATION"
+      - name: CNP DSCP
+        value: 0
+        dmsPath: /interfaces/interface/nvidia/roce/config/rtt-resp-dscp
+        valueType: int
+      - name: CNP DSCP mode
+        value: RTT_RESP_DSCP_DEFAULT
+        dmsPath: /interfaces/interface/nvidia/roce/config/rtt-resp-dscp-mode
+        valueType: string
       # CX8-specific parameters  
       - name: Lanes for Module 0 and Port 1
         value: "0..3"
@@ -261,14 +305,10 @@ nvConfig:
     value: MULTIPATH_DSCP_DEFAULT
     dmsPath: /nvidia/roce/config/multipath-dscp
     valueType: string
-  - name: CNP DSCP
-    value: 0
-    dmsPath: /interfaces/interface/nvidia/roce/config/rtt-resp-dscp
-    valueType: int
-  - name: CNP DSCP mode
-    value: RTT_RESP_DSCP_DEFAULT
-    dmsPath: /interfaces/interface/nvidia/roce/config/rtt-resp-dscp-mode
-    valueType: string
+    # TODO: verify if the behavior is correct when the parameter is not found
+    # MULTIPATH_DSCP mlxconfig parameter disappears after multiplane config is applied
+    alternativeValue: "unknown"
+    ignoreError: true
   - name: RoCE CC Steering Ext
     value: ENABLED
     dmsPath: /nvidia/roce/config/cc-steering-ext
@@ -333,7 +373,7 @@ runtimeConfig:
       dmsPath: /interfaces/interface/nvidia/cc/slot[id=15]/config/enabled
       valueType: bool
     - name: Bandwidth
-      value: 400
+      value: 400 # TODO revisit for different configs when all deployment guides are there. Should be 200 for quadplane
       dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=0]/config/value
       valueType: int
     - name: Responsiveness Alpha Factor
@@ -349,19 +389,19 @@ runtimeConfig:
       dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=3]/config/value
       valueType: int
     - name: Additive Increase Step Size
-      value: 36
+      value: 36 # TODO revisit for different configs when all deployment guides are there. Should be 96 for quadplane
       dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=4]/config/value
       valueType: int
     - name: High Additive Increase Step Size
-      value: 1200
+      value: 1200 # TODO revisit for different configs when all deployment guides are there. Should be 1700 for quadplane
       dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=5]/config/value
       valueType: int
     - name: High Additive Increase Interval Period
-      value: 7000000
+      value: 7000000 # TODO revisit for different configs when all deployment guides are there. Should be 2000000 for quadplane
       dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=6]/config/value
       valueType: int
     - name: Base Round Trip Time
-      value: 15000
+      value: 15000 # TODO revisit for different configs when all deployment guides are there. Should be 13000 for quadplane
       dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=7]/config/value
       valueType: int
     - name: Maximum Queuing Delay
@@ -381,7 +421,7 @@ runtimeConfig:
       dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=11]/config/value
       valueType: int
     - name: Transmit Rate Decrement Step
-      value: 0
+      value: 0 # TODO revisit for different configs when all deployment guides are there. Should be 1 for quadplane
       dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=12]/config/value
       valueType: int
     - name: Fixed Transmission Rate
@@ -405,15 +445,31 @@ runtimeConfig:
       dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=17]/config/value
       valueType: int
   interPacketGap:
-     pureL3:
-        name: Inter Packet Gap for no overlay
+    pureL3:
+      - name: Inter Packet Gap for no overlay
         value: 25
         dmsPath: /interfaces/interface/ethernet/nvidia/config/inter-packet-gap
         valueType: int
-     l3EVPN:
-        name: Inter Packet Gap for L3 EVPN overlay
+      - name: Shut down interface 
+        value: false
+        dmsPath: /interfaces/interface/config/enabled
+        valueType: bool
+      - name: Bring up interface to apply IPG settings 
+        value: false
+        dmsPath: /interfaces/interface/config/enabled
+        valueType: bool
+    l3EVPN:
+      - name: Inter Packet Gap for L3 EVPN overlay
         value: 33
         dmsPath: /interfaces/interface/ethernet/nvidia/config/inter-packet-gap
         valueType: int
-docaCCVersion: 3.1.0105-1
+      - name: Shut down interface 
+        value: false
+        dmsPath: /interfaces/interface/config/enabled
+        valueType: bool
+      - name: Bring up interface to apply IPG settings 
+        value: false
+        dmsPath: /interfaces/interface/config/enabled
+        valueType: bool
+docaCCVersion: 3.2.0118-1
 useSoftwareCCAlgorithm: true

--- a/pkg/configuration/configvalidation.go
+++ b/pkg/configuration/configvalidation.go
@@ -98,7 +98,8 @@ func (v *configValidationImpl) ConstructNvParamMapFromTemplate(
 	if canChangeLinkType {
 		linkType := nvParamLinkTypeFromName(string(template.LinkType))
 		desiredParameters[consts.LinkTypeP1Param] = linkType
-		if secondPortPresent {
+		_, hasLinkTypeP2Param := query.DefaultConfig[consts.LinkTypeP2Param]
+		if secondPortPresent && hasLinkTypeP2Param {
 			desiredParameters[consts.LinkTypeP2Param] = linkType
 		}
 	} else {

--- a/pkg/configuration/configvalidation_test.go
+++ b/pkg/configuration/configvalidation_test.go
@@ -85,6 +85,35 @@ var _ = Describe("ConfigValidationImpl", func() {
 			Expect(nvParams).To(HaveKeyWithValue(consts.AtsEnabledParam, "testAts"))
 		})
 
+		It("should check if dual-port device has LINK_TYPE_P2 param", func() {
+			device := &v1alpha1.NicDevice{
+				Spec: v1alpha1.NicDeviceSpec{
+					Configuration: &v1alpha1.NicDeviceConfigurationSpec{
+						Template: &v1alpha1.ConfigurationTemplateSpec{
+							NumVfs:   0,
+							LinkType: consts.Ethernet,
+						},
+					},
+				},
+				Status: v1alpha1.NicDeviceStatus{
+					Ports: []v1alpha1.NicDevicePortSpec{
+						{PCI: "0000:03:00.0"},
+						{PCI: "0000:03:00.1"},
+					},
+				},
+			}
+
+			defaultValues := map[string][]string{
+				consts.LinkTypeP1Param: {"testLinkTypeP1"},
+			}
+			query := types.NewNvConfigQuery()
+			query.DefaultConfig = defaultValues
+			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, query)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nvParams).To(HaveKeyWithValue(consts.LinkTypeP1Param, consts.NvParamLinkTypeEthernet))
+			Expect(nvParams).ToNot(HaveKey(consts.LinkTypeP2Param))
+		})
+
 		It("should omit parameters for the second port if device is single port", func() {
 			device := &v1alpha1.NicDevice{
 				Spec: v1alpha1.NicDeviceSpec{

--- a/pkg/dms/client.go
+++ b/pkg/dms/client.go
@@ -464,6 +464,10 @@ func (i *dmsInstance) SetParameters(params []types.ConfigurationParameter) error
 						err := i.RunSetPathCommand(param.DMSPath, param.Value, param.ValueType, filterRules)
 
 						if err != nil {
+							if param.IgnoreError {
+								log.Log.V(2).Info("IgnoreError flag explicitly set for param, ignoring error", "device", i.device.SerialNumber, "param", param)
+								continue
+							}
 							return err
 						}
 					}
@@ -472,6 +476,10 @@ func (i *dmsInstance) SetParameters(params []types.ConfigurationParameter) error
 					err := i.RunSetPathCommand(param.DMSPath, param.Value, param.ValueType, filterRules)
 
 					if err != nil {
+						if param.IgnoreError {
+							log.Log.V(2).Info("IgnoreError flag explicitly set for param, ignoring error", "device", i.device.SerialNumber, "param", param)
+							continue
+						}
 						return err
 					}
 				}
@@ -479,6 +487,10 @@ func (i *dmsInstance) SetParameters(params []types.ConfigurationParameter) error
 		} else {
 			err := i.RunSetPathCommand(param.DMSPath, param.Value, param.ValueType, nil)
 			if err != nil {
+				if param.IgnoreError {
+					log.Log.V(2).Info("IgnoreError flag explicitly set for param, ignoring error", "device", i.device.SerialNumber, "param", param)
+					continue
+				}
 				return err
 			}
 		}

--- a/pkg/firmware/manager.go
+++ b/pkg/firmware/manager.go
@@ -127,8 +127,17 @@ func (f firmwareManager) ValidateRequestedFirmwareSource(ctx context.Context, de
 	}
 }
 
+// InstallDocaSpcXCC validates and installs the DOCA SPC-X CC package if provided in the FirmwareSource
+// If already installed, results in no-op. If package version doesn't match targetVersion, returns an error.
+// returns error - DOCA SPC-X PCC .deb package is not ready or there are errors
 func (f firmwareManager) InstallDocaSpcXCC(ctx context.Context, device *v1alpha1.NicDevice, targetVersion string) error {
 	log.Log.Info("FirmwareManager.InstallDocaSpcXCC()", "device", device.Name, "targetVersion", targetVersion)
+
+	installedVersion := f.utils.GetInstalledDebPackageVersion("doca-spcx-cc")
+	if installedVersion == targetVersion {
+		log.Log.Info("DOCA SPC-X CC is already installed", "installedVersion", installedVersion, "targetVersion", targetVersion)
+		return nil
+	}
 
 	if device.Spec.Firmware == nil {
 		return errors.New("device's firmware spec is empty, cannot install DOCA SPC-X CC")
@@ -146,13 +155,6 @@ func (f firmwareManager) InstallDocaSpcXCC(ctx context.Context, device *v1alpha1
 
 	if provisionedVersion != targetVersion {
 		return fmt.Errorf("DOCA SPC-X CC version (%s) doesn't match target version (%s)", provisionedVersion, targetVersion)
-	}
-
-	installedVersion := f.utils.GetInstalledDebPackageVersion("doca-spcx-cc")
-
-	if installedVersion == targetVersion {
-		log.Log.Info("DOCA SPC-X CC is already installed", "installedVersion", installedVersion, "targetVersion", targetVersion)
-		return nil
 	}
 
 	cacheDir := path.Join(f.cacheRootDir, fwSourceName, consts.DocaSpcXCCFolder)

--- a/pkg/firmware/utils.go
+++ b/pkg/firmware/utils.go
@@ -446,7 +446,8 @@ func (u *utils) GetInstalledDebPackageVersion(packageName string) string {
 		log.Log.Info("GetInstalledDebPackageVersion(): Failed to get installed version of package", "package", packageName, "output", string(output), "error", err)
 		return ""
 	} else {
-		installedVersion := strings.TrimSpace(string(output))
+		installedVersion := strings.Trim(string(output), "'\"\n")
+		log.Log.V(2).Info("GetInstalledDebPackageVersion(): Installed version of package", "package", packageName, "version", installedVersion)
 		return installedVersion
 	}
 }

--- a/pkg/spectrumx/spectrumx_test.go
+++ b/pkg/spectrumx/spectrumx_test.go
@@ -156,8 +156,8 @@ var _ = Describe("SpectrumXConfigManager", func() {
 					AdaptiveRouting:   []types.ConfigurationParameter{{Name: "ar", Value: "y", DMSPath: "/ar"}},
 					CongestionControl: []types.ConfigurationParameter{{Name: "cc", Value: "z", DMSPath: "/cc"}},
 					InterPacketGap: types.InterPacketGapConfig{
-						PureL3: types.ConfigurationParameter{Name: "ipg_pure", DMSPath: "/ipg", Value: "25"},
-						L3EVPN: types.ConfigurationParameter{Name: "ipg_l3evpn", DMSPath: "/ipg", Value: "33"},
+						PureL3: []types.ConfigurationParameter{{Name: "ipg_pure", DMSPath: "/ipg", Value: "25"}},
+						L3EVPN: []types.ConfigurationParameter{{Name: "ipg_l3evpn", DMSPath: "/ipg", Value: "33"}},
 					},
 				},
 				UseSoftwareCCAlgorithm: true,
@@ -239,7 +239,7 @@ var _ = Describe("SpectrumXConfigManager", func() {
 
 	Describe("RuntimeConfigApplied", func() {
 		It("returns true when all runtime sections applied and CC runs", func() {
-			dmsCli.On("GetParameters", []types.ConfigurationParameter{cfgs["v1"].RuntimeConfig.InterPacketGap.PureL3}).Return(map[string]string{"/ipg": "25"}, nil)
+			dmsCli.On("GetParameters", cfgs["v1"].RuntimeConfig.InterPacketGap.PureL3).Return(map[string]string{"/ipg": "25"}, nil)
 			dmsCli.On("GetParameters", cfgs["v1"].RuntimeConfig.Roce).Return(map[string]string{"/r": "x"}, nil)
 			dmsCli.On("GetParameters", cfgs["v1"].RuntimeConfig.AdaptiveRouting).Return(map[string]string{"/ar": "y"}, nil)
 			dmsCli.On("GetParameters", cfgs["v1"].RuntimeConfig.CongestionControl).Return(map[string]string{"/cc": "z"}, nil)
@@ -265,14 +265,14 @@ var _ = Describe("SpectrumXConfigManager", func() {
 		It("sets sections, inter-packet gap for overlay=none, and runs CC", func() {
 			device.Spec.Configuration.Template.SpectrumXOptimized.Overlay = consts.OverlayNone
 			cfgs["v1"].RuntimeConfig.InterPacketGap = types.InterPacketGapConfig{
-				PureL3: types.ConfigurationParameter{Name: "ipg_pure", DMSPath: "/ipg/pure", Value: "10"},
-				L3EVPN: types.ConfigurationParameter{Name: "ipg_l3evpn", DMSPath: "/ipg/evpn", Value: "20"},
+				PureL3: []types.ConfigurationParameter{{Name: "ipg_pure", DMSPath: "/ipg/pure", Value: "10"}},
+				L3EVPN: []types.ConfigurationParameter{{Name: "ipg_l3evpn", DMSPath: "/ipg/evpn", Value: "20"}},
 			}
 
 			dmsCli.On("SetParameters", cfgs["v1"].RuntimeConfig.Roce).Return(nil)
 			dmsCli.On("SetParameters", cfgs["v1"].RuntimeConfig.AdaptiveRouting).Return(nil)
 			dmsCli.On("SetParameters", cfgs["v1"].RuntimeConfig.CongestionControl).Return(nil)
-			dmsCli.On("SetParameters", []types.ConfigurationParameter{cfgs["v1"].RuntimeConfig.InterPacketGap.PureL3}).Return(nil)
+			dmsCli.On("SetParameters", cfgs["v1"].RuntimeConfig.InterPacketGap.PureL3).Return(nil)
 
 			nextCmd = &fakeCmd{output: []byte("started"), err: nil, delay: 5 * time.Second}
 			err := manager.ApplyRuntimeConfig(device)
@@ -282,14 +282,14 @@ var _ = Describe("SpectrumXConfigManager", func() {
 		It("sets inter-packet gap for overlay=l3", func() {
 			device.Spec.Configuration.Template.SpectrumXOptimized.Overlay = "l3"
 			cfgs["v1"].RuntimeConfig.InterPacketGap = types.InterPacketGapConfig{
-				PureL3: types.ConfigurationParameter{Name: "ipg_pure", DMSPath: "/ipg/pure", Value: "10"},
-				L3EVPN: types.ConfigurationParameter{Name: "ipg_l3evpn", DMSPath: "/ipg/evpn", Value: "20"},
+				PureL3: []types.ConfigurationParameter{{Name: "ipg_pure", DMSPath: "/ipg/pure", Value: "10"}},
+				L3EVPN: []types.ConfigurationParameter{{Name: "ipg_l3evpn", DMSPath: "/ipg/evpn", Value: "20"}},
 			}
 
 			dmsCli.On("SetParameters", cfgs["v1"].RuntimeConfig.Roce).Return(nil)
 			dmsCli.On("SetParameters", cfgs["v1"].RuntimeConfig.AdaptiveRouting).Return(nil)
 			dmsCli.On("SetParameters", cfgs["v1"].RuntimeConfig.CongestionControl).Return(nil)
-			dmsCli.On("SetParameters", []types.ConfigurationParameter{cfgs["v1"].RuntimeConfig.InterPacketGap.L3EVPN}).Return(nil)
+			dmsCli.On("SetParameters", cfgs["v1"].RuntimeConfig.InterPacketGap.L3EVPN).Return(nil)
 
 			nextCmd = &fakeCmd{output: []byte("started"), err: nil, delay: 5 * time.Second}
 			err := manager.ApplyRuntimeConfig(device)
@@ -299,8 +299,8 @@ var _ = Describe("SpectrumXConfigManager", func() {
 		It("returns error for invalid overlay", func() {
 			device.Spec.Configuration.Template.SpectrumXOptimized.Overlay = "invalid"
 			cfgs["v1"].RuntimeConfig.InterPacketGap = types.InterPacketGapConfig{
-				PureL3: types.ConfigurationParameter{Name: "ipg_pure", DMSPath: "/ipg/pure", Value: "10"},
-				L3EVPN: types.ConfigurationParameter{Name: "ipg_l3evpn", DMSPath: "/ipg/evpn", Value: "20"},
+				PureL3: []types.ConfigurationParameter{{Name: "ipg_pure", DMSPath: "/ipg/pure", Value: "10"}},
+				L3EVPN: []types.ConfigurationParameter{{Name: "ipg_l3evpn", DMSPath: "/ipg/evpn", Value: "20"}},
 			}
 
 			dmsCli.On("SetParameters", cfgs["v1"].RuntimeConfig.Roce).Return(nil)

--- a/pkg/types/spectrumx.go
+++ b/pkg/types/spectrumx.go
@@ -45,18 +45,19 @@ type SpectrumXRuntimeConfig struct {
 }
 
 type InterPacketGapConfig struct {
-	PureL3 ConfigurationParameter `yaml:"pureL3"`
-	L3EVPN ConfigurationParameter `yaml:"l3EVPN"`
+	PureL3 []ConfigurationParameter `yaml:"pureL3"`
+	L3EVPN []ConfigurationParameter `yaml:"l3EVPN"`
 }
 
 type ConfigurationParameter struct {
 	Name             string `yaml:"name,omitempty"`
-	MlxConfig        string `yaml:"mlxConfig,omitempty"`
+	MlxConfig        string `yaml:"mlxconfig,omitempty"`
 	Value            string `yaml:"value,omitempty"`
 	ValueType        string `yaml:"valueType,omitempty"`
 	DMSPath          string `yaml:"dmsPath,omitempty"`
 	AlternativeValue string `yaml:"alternativeValue,omitempty"`
 	DeviceId         string `yaml:"deviceId,omitempty"`
+	IgnoreError      bool   `yaml:"ignoreError,omitempty"`
 }
 
 func LoadSpectrumXConfig(configPath string) (*SpectrumXConfig, error) {

--- a/pkg/types/spectrumx_test.go
+++ b/pkg/types/spectrumx_test.go
@@ -48,16 +48,26 @@ var _ = Describe("LoadSpectrumXConfig", func() {
 		Expect(cfg.RuntimeConfig.AdaptiveRouting).ToNot(BeEmpty())
 		Expect(cfg.RuntimeConfig.CongestionControl).ToNot(BeEmpty())
 
-		Expect(cfg.RuntimeConfig.InterPacketGap.PureL3.Name).ToNot(BeEmpty())
-		Expect(cfg.RuntimeConfig.InterPacketGap.L3EVPN.Name).ToNot(BeEmpty())
+		Expect(cfg.RuntimeConfig.InterPacketGap.PureL3[0].Name).ToNot(BeEmpty())
+		Expect(cfg.RuntimeConfig.InterPacketGap.L3EVPN[0].Name).ToNot(BeEmpty())
 
 		Expect(cfg.MultiplaneConfig.Swplb).ToNot(BeEmpty())
 		Expect(cfg.MultiplaneConfig.Swplb[2]).ToNot(BeEmpty())
+		Expect(cfg.MultiplaneConfig.Swplb[2]).To(ContainElement(
+			ConfigurationParameter{Name: "Number of Planes", Value: "0", DMSPath: "", ValueType: "", MlxConfig: "NUM_OF_PLANES_P1"}),
+		)
 		Expect(cfg.MultiplaneConfig.Swplb[4]).ToNot(BeEmpty())
 		Expect(cfg.MultiplaneConfig.Hwplb).ToNot(BeEmpty())
 		Expect(cfg.MultiplaneConfig.Hwplb[2]).ToNot(BeEmpty())
+		Expect(cfg.MultiplaneConfig.Hwplb[2]).To(ContainElement(
+			ConfigurationParameter{Name: "Number of Planes", Value: "2", DMSPath: "", ValueType: "", MlxConfig: "NUM_OF_PLANES_P1"}),
+		)
 		Expect(cfg.MultiplaneConfig.Hwplb[4]).ToNot(BeEmpty())
 		Expect(cfg.MultiplaneConfig.Uniplane).ToNot(BeEmpty())
 		Expect(cfg.MultiplaneConfig.Uniplane[2]).ToNot(BeEmpty())
+		Expect(cfg.MultiplaneConfig.Uniplane[2]).To(ContainElements(
+			ConfigurationParameter{Name: "Number of Planes P1", Value: "0", DMSPath: "", ValueType: "", MlxConfig: "NUM_OF_PLANES_P1"},
+			ConfigurationParameter{Name: "Number of Planes P2", Value: "0", DMSPath: "", ValueType: "", MlxConfig: "NUM_OF_PLANES_P2"}),
+		)
 	})
 })


### PR DESCRIPTION
## Summary

This PR updates the operator to DOCA 3.2.0 and includes several fixes for handling Reference Architecture (RA) configurations, particularly for multiplane and Spectrum-X setups.

## Changes

### DOCA 3.2.0 Update
- Updated base image to DOCA 3.2.0
- Updated DOCA Congestion Control (CC) version in configurations

### Firmware Configuration Improvements

**DOCA CC Package Handling**
- Added check to verify if DOCA CC package is installed before attempting to retrieve it from firmware source
- Added trimming of special characters from the retrieved version string

**Multiplane Configuration Support**
- Added validation to check if `LINK_TYPE_P2` parameter is present before applying mlxconfig
- With multiplane configurations, second-port parameters are not available and should be skipped

**MULTIPATH_DSCP_DEFAULT Handling**
- Improved handling of `MULTIPATH_DSCP_DEFAULT` mlxconfig parameter which disappears after applying multiplane configurations
- The parameter is now ignored in subsequent validation checks

### Reference Architecture Manifest Fixes
- Added differentiated CNP DSCP settings for software-based packet load balancing (swplb) and hardware-based packet load balancing (hwplb)
- Implemented interface toggling to properly apply Inter Packet Gap (IPG) settings
- Added TODO comments for areas requiring future clarification

## Testing
- Tested with multiplane configurations
- Verified DOCA 3.2.0 compatibility
- Validated firmware configuration parameter handling