### PR TITLE
fix: configurationDaemon should handle zero-trust bluefield devices gracefully

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -51,15 +51,16 @@ const (
 	DeviceFwMismatchReason        = "DeviceFirmwareConfigMismatch"
 	DeviceFwMismatchMessage       = "Firmware doesn't match the requested version, can't proceed with update because policy is set to Validate"
 
-	PartNumberPrefix      = "PN:"
-	SerialNumberPrefix    = "SN:"
-	ModelNamePrefix       = "ID:"
-	FirmwareVersionPrefix = "fw version:"
-	PSIDPrefix            = "psid:"
-	LinkStatsPrefix       = "lnksta"
-	MaxReadReqPrefix      = "maxreadreq"
-	TrustStatePrefix      = "priority trust state:"
-	PfcEnabledPrefix      = "enabled"
+	PartNumberPrefix          = "PN:"
+	SerialNumberPrefix        = "SN:"
+	ModelNamePrefix           = "ID:"
+	FirmwareVersionPrefix     = "fw version:"
+	PSIDPrefix                = "psid:"
+	LinkStatsPrefix           = "lnksta"
+	MaxReadReqPrefix          = "maxreadreq"
+	TrustStatePrefix          = "priority trust state:"
+	PfcEnabledPrefix          = "enabled"
+	ZeroTrustHostConfigPrefix = "level"
 
 	SuperNIC = "SuperNIC"
 
@@ -148,4 +149,7 @@ const (
 	MultiplaneModeSwplb    = "swplb"
 	MultiplaneModeHwplb    = "hwplb"
 	MultiplaneModeUniplane = "uniplane"
+
+	HostRestrictionLevelPrivileged = "privileged"
+	HostRestrictionLevelRestricted = "restricted"
 )

--- a/pkg/devicediscovery/mocks/DeviceDiscoveryUtils.go
+++ b/pkg/devicediscovery/mocks/DeviceDiscoveryUtils.go
@@ -163,6 +163,34 @@ func (_m *DeviceDiscoveryUtils) IsSriovVF(pciAddr string) bool {
 	return r0
 }
 
+// IsZeroTrust provides a mock function with given fields: pciAddr
+func (_m *DeviceDiscoveryUtils) IsZeroTrust(pciAddr string) (bool, error) {
+	ret := _m.Called(pciAddr)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsZeroTrust")
+	}
+
+	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (bool, error)); ok {
+		return rf(pciAddr)
+	}
+	if rf, ok := ret.Get(0).(func(string) bool); ok {
+		r0 = rf(pciAddr)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(pciAddr)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // NewDeviceDiscoveryUtils creates a new instance of DeviceDiscoveryUtils. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewDeviceDiscoveryUtils(t interface {

--- a/pkg/nvconfig/suite_test.go
+++ b/pkg/nvconfig/suite_test.go
@@ -1,0 +1,30 @@
+/*
+2026 NVIDIA CORPORATION & AFFILIATES
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nvconfig
+
+import (
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+func TestNVConfig(t *testing.T) {
+	// Register Gomega with Ginkgo
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	// Run the test suite
+	ginkgo.RunSpecs(t, "NVConfig Suite")
+}


### PR DESCRIPTION
## Summary
To address #218.

1. Use `mlxprivhost` to capture if a bluefield device is in zero-trust mode
2. Address the index one-off bug in `nvconfig` pkg for `mlxconfig` query parsing
3. Add unit tests accordingly for the newly-added content

## Test
1. All unit tests passed
2. Deploy the modified image to a cluster, which has zero-trust BF3 device:

```
2026-01-08T01:47:36.110412637Z    INFO    devicediscovery/devicediscovery.go:78    Found Mellanox device    {"address": "0000:be:00.0", "type": "MT43244 BlueField-3 integrated ConnectX-7 network controller"}
2026-01-08T01:47:36.110431267Z    INFO    devicediscovery/utils.go:78    HostUtils.GetPartAndSerialNumber()    {"pciAddr": "0000:be:00.0"}
2026-01-08T01:47:36.172405493Z    INFO    devicediscovery/utils.go:198    HostUtils.IsZeroTrust()    {"pciAddr": "0000:be:00.0"}
2026-01-08T01:47:36.585217907Z    INFO    devicediscovery/devicediscovery.go:95    Device is zero-trust (host restriction) mode, skipping as it disallows any config change from host    {"address": "0000:be:00.0"}
```