### PR TITLE
Refactor SpectrumX apply functions and fix udev rules for multi-PF NICs

### DIFF
--- a/bindata/spectrum-x/RA2.1.yaml
+++ b/bindata/spectrum-x/RA2.1.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-multiplane:
+breakout:
   swplb:
     2:
       - name: Number of PFs
@@ -26,20 +26,6 @@ multiplane:
       - name: LAG Resource Allocation
         value: 0
         mlxconfig: "LAG_RESOURCE_ALLOCATION"
-      - name: CNP DSCP
-        value: 0
-        dmsPath: /interfaces/interface/nvidia/roce/config/rtt-resp-dscp
-        valueType: int
-      - name: CNP DSCP mode
-        value: RTT_RESP_DSCP_DEFAULT
-        dmsPath: /interfaces/interface/nvidia/roce/config/rtt-resp-dscp-mode
-        valueType: string
-      - name: RoCE Multipath DSCP
-        value: MULTIPATH_DSCP_DEFAULT
-        dmsPath: /nvidia/roce/config/multipath-dscp
-        valueType: string
-        alternativeValue: "unknown"
-        ignoreError: true
       # CX8-specific parameters  
       - name: Lanes for Module 0 and Port 1
         value: "0..3"
@@ -89,20 +75,6 @@ multiplane:
       - name: LAG Resource Allocation
         value: 0
         mlxconfig: "LAG_RESOURCE_ALLOCATION"
-      - name: CNP DSCP
-        value: 0
-        dmsPath: /interfaces/interface/nvidia/roce/config/rtt-resp-dscp
-        valueType: int
-      - name: CNP DSCP mode
-        value: RTT_RESP_DSCP_DEFAULT
-        dmsPath: /interfaces/interface/nvidia/roce/config/rtt-resp-dscp-mode
-        valueType: string
-      - name: RoCE Multipath DSCP
-        value: MULTIPATH_DSCP_DEFAULT
-        dmsPath: /nvidia/roce/config/multipath-dscp
-        valueType: string
-        alternativeValue: "unknown"
-        ignoreError: true
       # CX8-specific parameters  
       - name: Lanes for Module 0 and Port 1
         value: "0..1"
@@ -176,19 +148,7 @@ multiplane:
         mlxconfig: "NUM_OF_PLANES_P1"
       - name: LAG Resource Allocation
         value: 1
-        mlxconfig: "LAG_RESOURCE_ALLOCATION"   
-      - name: CNP DSCP
-        value: 48
-        mlxconfig: "ROCE_RTT_RESP_DSCP_P1"
-      - name: CNP DSCP mode
-        value: 1
-        mlxconfig: "ROCE_RTT_RESP_DSCP_MODE_P1"
-      - name: Flex Parser Profile
-        value: 10
-        mlxconfig: "FLEX_PARSER_PROFILE_ENABLE"
-      - name: Disable RDE
-        value: 1
-        mlxconfig: "RDE_DISABLE"
+        mlxconfig: "LAG_RESOURCE_ALLOCATION"
       # CX8-specific parameters  
       - name: Lanes for Module 0 and Port 1
         value: "0..7"
@@ -212,16 +172,7 @@ multiplane:
         mlxconfig: "NUM_OF_PLANES_P1"
       - name: LAG Resource Allocation
         value: 1
-        mlxconfig: "LAG_RESOURCE_ALLOCATION"     
-      - name: CNP DSCP
-        value: 48
-        mlxconfig: "ROCE_RTT_RESP_DSCP_P1"
-      - name: CNP DSCP mode
-        value: 1
-        mlxconfig: "ROCE_RTT_RESP_DSCP_MODE_P1"
-      - name: Flex Parser Profile
-        value: 10
-        mlxconfig: "FLEX_PARSER_PROFILE_ENABLE"
+        mlxconfig: "LAG_RESOURCE_ALLOCATION"
       # CX8-specific parameters  
       - name: Lanes for Module 0 and Port 1
         value: "0..7"
@@ -250,20 +201,6 @@ multiplane:
       - name: LAG Resource Allocation
         value: 0
         mlxconfig: "LAG_RESOURCE_ALLOCATION"
-      - name: CNP DSCP
-        value: 0
-        dmsPath: /interfaces/interface/nvidia/roce/config/rtt-resp-dscp
-        valueType: int
-      - name: CNP DSCP mode
-        value: RTT_RESP_DSCP_DEFAULT
-        dmsPath: /interfaces/interface/nvidia/roce/config/rtt-resp-dscp-mode
-        valueType: string
-      - name: RoCE Multipath DSCP
-        value: MULTIPATH_DSCP_DEFAULT
-        dmsPath: /nvidia/roce/config/multipath-dscp
-        valueType: string
-        alternativeValue: "unknown"
-        ignoreError: true
       # CX8-specific parameters  
       - name: Lanes for Module 0 and Port 1
         value: "0..3"
@@ -324,6 +261,58 @@ nvConfig:
     value: ENABLED
     dmsPath: /nvidia/roce/config/cc-steering-ext
     valueType: string
+  # swplb/uniplane-specific settings (via DMS)
+  - name: CNP DSCP
+    value: 0
+    dmsPath: /interfaces/interface/nvidia/roce/config/rtt-resp-dscp
+    valueType: int
+    multiplane: swplb
+  - name: CNP DSCP
+    value: 0
+    dmsPath: /interfaces/interface/nvidia/roce/config/rtt-resp-dscp
+    valueType: int
+    multiplane: uniplane
+  - name: CNP DSCP mode
+    value: RTT_RESP_DSCP_DEFAULT
+    dmsPath: /interfaces/interface/nvidia/roce/config/rtt-resp-dscp-mode
+    valueType: string
+    multiplane: swplb
+  - name: CNP DSCP mode
+    value: RTT_RESP_DSCP_DEFAULT
+    dmsPath: /interfaces/interface/nvidia/roce/config/rtt-resp-dscp-mode
+    valueType: string
+    multiplane: uniplane
+  - name: RoCE Multipath DSCP
+    value: MULTIPATH_DSCP_DEFAULT
+    dmsPath: /nvidia/roce/config/multipath-dscp
+    valueType: string
+    alternativeValue: "unknown"
+    ignoreError: true
+    multiplane: swplb
+  - name: RoCE Multipath DSCP
+    value: MULTIPATH_DSCP_DEFAULT
+    dmsPath: /nvidia/roce/config/multipath-dscp
+    valueType: string
+    alternativeValue: "unknown"
+    ignoreError: true
+    multiplane: uniplane
+  # hwplb-specific settings (via mlxconfig)
+  - name: CNP DSCP
+    value: 48
+    mlxconfig: "ROCE_RTT_RESP_DSCP_P1"
+    multiplane: hwplb
+  - name: CNP DSCP mode
+    value: 1
+    mlxconfig: "ROCE_RTT_RESP_DSCP_MODE_P1"
+    multiplane: hwplb
+  - name: Flex Parser Profile
+    value: 10
+    mlxconfig: "FLEX_PARSER_PROFILE_ENABLE"
+    multiplane: hwplb
+  - name: Disable RDE
+    value: 1
+    mlxconfig: "RDE_DISABLE"
+    multiplane: hwplb
 runtimeConfig:
   roce:
     - name: Trust
@@ -341,20 +330,10 @@ runtimeConfig:
       valueType: int
   adaptiveRouting:
     - name: Enable CC per plane
-      value: true # False in swplb/uniplane, True in hwplb
+      value: true
       dmsPath: /interfaces/interface/nvidia/roce/config/cc-per-plane
       valueType: bool
       multiplane: hwplb
-    - name: Enable CC per plane
-      value: false # False in swplb/uniplane, True in hwplb
-      dmsPath: /interfaces/interface/nvidia/roce/config/cc-per-plane
-      valueType: bool
-      multiplane: swplb
-    - name: Enable CC per plane
-      value: false # False in swplb/uniplane, True in hwplb
-      dmsPath: /interfaces/interface/nvidia/roce/config/cc-per-plane
-      valueType: bool
-      multiplane: uniplane
     - name: Adaptive Retransmission
       value: true
       dmsPath: /interfaces/interface/nvidia/roce/config/adaptive-retransmission
@@ -371,11 +350,12 @@ runtimeConfig:
       value: false
       dmsPath: /interfaces/interface/nvidia/roce/config/slow-restart-idle
       valueType: bool
-    - name: CC Probe MP mode
-      value: true
-      dmsPath: /interfaces/interface/nvidia/roce/config/cc-probe-mp-mode
-      valueType: bool
-      multiplane: hwplb
+    # TODO: Uncomment when DMS is fixed in DOCA 3.3.0
+    # - name: CC Probe MP mode
+    #   value: true
+    #   dmsPath: /interfaces/interface/nvidia/roce/config/cc-probe-mp-mode
+    #   valueType: bool
+    #   multiplane: hwplb
     - name: Adaptive Routing Force
       value: true
       dmsPath: /interfaces/interface/nvidia/roce/config/adaptive-routing-force
@@ -502,15 +482,15 @@ runtimeConfig:
       valueType: int
     - name: Enable CC Plane Failure Detection
       value: 1
-      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[19]/config/value
+      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=19]/config/value
       valueType: int
     - name: CC Plane Failure Threshold
       value: 3
-      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[20]/config/value
+      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=20]/config/value
       valueType: int
     - name: CC Plane Recovery Threshold
       value: 1
-      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[21]/config/value
+      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=21]/config/value
       valueType: int
   interPacketGap:
     pureL3:
@@ -518,26 +498,11 @@ runtimeConfig:
         value: 25
         dmsPath: /interfaces/interface/ethernet/nvidia/config/inter-packet-gap
         valueType: int
-      - name: Shut down interface 
-        value: false
-        dmsPath: /interfaces/interface/config/enabled
-        valueType: bool
-      - name: Bring up interface to apply IPG settings 
-        value: false
-        dmsPath: /interfaces/interface/config/enabled
-        valueType: bool
     l3EVPN:
       - name: Inter Packet Gap for L3 EVPN overlay
         value: 33
         dmsPath: /interfaces/interface/ethernet/nvidia/config/inter-packet-gap
         valueType: int
-      - name: Shut down interface 
-        value: false
-        dmsPath: /interfaces/interface/config/enabled
-        valueType: bool
-      - name: Bring up interface to apply IPG settings 
-        value: false
-        dmsPath: /interfaces/interface/config/enabled
-        valueType: bool
-docaCCVersion: 3.2.0118-1
+#docaCCVersion: 3.3.0090-1
+docaCCVersion: 3.2.1025-1
 useSoftwareCCAlgorithm: true

--- a/internal/controller/nicdevice_controller.go
+++ b/internal/controller/nicdevice_controller.go
@@ -281,13 +281,12 @@ func (r *NicDeviceReconciler) reconcileInterfaceNameTemplates(ctx context.Contex
 	for _, device := range devicesWithTemplates {
 		var mismatchedPorts []string
 
-		for portIdx := range device.Status.Ports {
-			port := &device.Status.Ports[portIdx]
-
+		for i := range device.Status.Ports {
+			port := &device.Status.Ports[i]
 			expected, exists := expectedNames[port.PCI]
 			if !exists {
-				log.Log.Error(nil, "expected interface names not found for port", "device", device.Name, "port", port.PCI)
-				return fmt.Errorf("expected interface names not found for port %s", port.PCI)
+				log.Log.V(2).Info("expected interface names not found for port, skipping the check", "device", device.Name, "port", port.PCI)
+				continue
 			}
 
 			// Get actual interface names from sysfs

--- a/pkg/spectrumx/mocks/SpectrumXManager.go
+++ b/pkg/spectrumx/mocks/SpectrumXManager.go
@@ -15,32 +15,40 @@ type SpectrumXManager struct {
 	mock.Mock
 }
 
+// ApplyBreakoutConfig provides a mock function with given fields: ctx, device
+func (_m *SpectrumXManager) ApplyBreakoutConfig(ctx context.Context, device *v1alpha1.NicDevice) error {
+	ret := _m.Called(ctx, device)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ApplyBreakoutConfig")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *v1alpha1.NicDevice) error); ok {
+		r0 = rf(ctx, device)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // ApplyNvConfig provides a mock function with given fields: ctx, device
-func (_m *SpectrumXManager) ApplyNvConfig(ctx context.Context, device *v1alpha1.NicDevice) (bool, error) {
+func (_m *SpectrumXManager) ApplyNvConfig(ctx context.Context, device *v1alpha1.NicDevice) error {
 	ret := _m.Called(ctx, device)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ApplyNvConfig")
 	}
 
-	var r0 bool
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *v1alpha1.NicDevice) (bool, error)); ok {
-		return rf(ctx, device)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, *v1alpha1.NicDevice) bool); ok {
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *v1alpha1.NicDevice) error); ok {
 		r0 = rf(ctx, device)
 	} else {
-		r0 = ret.Get(0).(bool)
+		r0 = ret.Error(0)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, *v1alpha1.NicDevice) error); ok {
-		r1 = rf(ctx, device)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }
 
 // ApplyRuntimeConfig provides a mock function with given fields: device
@@ -82,6 +90,34 @@ func (_m *SpectrumXManager) GetDocaCCTargetVersion(device *v1alpha1.NicDevice) (
 
 	if rf, ok := ret.Get(1).(func(*v1alpha1.NicDevice) error); ok {
 		r1 = rf(device)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// BreakoutConfigApplied provides a mock function with given fields: ctx, device
+func (_m *SpectrumXManager) BreakoutConfigApplied(ctx context.Context, device *v1alpha1.NicDevice) (bool, error) {
+	ret := _m.Called(ctx, device)
+
+	if len(ret) == 0 {
+		panic("no return value specified for BreakoutConfigApplied")
+	}
+
+	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *v1alpha1.NicDevice) (bool, error)); ok {
+		return rf(ctx, device)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *v1alpha1.NicDevice) bool); ok {
+		r0 = rf(ctx, device)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *v1alpha1.NicDevice) error); ok {
+		r1 = rf(ctx, device)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/types/spectrumx.go
+++ b/pkg/types/spectrumx.go
@@ -24,14 +24,14 @@ import (
 )
 
 type SpectrumXConfig struct {
-	MultiplaneConfig       SpectrumXMultiplaneConfig `yaml:"multiplane"`
-	NVConfig               []ConfigurationParameter  `yaml:"nvConfig"`
-	RuntimeConfig          SpectrumXRuntimeConfig    `yaml:"runtimeConfig"`
-	UseSoftwareCCAlgorithm bool                      `yaml:"useSoftwareCCAlgorithm"`
-	DocaCCVersion          string                    `yaml:"docaCCVersion"`
+	BreakoutConfig         SpectrumXBreakoutConfig  `yaml:"breakout"`
+	NVConfig               []ConfigurationParameter `yaml:"nvConfig"`
+	RuntimeConfig          SpectrumXRuntimeConfig   `yaml:"runtimeConfig"`
+	UseSoftwareCCAlgorithm bool                     `yaml:"useSoftwareCCAlgorithm"`
+	DocaCCVersion          string                   `yaml:"docaCCVersion"`
 }
 
-type SpectrumXMultiplaneConfig struct {
+type SpectrumXBreakoutConfig struct {
 	Swplb    map[int][]ConfigurationParameter `yaml:"swplb"`
 	Hwplb    map[int][]ConfigurationParameter `yaml:"hwplb"`
 	Uniplane map[int][]ConfigurationParameter `yaml:"uniplane"`

--- a/pkg/types/spectrumx_test.go
+++ b/pkg/types/spectrumx_test.go
@@ -51,21 +51,21 @@ var _ = Describe("LoadSpectrumXConfig", func() {
 		Expect(cfg.RuntimeConfig.InterPacketGap.PureL3[0].Name).ToNot(BeEmpty())
 		Expect(cfg.RuntimeConfig.InterPacketGap.L3EVPN[0].Name).ToNot(BeEmpty())
 
-		Expect(cfg.MultiplaneConfig.Swplb).ToNot(BeEmpty())
-		Expect(cfg.MultiplaneConfig.Swplb[2]).ToNot(BeEmpty())
-		Expect(cfg.MultiplaneConfig.Swplb[2]).To(ContainElement(
+		Expect(cfg.BreakoutConfig.Swplb).ToNot(BeEmpty())
+		Expect(cfg.BreakoutConfig.Swplb[2]).ToNot(BeEmpty())
+		Expect(cfg.BreakoutConfig.Swplb[2]).To(ContainElement(
 			ConfigurationParameter{Name: "Number of Planes", Value: "0", DMSPath: "", ValueType: "", MlxConfig: "NUM_OF_PLANES_P1"}),
 		)
-		Expect(cfg.MultiplaneConfig.Swplb[4]).ToNot(BeEmpty())
-		Expect(cfg.MultiplaneConfig.Hwplb).ToNot(BeEmpty())
-		Expect(cfg.MultiplaneConfig.Hwplb[2]).ToNot(BeEmpty())
-		Expect(cfg.MultiplaneConfig.Hwplb[2]).To(ContainElement(
+		Expect(cfg.BreakoutConfig.Swplb[4]).ToNot(BeEmpty())
+		Expect(cfg.BreakoutConfig.Hwplb).ToNot(BeEmpty())
+		Expect(cfg.BreakoutConfig.Hwplb[2]).ToNot(BeEmpty())
+		Expect(cfg.BreakoutConfig.Hwplb[2]).To(ContainElement(
 			ConfigurationParameter{Name: "Number of Planes", Value: "2", DMSPath: "", ValueType: "", MlxConfig: "NUM_OF_PLANES_P1"}),
 		)
-		Expect(cfg.MultiplaneConfig.Hwplb[4]).ToNot(BeEmpty())
-		Expect(cfg.MultiplaneConfig.Uniplane).ToNot(BeEmpty())
-		Expect(cfg.MultiplaneConfig.Uniplane[2]).ToNot(BeEmpty())
-		Expect(cfg.MultiplaneConfig.Uniplane[2]).To(ContainElements(
+		Expect(cfg.BreakoutConfig.Hwplb[4]).ToNot(BeEmpty())
+		Expect(cfg.BreakoutConfig.Uniplane).ToNot(BeEmpty())
+		Expect(cfg.BreakoutConfig.Uniplane[2]).ToNot(BeEmpty())
+		Expect(cfg.BreakoutConfig.Uniplane[2]).To(ContainElements(
 			ConfigurationParameter{Name: "Number of Planes P1", Value: "0", DMSPath: "", ValueType: "", MlxConfig: "NUM_OF_PLANES_P1"},
 			ConfigurationParameter{Name: "Number of Planes P2", Value: "0", DMSPath: "", ValueType: "", MlxConfig: "NUM_OF_PLANES_P2"}),
 		)


### PR DESCRIPTION
SpectrumX configuration changes:
- Change ApplyBreakoutConfig and ApplyNvConfig to return only error instead of (bool, error). The reboot decision is made by the manager based on whether config was already applied, not by the apply functions.
- Update configuration manager to always trigger reboot after applying breakout or nvconfig since that decision is already made when *Applied() returns false.
- Simplify applyParams helper to return just error.

Udev rules generation fix:
- Add CalculatePCIAddressForPF() function to calculate PCI addresses for multi-function NICs by incrementing the function number.
- Modify generateUdevRules() to iterate over len(PlaneIndices) instead of device.Status.Ports. This allows generating rules for PFs that will exist after reconfiguration, even if they don't exist yet.
- The validation in the controller still iterates over existing ports, so it won't error if rules were created for PFs that don't exist yet.

Bug fix in nicdevice_controller:
- Fix range loop where port was a copy instead of a pointer, causing port status updates (NetworkInterface, RdmaInterface) to be lost. Use index-based iteration with pointer to modify the original slice.

Updated tests accordingly.