### PR TITLE
[DNM]: Add mlxreg workaround for CC Probe MP mode in hwplb multiplane

### DIFF
--- a/bindata/spectrum-x/RA2.1.yaml
+++ b/bindata/spectrum-x/RA2.1.yaml
@@ -419,11 +419,14 @@ runtimeConfig:
       value: false
       dmsPath: /interfaces/interface/nvidia/roce/config/slow-restart-idle
       valueType: bool
-    - name: CC Probe MP mode
-      value: true
-      dmsPath: /interfaces/interface/nvidia/roce/config/cc-probe-mp-mode
-      valueType: bool
-      multiplane: hwplb
+    # Workaround: CC Probe MP mode is not configurable via DMS.
+    # It is set via mlxreg in the nic-configuration-operator instead.
+    # Remove this workaround once the parameter is added to DMS.
+    # - name: CC Probe MP mode
+    #   value: true
+    #   dmsPath: /interfaces/interface/nvidia/roce/config/cc-probe-mp-mode
+    #   valueType: bool
+    #   multiplane: hwplb
     - name: Adaptive Routing Force
       value: true
       dmsPath: /interfaces/interface/nvidia/roce/config/adaptive-routing-force


### PR DESCRIPTION
CC Probe MP mode is not configurable via DMS, so set it directly via mlxreg on all PFs before the last adaptive routing parameter. This is a temporary workaround until the parameter is added to DMS.