### PR TITLE
Remove control plane tolerations

### DIFF
--- a/deployment/nic-configuration-operator-chart/values.yaml
+++ b/deployment/nic-configuration-operator-chart/values.yaml
@@ -6,13 +6,7 @@ operator:
     # -- image tag to use for the operator image
     tag: latest
   # -- tolerations for the operator
-  tolerations:
-    - key: "node-role.kubernetes.io/master"
-      operator: "Exists"
-      effect: "NoSchedule"
-    - key: "node-role.kubernetes.io/control-plane"
-      operator: "Exists"
-      effect: "NoSchedule"
+  tolerations: []
   # -- node selector for the operator
   nodeSelector: {}
   # -- node affinity for the operator
@@ -23,12 +17,12 @@ operator:
           preference:
             matchExpressions:
               - key: "node-role.kubernetes.io/master"
-                operator: Exists
+                operator: DoesNotExist
         - weight: 1
           preference:
             matchExpressions:
               - key: "node-role.kubernetes.io/control-plane"
-                operator: Exists
+                operator: DoesNotExist
   # -- specify resource requests and limits for the operator
   resources:
     limits:


### PR DESCRIPTION
Remove control plane tolerations

Remove unneeded tolerations that can cause the pod to run on a node without a CSI.
The NIC Config Operator only typically runs either on worker nodes, or on nodes that act as both workers and CP nodes. In both of these cases, the node doesn't have a control plane taint. Hence this toleration is not desirabe.

We have seen a customer use case where the CSI driver isn't installed on the CP nodes, which then causes problems for the operator pod if it gets scheduled on a CP node, since it cannot access the firmware PVC. Removing the tolerations fixes that.

