### PR TITLE
Add ConnectX-9 (device ID 1025) support for Spectrum-X RA3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ spec:
   * Requires `linkType=Ethernet` and `numVfs=1`
   * Cannot be combined with `roceOptimized` (RoCE settings are included automatically)
   * Cannot be combined with `rawNvConfig`
-  * Only supported on ConnectX-8 (`nicType: 1023`) and BlueField-3 SuperNIC (`nicType: a2dc`)
-  * `version`: Required. Reference Architecture version (`RA1.3`, `RA2.0`, or `RA2.1`)
+  * Only supported on ConnectX-8 (`nicType: 1023`), ConnectX-9 (`nicType: 1025`) and BlueField-3 SuperNIC (`nicType: a2dc`)
+  * `version`: Required. Reference Architecture version (`RA1.3`, `RA2.0`, `RA2.1`, or `RA3.0`)
   * `overlay`: Optional, default `none`. Set to `l3` for L3 EVPN overlay
   * `multiplaneMode`: Optional, default `none`. Only available with RA2.1. Options: `none`, `swplb`, `hwplb`, `uniplane`
   * `numberOfPlanes`: Optional, default `1`. Only available with RA2.1. Options: `1`, `2`, or `4`
@@ -121,16 +121,17 @@ The NIC Configuration Operator supports Spectrum-X-specific NIC configuration fo
 
 Supported NIC types for Spectrum-X:
 * ConnectX-8 (device ID `1023`) -- supports all multiplane modes
+* ConnectX-9 (device ID `1025`) -- supports all multiplane modes (same configuration as ConnectX-8)
 * BlueField-3 SuperNIC (device ID `a2dc`) -- supports all multiplane modes except `hwplb`
 
 RA2.1 introduces multiplane mode support, allowing NICs to be configured with multiple data planes. Available modes:
 
 | Mode | Description | Supported NICs | Planes |
 |------|-------------|----------------|--------|
-| `none` | Single plane (default) | ConnectX-8, BF3 SuperNIC | 1 |
-| `swplb` | Software Packet Load Balancing | ConnectX-8, BF3 SuperNIC | 2, 4 |
-| `hwplb` | Hardware Packet Load Balancing | ConnectX-8 only | 2, 4 |
-| `uniplane` | Uniplane mode | ConnectX-8, BF3 SuperNIC | 2 |
+| `none` | Single plane (default) | ConnectX-8, ConnectX-9, BF3 SuperNIC | 1 |
+| `swplb` | Software Packet Load Balancing | ConnectX-8, ConnectX-9, BF3 SuperNIC | 2, 4 |
+| `hwplb` | Hardware Packet Load Balancing | ConnectX-8, ConnectX-9 only | 2, 4 |
+| `uniplane` | Uniplane mode | ConnectX-8, ConnectX-9, BF3 SuperNIC | 2 |
 
 > **Note:** Multiplane modes are only available with RA2.1. For RA1.3 and RA2.0, `multiplaneMode` must be `none` and `numberOfPlanes` must be `1`.
 
@@ -146,7 +147,7 @@ spec:
   nodeSelector:
       feature.node.kubernetes.io/network-sriov.capable: "true"
   nicSelector:
-      nicType: "1023" # ConnectX-8. Use "a2dc" for BlueField-3 SuperNIC (hwplb not supported on BF3)
+      nicType: "1023" # ConnectX-8. Use "1025" for ConnectX-9, or "a2dc" for BlueField-3 SuperNIC (hwplb not supported on BF3)
       # partNumbers:
       #   - "MCX713106AEHEA_QP1"
   template:

--- a/api/v1alpha1/nicconfigurationtemplate_types.go
+++ b/api/v1alpha1/nicconfigurationtemplate_types.go
@@ -136,8 +136,8 @@ type ConfigurationTemplateSpec struct {
 }
 
 // NicConfigurationTemplateSpec defines the desired state of NicConfigurationTemplate
-// +kubebuilder:validation:XValidation:rule="!(has(self.template.spectrumXOptimized) && self.template.spectrumXOptimized.enabled) || (self.nicSelector.nicType == '1023' || self.nicSelector.nicType == 'a2dc')",message="spectrumXOptimized can be enabled only for ConnectX-8 or BlueField-3 SuperNICs"
-// +kubebuilder:validation:XValidation:rule="!has(self.template.spectrumXOptimized) || !has(self.template.spectrumXOptimized.multiplaneMode) || self.template.spectrumXOptimized.multiplaneMode != 'hwplb' || self.nicSelector.nicType == '1023'",message="hwplb MultiplaneMode can only be enabled for ConnectX-8 (NicType 1023)"
+// +kubebuilder:validation:XValidation:rule="!(has(self.template.spectrumXOptimized) && self.template.spectrumXOptimized.enabled) || (self.nicSelector.nicType == '1023' || self.nicSelector.nicType == '1025' || self.nicSelector.nicType == 'a2dc')",message="spectrumXOptimized can be enabled only for ConnectX-8, ConnectX-9 or BlueField-3 SuperNICs"
+// +kubebuilder:validation:XValidation:rule="!has(self.template.spectrumXOptimized) || !has(self.template.spectrumXOptimized.multiplaneMode) || self.template.spectrumXOptimized.multiplaneMode != 'hwplb' || self.nicSelector.nicType == '1023' || self.nicSelector.nicType == '1025'",message="hwplb MultiplaneMode can only be enabled for ConnectX-8 (NicType 1023) or ConnectX-9 (NicType 1025)"
 type NicConfigurationTemplateSpec struct {
 	// NodeSelector contains labels required on the node. When empty, the template will be applied to matching devices on all nodes.
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`

--- a/api/v1alpha1/validation_test.go
+++ b/api/v1alpha1/validation_test.go
@@ -28,6 +28,7 @@ import (
 
 const (
 	nicTypeConnectX8   = "1023"
+	nicTypeConnectX9   = "1025"
 	nicTypeBlueField3  = "a2dc"
 	unsupportedNicType = "a2d0"
 )
@@ -147,6 +148,13 @@ var _ = Describe("NicConfigurationTemplate CEL validation", func() {
 	It("allows SpectrumXOptimized enabled for ConnectX-8 (NicType 1023)", func() {
 		obj := newNicConfigurationTemplate("spcx-allow-1023", "Ethernet", 1, &SpectrumXOptimizedSpec{Enabled: true, Version: "RA2.0"})
 		obj.Spec.NicSelector.NicType = nicTypeConnectX8
+		err := k8sClient.Create(ctx, obj)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("allows SpectrumXOptimized enabled for ConnectX-9 (NicType 1025)", func() {
+		obj := newNicConfigurationTemplate("spcx-allow-1025", "Ethernet", 1, &SpectrumXOptimizedSpec{Enabled: true, Version: "RA2.0"})
+		obj.Spec.NicSelector.NicType = nicTypeConnectX9
 		err := k8sClient.Create(ctx, obj)
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -381,6 +389,17 @@ var _ = Describe("NicConfigurationTemplate CEL validation", func() {
 			Expect(k8sClient.Create(ctx, obj)).To(Succeed())
 		})
 
+		It("allows hwplb with NicType 1025 (ConnectX-9)", func() {
+			obj := newNicConfigurationTemplate("hwplb-cx9-valid", "Ethernet", 1, &SpectrumXOptimizedSpec{
+				Enabled:        true,
+				Version:        "RA2.1",
+				MultiplaneMode: "hwplb",
+				NumberOfPlanes: 4,
+			})
+			obj.Spec.NicSelector.NicType = nicTypeConnectX9
+			Expect(k8sClient.Create(ctx, obj)).To(Succeed())
+		})
+
 		It("rejects hwplb with NicType a2dc (BlueField-3)", func() {
 			obj := newNicConfigurationTemplate("hwplb-bf3-invalid", "Ethernet", 1, &SpectrumXOptimizedSpec{
 				Enabled:        true,
@@ -391,7 +410,7 @@ var _ = Describe("NicConfigurationTemplate CEL validation", func() {
 			obj.Spec.NicSelector.NicType = nicTypeBlueField3
 			err := k8sClient.Create(ctx, obj)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("hwplb MultiplaneMode can only be enabled for ConnectX-8 (NicType 1023)"))
+			Expect(err.Error()).To(ContainSubstring("hwplb MultiplaneMode can only be enabled for ConnectX-8 (NicType 1023) or ConnectX-9 (NicType 1025)"))
 		})
 
 		It("allows swplb with NicType a2dc (BlueField-3)", func() {
@@ -438,7 +457,7 @@ var _ = Describe("NicConfigurationTemplate CEL validation", func() {
 			err := k8sClient.Create(ctx, obj)
 			Expect(err).To(HaveOccurred())
 			// Should fail on the spectrumXOptimized device type check first
-			Expect(err.Error()).To(ContainSubstring("spectrumXOptimized can be enabled only for ConnectX-8 or BlueField-3 SuperNICs"))
+			Expect(err.Error()).To(ContainSubstring("spectrumXOptimized can be enabled only for ConnectX-8, ConnectX-9 or BlueField-3 SuperNICs"))
 		})
 	})
 })

--- a/bindata/spectrum-x/RA3.0.yaml
+++ b/bindata/spectrum-x/RA3.0.yaml
@@ -68,6 +68,59 @@ mlxConfig:
         ROCE_RTT_RESP_DSCP_P1: "0"
         ROCE_RTT_RESP_DSCP_MODE_P1: "0"
         MULTIPATH_DSCP: "0"
+    "1025":
+      breakout:
+        2:
+          NUM_OF_PF: "2"
+          NUM_OF_PLANES_P1: "0"
+          LAG_RESOURCE_ALLOCATION: "0"
+          MODULE_SPLIT_M0[0]: "0x1"
+          MODULE_SPLIT_M0[1]: "0x1"
+          MODULE_SPLIT_M0[2]: "0x1"
+          MODULE_SPLIT_M0[3]: "0x1"
+          MODULE_SPLIT_M0[4]: "0x2"
+          MODULE_SPLIT_M0[5]: "0x2"
+          MODULE_SPLIT_M0[6]: "0x2"
+          MODULE_SPLIT_M0[7]: "0x2"
+          MODULE_SPLIT_M0[8]: "0xff"
+          MODULE_SPLIT_M0[9]: "0xff"
+          MODULE_SPLIT_M0[10]: "0xff"
+          MODULE_SPLIT_M0[11]: "0xff"
+          MODULE_SPLIT_M0[12]: "0xff"
+          MODULE_SPLIT_M0[13]: "0xff"
+          MODULE_SPLIT_M0[14]: "0xff"
+          MODULE_SPLIT_M0[15]: "0xff"
+        4:
+          NUM_OF_PF: "4"
+          NUM_OF_PLANES_P1: "0"
+          LAG_RESOURCE_ALLOCATION: "0"
+          MODULE_SPLIT_M0[0]: "0x1"
+          MODULE_SPLIT_M0[1]: "0x1"
+          MODULE_SPLIT_M0[2]: "0x2"
+          MODULE_SPLIT_M0[3]: "0x2"
+          MODULE_SPLIT_M0[4]: "0x3"
+          MODULE_SPLIT_M0[5]: "0x3"
+          MODULE_SPLIT_M0[6]: "0x4"
+          MODULE_SPLIT_M0[7]: "0x4"
+          MODULE_SPLIT_M0[8]: "0xff"
+          MODULE_SPLIT_M0[9]: "0xff"
+          MODULE_SPLIT_M0[10]: "0xff"
+          MODULE_SPLIT_M0[11]: "0xff"
+          MODULE_SPLIT_M0[12]: "0xff"
+          MODULE_SPLIT_M0[13]: "0xff"
+          MODULE_SPLIT_M0[14]: "0xff"
+          MODULE_SPLIT_M0[15]: "0xff"
+      postBreakout:
+        LINK_TYPE_P1: "2"
+        SRIOV_EN: "1"
+        NUM_OF_VFS: "1"
+        ROCE_ADAPTIVE_ROUTING_EN: "1"
+        USER_PROGRAMMABLE_CC: "1"
+        TX_SCHEDULER_LOCALITY_MODE: "2"
+        ROCE_CC_STEERING_EXT: "2"
+        ROCE_RTT_RESP_DSCP_P1: "0"
+        ROCE_RTT_RESP_DSCP_MODE_P1: "0"
+        MULTIPATH_DSCP: "0"
     "a2dc":
       breakout:
         2:
@@ -179,6 +232,61 @@ mlxConfig:
         FLEX_PARSER_PROFILE_ENABLE: "10"
         RDE_DISABLE: "1"
         VF_LOG_BAR_SIZE: "5"
+    "1025":
+      breakout:
+        2:
+          NUM_OF_PF: "2"
+          NUM_OF_PLANES_P1: "2"
+          LAG_RESOURCE_ALLOCATION: "1"
+          MODULE_SPLIT_M0[0]: "0x1"
+          MODULE_SPLIT_M0[1]: "0x1"
+          MODULE_SPLIT_M0[2]: "0x1"
+          MODULE_SPLIT_M0[3]: "0x1"
+          MODULE_SPLIT_M0[4]: "0x1"
+          MODULE_SPLIT_M0[5]: "0x1"
+          MODULE_SPLIT_M0[6]: "0x1"
+          MODULE_SPLIT_M0[7]: "0x1"
+          MODULE_SPLIT_M0[8]: "0xff"
+          MODULE_SPLIT_M0[9]: "0xff"
+          MODULE_SPLIT_M0[10]: "0xff"
+          MODULE_SPLIT_M0[11]: "0xff"
+          MODULE_SPLIT_M0[12]: "0xff"
+          MODULE_SPLIT_M0[13]: "0xff"
+          MODULE_SPLIT_M0[14]: "0xff"
+          MODULE_SPLIT_M0[15]: "0xff"
+        4:
+          NUM_OF_PF: "4"
+          NUM_OF_PLANES_P1: "4"
+          LAG_RESOURCE_ALLOCATION: "1"
+          MODULE_SPLIT_M0[0]: "0x1"
+          MODULE_SPLIT_M0[1]: "0x1"
+          MODULE_SPLIT_M0[2]: "0x1"
+          MODULE_SPLIT_M0[3]: "0x1"
+          MODULE_SPLIT_M0[4]: "0x1"
+          MODULE_SPLIT_M0[5]: "0x1"
+          MODULE_SPLIT_M0[6]: "0x1"
+          MODULE_SPLIT_M0[7]: "0x1"
+          MODULE_SPLIT_M0[8]: "0xff"
+          MODULE_SPLIT_M0[9]: "0xff"
+          MODULE_SPLIT_M0[10]: "0xff"
+          MODULE_SPLIT_M0[11]: "0xff"
+          MODULE_SPLIT_M0[12]: "0xff"
+          MODULE_SPLIT_M0[13]: "0xff"
+          MODULE_SPLIT_M0[14]: "0xff"
+          MODULE_SPLIT_M0[15]: "0xff"
+      postBreakout:
+        LINK_TYPE_P1: "2"
+        SRIOV_EN: "1"
+        NUM_OF_VFS: "1"
+        ROCE_ADAPTIVE_ROUTING_EN: "1"
+        USER_PROGRAMMABLE_CC: "1"
+        TX_SCHEDULER_LOCALITY_MODE: "2"
+        ROCE_CC_STEERING_EXT: "2"
+        ROCE_RTT_RESP_DSCP_P1: "48"
+        ROCE_RTT_RESP_DSCP_MODE_P1: "1"
+        FLEX_PARSER_PROFILE_ENABLE: "10"
+        RDE_DISABLE: "1"
+        VF_LOG_BAR_SIZE: "5"
     "a2dc":
       postBreakout:
         LINK_TYPE_P1: "2"
@@ -197,6 +305,40 @@ mlxConfig:
         VF_LOG_BAR_SIZE: "5"
   uniplane:
     "1023":
+      breakout:
+        2:
+          NUM_OF_PF: "2"
+          NUM_OF_PLANES_P1: "0"
+          NUM_OF_PLANES_P2: "0"
+          LAG_RESOURCE_ALLOCATION: "0"
+          MODULE_SPLIT_M0[0]: "0x1"
+          MODULE_SPLIT_M0[1]: "0x1"
+          MODULE_SPLIT_M0[2]: "0x1"
+          MODULE_SPLIT_M0[3]: "0x1"
+          MODULE_SPLIT_M0[4]: "0x2"
+          MODULE_SPLIT_M0[5]: "0x2"
+          MODULE_SPLIT_M0[6]: "0x2"
+          MODULE_SPLIT_M0[7]: "0x2"
+          MODULE_SPLIT_M0[8]: "0xff"
+          MODULE_SPLIT_M0[9]: "0xff"
+          MODULE_SPLIT_M0[10]: "0xff"
+          MODULE_SPLIT_M0[11]: "0xff"
+          MODULE_SPLIT_M0[12]: "0xff"
+          MODULE_SPLIT_M0[13]: "0xff"
+          MODULE_SPLIT_M0[14]: "0xff"
+          MODULE_SPLIT_M0[15]: "0xff"
+      postBreakout:
+        LINK_TYPE_P1: "2"
+        SRIOV_EN: "1"
+        NUM_OF_VFS: "1"
+        ROCE_ADAPTIVE_ROUTING_EN: "1"
+        USER_PROGRAMMABLE_CC: "1"
+        TX_SCHEDULER_LOCALITY_MODE: "2"
+        ROCE_CC_STEERING_EXT: "2"
+        ROCE_RTT_RESP_DSCP_P1: "0"
+        ROCE_RTT_RESP_DSCP_MODE_P1: "0"
+        MULTIPATH_DSCP: "0"
+    "1025":
       breakout:
         2:
           NUM_OF_PF: "2"
@@ -268,6 +410,18 @@ mlxConfig:
         MULTIPATH_DSCP: "0"
   none:
     "1023":
+      postBreakout:
+        LINK_TYPE_P1: "2"
+        SRIOV_EN: "1"
+        NUM_OF_VFS: "1"
+        ROCE_ADAPTIVE_ROUTING_EN: "1"
+        USER_PROGRAMMABLE_CC: "1"
+        TX_SCHEDULER_LOCALITY_MODE: "2"
+        ROCE_CC_STEERING_EXT: "2"
+        ROCE_RTT_RESP_DSCP_P1: "0"
+        ROCE_RTT_RESP_DSCP_MODE_P1: "0"
+        MULTIPATH_DSCP: "0"
+    "1025":
       postBreakout:
         LINK_TYPE_P1: "2"
         SRIOV_EN: "1"
@@ -364,6 +518,18 @@ runtimeConfig:
       dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=0]/config/value
       valueType: int
       deviceId: "1023"
+      breakout: 4
+    - name: Bandwidth
+      value: 400
+      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=0]/config/value
+      valueType: int
+      deviceId: "1025"
+      breakout: 2
+    - name: Bandwidth
+      value: 200
+      dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/param[id=0]/config/value
+      valueType: int
+      deviceId: "1025"
       breakout: 4
     - name: Bandwidth
       value: 200

--- a/config/crd/bases/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
+++ b/config/crd/bases/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
@@ -263,16 +263,17 @@ spec:
             - template
             type: object
             x-kubernetes-validations:
-            - message: spectrumXOptimized can be enabled only for ConnectX-8 or BlueField-3
-                SuperNICs
+            - message: spectrumXOptimized can be enabled only for ConnectX-8, ConnectX-9
+                or BlueField-3 SuperNICs
               rule: '!(has(self.template.spectrumXOptimized) && self.template.spectrumXOptimized.enabled)
                 || (self.nicSelector.nicType == ''1023'' || self.nicSelector.nicType
-                == ''a2dc'')'
+                == ''1025'' || self.nicSelector.nicType == ''a2dc'')'
             - message: hwplb MultiplaneMode can only be enabled for ConnectX-8 (NicType
-                1023)
+                1023) or ConnectX-9 (NicType 1025)
               rule: '!has(self.template.spectrumXOptimized) || !has(self.template.spectrumXOptimized.multiplaneMode)
                 || self.template.spectrumXOptimized.multiplaneMode != ''hwplb'' ||
-                self.nicSelector.nicType == ''1023'''
+                self.nicSelector.nicType == ''1023'' || self.nicSelector.nicType ==
+                ''1025'''
           status:
             description: Defines the observed state of NicConfigurationTemplate
             properties:

--- a/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
+++ b/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
@@ -263,16 +263,17 @@ spec:
             - template
             type: object
             x-kubernetes-validations:
-            - message: spectrumXOptimized can be enabled only for ConnectX-8 or BlueField-3
-                SuperNICs
+            - message: spectrumXOptimized can be enabled only for ConnectX-8, ConnectX-9
+                or BlueField-3 SuperNICs
               rule: '!(has(self.template.spectrumXOptimized) && self.template.spectrumXOptimized.enabled)
                 || (self.nicSelector.nicType == ''1023'' || self.nicSelector.nicType
-                == ''a2dc'')'
+                == ''1025'' || self.nicSelector.nicType == ''a2dc'')'
             - message: hwplb MultiplaneMode can only be enabled for ConnectX-8 (NicType
-                1023)
+                1023) or ConnectX-9 (NicType 1025)
               rule: '!has(self.template.spectrumXOptimized) || !has(self.template.spectrumXOptimized.multiplaneMode)
                 || self.template.spectrumXOptimized.multiplaneMode != ''hwplb'' ||
-                self.nicSelector.nicType == ''1023'''
+                self.nicSelector.nicType == ''1023'' || self.nicSelector.nicType ==
+                ''1025'''
           status:
             description: Defines the observed state of NicConfigurationTemplate
             properties:

--- a/docs/examples/spectrum-x/example-nicconfigurationtemplate-spectrum-x-multiplane.yaml
+++ b/docs/examples/spectrum-x/example-nicconfigurationtemplate-spectrum-x-multiplane.yaml
@@ -24,7 +24,7 @@ spec:
   nodeSelector:
       feature.node.kubernetes.io/network-sriov.capable: "true"
   nicSelector:
-      nicType: "1023" # ConnectX-8. Use "a2dc" for BlueField-3 SuperNIC (hwplb not supported on BF3)
+      nicType: "1023" # ConnectX-8. Use "1025" for ConnectX-9, or "a2dc" for BlueField-3 SuperNIC (hwplb not supported on BF3)
       # partNumbers:
       #   - "MCX713106AEHEA_QP1"
   template:

--- a/docs/examples/spectrum-x/example-nicconfigurationtemplate-spectrum-x.yaml
+++ b/docs/examples/spectrum-x/example-nicconfigurationtemplate-spectrum-x.yaml
@@ -24,7 +24,7 @@ spec:
   nodeSelector:
       feature.node.kubernetes.io/network-sriov.capable: "true"
   nicSelector:
-      nicType: a2dc # BlueField-3 SuperNIC, Can also be "1023" for ConnectX-8
+      nicType: a2dc # BlueField-3 SuperNIC, Can also be "1023" for ConnectX-8 or "1025" for ConnectX-9
       # partNumbers:
       #   - "MCX713106AEHEA_QP1"
   template:

--- a/docs/examples/spectrum-x/example-nicfirmwaretemplate-spectrum-x.yaml
+++ b/docs/examples/spectrum-x/example-nicfirmwaretemplate-spectrum-x.yaml
@@ -22,7 +22,7 @@ metadata:
   namespace: nvidia-network-operator
 spec:
   nicSelector:
-    nicType: "a2dc" # BlueField-3 SuperNIC, Can also be "1023" for ConnectX-8
+    nicType: "a2dc" # BlueField-3 SuperNIC, Can also be "1023" for ConnectX-8 or "1025" for ConnectX-9
     # partNumbers:
     #   - "MCX713106AEHEA_QP1"
   template:

--- a/docs/nic-configuration-library.md
+++ b/docs/nic-configuration-library.md
@@ -324,7 +324,7 @@ func NewSpectrumXConfigManager(
 2. **NV config** → filter by `DeviceId`, `Breakout`, `Multiplane` → split into MLXConfig params (`SetNvConfigParametersBatch`) and DMS params (`SetParameters`) → apply in batch → reboot
 3. **Runtime** → RoCE, Adaptive Routing, Congestion Control, InterPacketGap settings applied via DMS and sysfs — no reboot
 
-**Parameter filtering:** each `ConfigurationParameter` can be filtered by `DeviceId` (e.g., `"1023"` for CX8, `"a2dc"` for BF3), `Breakout` (plane count), and `Multiplane` mode.
+**Parameter filtering:** each `ConfigurationParameter` can be filtered by `DeviceId` (e.g., `"1023"` for CX8, `"1025"` for CX9, `"a2dc"` for BF3), `Breakout` (plane count), and `Multiplane` mode.
 
 #### CC Process Lifecycle
 

--- a/pkg/types/spectrumx_test.go
+++ b/pkg/types/spectrumx_test.go
@@ -60,11 +60,26 @@ var _ = Describe("LoadSpectrumXConfig", func() {
 		Expect(cx8Swplb.PostBreakout).To(HaveKeyWithValue("SRIOV_EN", "1"))
 		Expect(bf3Swplb.PostBreakout).To(HaveKeyWithValue("INTERNAL_CPU_MODEL", "1"))
 
-		// Check hwplb CX8 only
+		// Check CX9 swplb breakout (same config as CX8)
+		cx9Swplb := cfg.MlxConfig["swplb"]["1025"]
+		Expect(cx9Swplb.Breakout).To(HaveKey(2))
+		Expect(cx9Swplb.Breakout).To(HaveKey(4))
+		Expect(cx9Swplb.Breakout[2]).To(HaveKeyWithValue("NUM_OF_PF", "2"))
+		Expect(cx9Swplb.PostBreakout).To(HaveKeyWithValue("LINK_TYPE_P1", "2"))
+
+		// Check hwplb CX8 and CX9
 		Expect(cfg.MlxConfig["hwplb"]).To(HaveKey("1023"))
+		Expect(cfg.MlxConfig["hwplb"]).To(HaveKey("1025"))
 		cx8Hwplb := cfg.MlxConfig["hwplb"]["1023"]
 		Expect(cx8Hwplb.Breakout[2]).To(HaveKeyWithValue("NUM_OF_PLANES_P1", "2"))
 		Expect(cx8Hwplb.PostBreakout).To(HaveKeyWithValue("FLEX_PARSER_PROFILE_ENABLE", "10"))
+		cx9Hwplb := cfg.MlxConfig["hwplb"]["1025"]
+		Expect(cx9Hwplb.Breakout[2]).To(HaveKeyWithValue("NUM_OF_PLANES_P1", "2"))
+		Expect(cx9Hwplb.PostBreakout).To(HaveKeyWithValue("FLEX_PARSER_PROFILE_ENABLE", "10"))
+
+		// Check CX9 uniplane and none
+		Expect(cfg.MlxConfig["uniplane"]).To(HaveKey("1025"))
+		Expect(cfg.MlxConfig["none"]).To(HaveKey("1025"))
 
 		// Check runtime config
 		Expect(cfg.UseSoftwareCCAlgorithm).To(BeTrue())


### PR DESCRIPTION
ConnectX-9 uses the same configuration as ConnectX-8 (1023). Updates CEL validation rules, RA3.0 bindata, CRDs, tests, and documentation.