### PR TITLE
Fix NicInterfaceNameTemplate for hwplb multiport and DMS per-PF limit…

### DIFF
--- a/api/v1alpha1/nicdevice_types.go
+++ b/api/v1alpha1/nicdevice_types.go
@@ -42,8 +42,8 @@ type NicDeviceInterfaceNameSpec struct {
 	// PlaneIndices is the indices of the planes for the given NIC based on the Template
 	PlaneIndices []int `json:"planeIndices"`
 	// --- Parameters from the NicInterfaceNameTemplate CR ---
-	// RdmaDevicePrefix specifies the prefix for the rdma device name
-	RdmaDevicePrefix string `json:"rdmaDevicePrefix"`
+	// RdmaDevicePrefix specifies the prefix for the rdma device name. Empty means RDMA naming is skipped.
+	RdmaDevicePrefix string `json:"rdmaDevicePrefix,omitempty"`
 	// NetDevicePrefix specifies the prefix for the net device name
 	NetDevicePrefix string `json:"netDevicePrefix"`
 }

--- a/api/v1alpha1/nicinterfacenametemplate.go
+++ b/api/v1alpha1/nicinterfacenametemplate.go
@@ -27,13 +27,14 @@ type NicInterfaceNameTemplateSpec struct {
 	// Used to calculate the number of planes per NIC
 	// +required
 	PfsPerNic int `json:"pfsPerNic"`
-	// RdmaDevicePrefix specifies the prefix for the rdma device name
+	// RdmaDevicePrefix specifies the prefix for the rdma device name.
+	// When empty, no RDMA udev rules are generated and RDMA device naming is skipped.
 	// %nic_id%, %plane_id% and %rail_id% placeholders can be used to construct the device name
 	// %nic_id% is the index of the NIC in the flattened list of NICs
 	// %plane_id% is the index of the plane of the specific NIC
 	// %rail_id% is the index of the rail where the given NIC belongs to
-	// +required
-	RdmaDevicePrefix string `json:"rdmaDevicePrefix"`
+	// +optional
+	RdmaDevicePrefix string `json:"rdmaDevicePrefix,omitempty"`
 	// NetDevicePrefix specifies the prefix for the net device name
 	// %nic_id%, %plane_id% and %rail_id% placeholders can be used to construct the device name
 	// %nic_id% is the index of the NIC in the flattened list of NICs

--- a/bindata/spectrum-x/RA3.0.yaml
+++ b/bindata/spectrum-x/RA3.0.yaml
@@ -490,11 +490,13 @@ runtimeConfig:
       dmsPath: /interfaces/interface/nvidia/cc/config/priority/rp_enabled
       valueType: bool
       alternativeValue: "1"
+      hwplbFirstPortOnly: true
     - name: Congestion Control on NP points
       value: true
       dmsPath: /interfaces/interface/nvidia/cc/config/priority/np_enabled
       valueType: bool
       alternativeValue: "1"
+      hwplbFirstPortOnly: true
     - name: Congestion Control
       value: true
       dmsPath: /interfaces/interface/nvidia/cc/slot[id=0]/config/enabled

--- a/config/crd/bases/configuration.net.nvidia.com_nicdevices.yaml
+++ b/config/crd/bases/configuration.net.nvidia.com_nicdevices.yaml
@@ -276,7 +276,6 @@ spec:
                 - nicIndex
                 - planeIndices
                 - railIndex
-                - rdmaDevicePrefix
                 type: object
             type: object
           status:

--- a/config/crd/bases/configuration.net.nvidia.com_nicinterfacenametemplates.yaml
+++ b/config/crd/bases/configuration.net.nvidia.com_nicinterfacenametemplates.yaml
@@ -73,7 +73,8 @@ spec:
                 type: array
               rdmaDevicePrefix:
                 description: |-
-                  RdmaDevicePrefix specifies the prefix for the rdma device name
+                  RdmaDevicePrefix specifies the prefix for the rdma device name.
+                  When empty, no RDMA udev rules are generated and RDMA device naming is skipped.
                   %nic_id%, %plane_id% and %rail_id% placeholders can be used to construct the device name
                   %nic_id% is the index of the NIC in the flattened list of NICs
                   %plane_id% is the index of the plane of the specific NIC
@@ -83,7 +84,6 @@ spec:
             - netDevicePrefix
             - pfsPerNic
             - railPciAddresses
-            - rdmaDevicePrefix
             type: object
           status:
             description: NicInterfaceNameTemplateStatus defines the observed state

--- a/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicdevices.yaml
+++ b/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicdevices.yaml
@@ -276,7 +276,6 @@ spec:
                 - nicIndex
                 - planeIndices
                 - railIndex
-                - rdmaDevicePrefix
                 type: object
             type: object
           status:

--- a/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicinterfacenametemplates.yaml
+++ b/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicinterfacenametemplates.yaml
@@ -73,7 +73,8 @@ spec:
                 type: array
               rdmaDevicePrefix:
                 description: |-
-                  RdmaDevicePrefix specifies the prefix for the rdma device name
+                  RdmaDevicePrefix specifies the prefix for the rdma device name.
+                  When empty, no RDMA udev rules are generated and RDMA device naming is skipped.
                   %nic_id%, %plane_id% and %rail_id% placeholders can be used to construct the device name
                   %nic_id% is the index of the NIC in the flattened list of NICs
                   %plane_id% is the index of the plane of the specific NIC
@@ -83,7 +84,6 @@ spec:
             - netDevicePrefix
             - pfsPerNic
             - railPciAddresses
-            - rdmaDevicePrefix
             type: object
           status:
             description: NicInterfaceNameTemplateStatus defines the observed state

--- a/internal/controller/nicdevice_controller.go
+++ b/internal/controller/nicdevice_controller.go
@@ -299,7 +299,7 @@ func (r *NicDeviceReconciler) reconcileInterfaceNameTemplates(ctx context.Contex
 				mismatchedPorts = append(mismatchedPorts,
 					fmt.Sprintf("net:%s expected=%s actual=%s", port.PCI, expected.NetDevice, actualNetDevice))
 			}
-			if actualRdmaDevice != expected.RdmaDevice {
+			if expected.RdmaDevice != "" && actualRdmaDevice != expected.RdmaDevice {
 				mismatchedPorts = append(mismatchedPorts,
 					fmt.Sprintf("rdma:%s expected=%s actual=%s", port.PCI, expected.RdmaDevice, actualRdmaDevice))
 			}

--- a/internal/controller/nicdevice_controller_test.go
+++ b/internal/controller/nicdevice_controller_test.go
@@ -1370,6 +1370,35 @@ var _ = Describe("NicDeviceReconciler", func() {
 			}, timeout).Should(BeTrue())
 		})
 
+		It("Should skip RDMA validation when expected RDMA name is empty", func() {
+			// When RdmaDevicePrefix is empty or multiport clears expected RDMA,
+			// the reconciler should not report a mismatch for RDMA
+			expectedNames := map[string]udev.ExpectedInterfaceNames{
+				pciAddress: {NetDevice: "net1p1", RdmaDevice: ""}, // empty RDMA expected
+			}
+
+			// Reset the mock to override the default behavior
+			udevManager.ExpectedCalls = nil
+			udevManager.On("ApplyUdevRules", mock.Anything, mock.Anything).Return(expectedNames, true, nil)
+
+			// Mock device discovery — net matches, RDMA returns something (should be ignored)
+			deviceDiscoveryUtils.On("GetInterfaceName", pciAddress).Return("net1p1")
+			deviceDiscoveryUtils.On("GetRDMADeviceName", pciAddress).Return("some_rdma_device")
+
+			// Mock maintenance manager to release maintenance at the end
+			maintenanceManager.On("ReleaseMaintenance", mock.Anything).Return(nil)
+
+			createDeviceWithInterfaceNameTemplate()
+
+			// Should succeed — RDMA mismatch not checked when expected is empty
+			Eventually(getDeviceConditions, timeout).Should(testutils.MatchCondition(metav1.Condition{
+				Type:    consts.InterfaceNameCondition,
+				Status:  metav1.ConditionTrue,
+				Reason:  consts.InterfaceNameAppliedReason,
+				Message: "Interface names applied successfully",
+			}))
+		})
+
 		It("Should update port status with actual interface names from sysfs", func() {
 			expectedNames := map[string]udev.ExpectedInterfaceNames{
 				pciAddress: {NetDevice: "net1p1", RdmaDevice: "rdma1p1"},

--- a/pkg/dms/client.go
+++ b/pkg/dms/client.go
@@ -391,7 +391,11 @@ func (i *dmsClient) GetParameters(params []types.ConfigurationParameter) (map[st
 		value := ""
 
 		if slices.Contains(paramPathParts, Interface) {
-			for _, port := range i.device.Ports {
+			ports := i.device.Ports
+			if param.HwplbFirstPortOnly && len(ports) > 0 {
+				ports = ports[:1]
+			}
+			for _, port := range ports {
 				filterRules := interfaceNameFilter(port.NetworkInterface)
 
 				if slices.Contains(paramPathParts, Priority) {
@@ -434,7 +438,11 @@ func (i *dmsClient) collectSetUpdates(params []types.ConfigurationParameter) []s
 		paramPathParts := strings.Split(param.DMSPath, "/")
 
 		if slices.Contains(paramPathParts, Interface) {
-			for _, port := range i.device.Ports {
+			ports := i.device.Ports
+			if param.HwplbFirstPortOnly && len(ports) > 0 {
+				ports = ports[:1]
+			}
+			for _, port := range ports {
 				filterRules := interfaceNameFilter(port.NetworkInterface)
 
 				if slices.Contains(paramPathParts, Priority) {

--- a/pkg/dms/client_test.go
+++ b/pkg/dms/client_test.go
@@ -576,6 +576,110 @@ var _ = Describe("DMSClient", func() {
 		})
 	})
 
+	Describe("HwplbFirstPortOnly", func() {
+		const (
+			secondNetworkInterface = "enp3s0f1np1"
+			secondPCI              = "0000:00:00.1"
+		)
+
+		var multiPortClient *dmsClient
+
+		BeforeEach(func() {
+			multiPortDevice := v1alpha1.NicDeviceStatus{
+				SerialNumber: "test-serial",
+				Ports: []v1alpha1.NicDevicePortSpec{
+					{PCI: testPCI, NetworkInterface: testNetworkInterface},
+					{PCI: secondPCI, NetworkInterface: secondNetworkInterface},
+				},
+			}
+			multiPortClient = &dmsClient{
+				device:        multiPortDevice,
+				targetPCI:     testPCI,
+				bindAddress:   ":9339",
+				authParams:    []string{"--insecure"},
+				execInterface: fakeExec,
+			}
+		})
+
+		collectUpdatePayloads := func(args []string) []string {
+			var payloads []string
+			for i, arg := range args {
+				if arg == "--update" && i+1 < len(args) {
+					payloads = append(payloads, args[i+1])
+				}
+			}
+			return payloads
+		}
+
+		It("should iterate only first port when HwplbFirstPortOnly is true", func() {
+			param := types.ConfigurationParameter{
+				DMSPath:            "/interfaces/interface/nvidia/cc/config/priority/rp_enabled",
+				Value:              "1",
+				ValueType:          ValueTypeBool,
+				HwplbFirstPortOnly: true,
+			}
+
+			fakeExec.CommandScript = []execTesting.FakeCommandAction{
+				func(cmd string, args ...string) exec.Cmd {
+					payloads := collectUpdatePayloads(args)
+					// 8 priorities × 1 port = 8 updates (not 16)
+					Expect(payloads).To(HaveLen(8))
+					for _, p := range payloads {
+						Expect(p).To(ContainSubstring(testNetworkInterface))
+						Expect(p).NotTo(ContainSubstring(secondNetworkInterface))
+					}
+					return createFakeCmd(nil, nil)
+				},
+			}
+
+			err := multiPortClient.SetParameters([]types.ConfigurationParameter{param})
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should iterate all ports when HwplbFirstPortOnly is false", func() {
+			param := types.ConfigurationParameter{
+				DMSPath:            "/interfaces/interface/nvidia/cc/config/priority/rp_enabled",
+				Value:              "1",
+				ValueType:          ValueTypeBool,
+				HwplbFirstPortOnly: false,
+			}
+
+			fakeExec.CommandScript = []execTesting.FakeCommandAction{
+				func(cmd string, args ...string) exec.Cmd {
+					payloads := collectUpdatePayloads(args)
+					// 8 priorities × 2 ports = 16 updates
+					Expect(payloads).To(HaveLen(16))
+					return createFakeCmd(nil, nil)
+				},
+			}
+
+			err := multiPortClient.SetParameters([]types.ConfigurationParameter{param})
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should query only first port when HwplbFirstPortOnly is true", func() {
+			param := types.ConfigurationParameter{
+				DMSPath:            "/interfaces/interface/nvidia/cc/config/priority/rp_enabled",
+				HwplbFirstPortOnly: true,
+			}
+
+			// 8 priority queries for first port only
+			for i := 0; i < 8; i++ {
+				expectedPath := fmt.Sprintf("/interfaces/interface[name=%s]/nvidia/cc/config/priority[id=%d]/rp_enabled", testNetworkInterface, i)
+				fakeExec.CommandScript = append(fakeExec.CommandScript, func(cmd string, args ...string) exec.Cmd {
+					reqPath := args[len(args)-1]
+					Expect(reqPath).To(Equal(expectedPath))
+					Expect(reqPath).NotTo(ContainSubstring(secondNetworkInterface))
+					return createFakeCmd(makeGetOutput(expectedPath, param.DMSPath, "1"), nil)
+				})
+			}
+
+			vals, err := multiPortClient.GetParameters([]types.ConfigurationParameter{param})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vals[param.DMSPath]).To(Equal("1"))
+		})
+	})
+
 	Describe("InstallBFB", func() {
 		const (
 			testBFBVersion = "24.35.1000"

--- a/pkg/spectrumx/spectrumx.go
+++ b/pkg/spectrumx/spectrumx.go
@@ -105,6 +105,10 @@ func filterParameters(params []types.ConfigurationParameter, deviceType string, 
 		if param.Multiplane != "" && param.Multiplane != multiplaneMode {
 			continue
 		}
+		// HwplbFirstPortOnly only takes effect in hwplb mode; clear it otherwise
+		if param.HwplbFirstPortOnly && multiplaneMode != consts.MultiplaneModeHwplb {
+			param.HwplbFirstPortOnly = false
+		}
 		filtered = append(filtered, param)
 	}
 	return filtered

--- a/pkg/spectrumx/spectrumx_test.go
+++ b/pkg/spectrumx/spectrumx_test.go
@@ -1303,4 +1303,26 @@ var _ = Describe("SpectrumXConfigManager", func() {
 			})
 		})
 	})
+
+	Describe("filterParameters", func() {
+		It("should keep HwplbFirstPortOnly when in hwplb mode", func() {
+			params := []types.ConfigurationParameter{
+				{Name: "rp_enabled", DMSPath: "/interfaces/interface/nvidia/cc/config/priority/rp_enabled", HwplbFirstPortOnly: true},
+				{Name: "other", DMSPath: "/interfaces/interface/nvidia/cc/slot[id=0]/config/enabled"},
+			}
+			filtered := filterParameters(params, "", 0, consts.MultiplaneModeHwplb)
+			Expect(filtered).To(HaveLen(2))
+			Expect(filtered[0].HwplbFirstPortOnly).To(BeTrue())
+			Expect(filtered[1].HwplbFirstPortOnly).To(BeFalse())
+		})
+
+		It("should clear HwplbFirstPortOnly when not in hwplb mode", func() {
+			params := []types.ConfigurationParameter{
+				{Name: "rp_enabled", DMSPath: "/interfaces/interface/nvidia/cc/config/priority/rp_enabled", HwplbFirstPortOnly: true},
+			}
+			filtered := filterParameters(params, "", 0, consts.MultiplaneModeSwplb)
+			Expect(filtered).To(HaveLen(1))
+			Expect(filtered[0].HwplbFirstPortOnly).To(BeFalse())
+		})
+	})
 })

--- a/pkg/types/spectrumx.go
+++ b/pkg/types/spectrumx.go
@@ -51,16 +51,17 @@ type InterPacketGapConfig struct {
 }
 
 type ConfigurationParameter struct {
-	Name             string `yaml:"name,omitempty"`
-	MlxConfig        string `yaml:"mlxconfig,omitempty"`
-	Value            string `yaml:"value,omitempty"`
-	ValueType        string `yaml:"valueType,omitempty"`
-	DMSPath          string `yaml:"dmsPath,omitempty"`
-	AlternativeValue string `yaml:"alternativeValue,omitempty"`
-	DeviceId         string `yaml:"deviceId,omitempty"`
-	Breakout         int    `yaml:"breakout,omitempty"`
-	Multiplane       string `yaml:"multiplane,omitempty"`
-	IgnoreError      bool   `yaml:"ignoreError,omitempty"`
+	Name               string `yaml:"name,omitempty"`
+	MlxConfig          string `yaml:"mlxconfig,omitempty"`
+	Value              string `yaml:"value,omitempty"`
+	ValueType          string `yaml:"valueType,omitempty"`
+	DMSPath            string `yaml:"dmsPath,omitempty"`
+	AlternativeValue   string `yaml:"alternativeValue,omitempty"`
+	DeviceId           string `yaml:"deviceId,omitempty"`
+	Breakout           int    `yaml:"breakout,omitempty"`
+	Multiplane         string `yaml:"multiplane,omitempty"`
+	IgnoreError        bool   `yaml:"ignoreError,omitempty"`
+	HwplbFirstPortOnly bool   `yaml:"hwplbFirstPortOnly,omitempty"`
 }
 
 func LoadSpectrumXConfig(configPath string) (*SpectrumXConfig, error) {

--- a/pkg/udev/manager.go
+++ b/pkg/udev/manager.go
@@ -271,9 +271,11 @@ func (m *udevManager) generateUdevRules(devices []*v1alpha1.NicDevice) (netRules
 				} else if rdmaDeviceName != firstPFRdmaName {
 					// Different name per PF = standard mode, generate rule for each
 					rdmaRulesMap[pciAddr] = generateRdmaDeviceRule(pciAddr, rdmaDeviceName)
+				} else {
+					// Same name as PF0 = multiport/hwplb mode.
+					// Non-first PFs have no RDMA device, so skip rule and clear expected name.
+					rdmaDeviceName = ""
 				}
-				// In multiport mode (pfIndex > 0 && rdmaDeviceName == firstPFRdmaName):
-				// skip rule generation but expectedNames still gets the shared name below
 			}
 
 			// Store expected names for this PCI address

--- a/pkg/udev/manager_test.go
+++ b/pkg/udev/manager_test.go
@@ -428,10 +428,10 @@ var _ = Describe("UdevManager", func() {
 			Expect(string(rdmaContent)).To(Equal(UdevRulesHeader))
 		})
 
-		It("should generate single RDMA rule per NIC when RdmaDevicePrefix has no plane_id placeholder (multiport mode)", func() {
+		It("should generate single RDMA rule and clear expected RDMA for non-first PFs in multiport mode", func() {
 			// In multiport mode (HW PLB with usw_multiport=true), all PFs share one RDMA device.
 			// RdmaDevicePrefix has no %plane_id%, so all PFs produce the same RDMA name.
-			// Only one RDMA rule should be generated (for PF0).
+			// Only PF0 gets an RDMA rule; non-first PFs have no RDMA device so expected name is empty.
 			devices := []*v1alpha1.NicDevice{
 				{
 					Spec: v1alpha1.NicDeviceSpec{
@@ -456,10 +456,10 @@ var _ = Describe("UdevManager", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(updated).To(BeTrue())
 
-			// Both PFs should have the same expected RDMA name
+			// PF0 gets expected RDMA name; PF1 gets empty (no RDMA device in multiport)
 			Expect(expectedNames).To(HaveLen(2))
 			Expect(expectedNames["0000:1a:00.0"]).To(Equal(ExpectedInterfaceNames{NetDevice: "nic_p0_r0_n0", RdmaDevice: "rdma_r0_n0"}))
-			Expect(expectedNames["0000:1a:00.1"]).To(Equal(ExpectedInterfaceNames{NetDevice: "nic_p1_r0_n0", RdmaDevice: "rdma_r0_n0"}))
+			Expect(expectedNames["0000:1a:00.1"]).To(Equal(ExpectedInterfaceNames{NetDevice: "nic_p1_r0_n0", RdmaDevice: ""}))
 
 			// Net rules: 2 rules (one per PF)
 			netRulesPath := filepath.Join(tempDir, UdevNetRulesFile)
@@ -520,6 +520,50 @@ var _ = Describe("UdevManager", func() {
 			Expect(rdmaContentStr).To(ContainSubstring("rdma_p0_r0"))
 			Expect(rdmaContentStr).To(ContainSubstring(`KERNELS=="0000:1a:00.1"`))
 			Expect(rdmaContentStr).To(ContainSubstring("rdma_p1_r0"))
+		})
+
+		It("should generate no RDMA rules when RdmaDevicePrefix is empty", func() {
+			devices := []*v1alpha1.NicDevice{
+				{
+					Spec: v1alpha1.NicDeviceSpec{
+						InterfaceNameTemplate: &v1alpha1.NicDeviceInterfaceNameSpec{
+							NicIndex:         0,
+							RailIndex:        0,
+							PlaneIndices:     []int{0, 1},
+							RdmaDevicePrefix: "", // empty — skip RDMA
+							NetDevicePrefix:  "nic_p%plane_id%_r%rail_id%",
+						},
+					},
+					Status: v1alpha1.NicDeviceStatus{
+						Ports: []v1alpha1.NicDevicePortSpec{
+							{PCI: "0000:1a:00.0"},
+							{PCI: "0000:1a:00.1"},
+						},
+					},
+				},
+			}
+
+			expectedNames, updated, err := manager.ApplyUdevRules(context.Background(), devices)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updated).To(BeTrue())
+
+			// Net rules generated, RDMA names empty
+			Expect(expectedNames).To(HaveLen(2))
+			Expect(expectedNames["0000:1a:00.0"]).To(Equal(ExpectedInterfaceNames{NetDevice: "nic_p0_r0", RdmaDevice: ""}))
+			Expect(expectedNames["0000:1a:00.1"]).To(Equal(ExpectedInterfaceNames{NetDevice: "nic_p1_r0", RdmaDevice: ""}))
+
+			// Net rules: 2 rules
+			netRulesPath := filepath.Join(tempDir, UdevNetRulesFile)
+			netContent, err := os.ReadFile(netRulesPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(netContent)).To(ContainSubstring(`KERNELS=="0000:1a:00.0", NAME="nic_p0_r0"`))
+			Expect(string(netContent)).To(ContainSubstring(`KERNELS=="0000:1a:00.1", NAME="nic_p1_r0"`))
+
+			// RDMA rules: header only (no rules)
+			rdmaRulesPath := filepath.Join(tempDir, UdevRdmaRulesFile)
+			rdmaContent, err := os.ReadFile(rdmaRulesPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(rdmaContent)).To(Equal(UdevRulesHeader))
 		})
 
 		It("should return error if udevadm control --reload-rules fails", func() {


### PR DESCRIPTION
…ations

In HW PLB mode with usw_multiport=true, non-first PFs share PF0's RDMA device and are not individually accessible via DMS/DOCA. This caused interface name mismatch errors and DMS query failures for non-first PFs.

Interface naming changes:
- Make rdmaDevicePrefix optional in NicInterfaceNameTemplate API, allowing hwplb users to skip RDMA device renaming entirely
- When non-first PFs produce the same RDMA name as PF0 (multiport detected), clear expected RDMA name to empty and skip the udev rule
- Skip RDMA mismatch validation when expected RDMA name is empty, fixing both the optional-prefix case and the hwplb multiport transition
- Move reconcileInterfaceNameTemplates before the early return in Reconcile() so stale udev rules are cleaned up even when no devices have specs
- Clear InterfaceNameApplied condition when InterfaceNameTemplate spec is removed, following the existing Firmware/Configuration pattern
- Refresh port names for non-template devices when udev rules change, preventing stale names from reaching downstream DMS consumers

DMS per-PF limitation:
- Add HwplbFirstPortOnly flag to ConfigurationParameter that limits per-interface DMS expansion to Ports[0] only. In hwplb+multiport, DOCA cannot resolve non-first PF interfaces because the shared IB device only maps to PF0's net interface in sysfs
- Set hwplbFirstPortOnly on rp_enabled/np_enabled CC params in RA3.0 config since these settings are mirrored across PFs
- filterParameters clears the flag when not in hwplb mode so it has no effect in swplb/uniplane/none