### PR TITLE
Increase dmsc gRPC timeout from 10s to 300s for Get/Set commands

### DIFF
--- a/pkg/dms/client.go
+++ b/pkg/dms/client.go
@@ -49,7 +49,8 @@ const (
 	Interface = "interface"
 	Priority  = "priority"
 
-	dmsClientPath = "/opt/mellanox/doca/services/dms/dmsc"
+	dmsClientPath    = "/opt/mellanox/doca/services/dms/dmsc"
+	dmsClientTimeout = "300s"
 )
 
 // DMSClient interface defines methods for interacting with a DMS instance to manage NIC device configuration
@@ -162,7 +163,7 @@ func (i *dmsInstance) RunGetPathCommand(path string, filterRules map[string]stri
 
 	queryPath := injectFilterRules(path, filterRules)
 
-	args := []string{dmsClientPath, "-a", i.bindAddress, "--insecure", "get", "--path", queryPath}
+	args := []string{dmsClientPath, "-a", i.bindAddress, "--insecure", "--timeout", dmsClientTimeout, "get", "--path", queryPath}
 	log.Log.V(2).Info("dmsInstance.RunGetPathCommand()", "args", strings.Join(args, " "))
 
 	command := i.execInterface.Command(args[0], args[1:]...)
@@ -215,7 +216,7 @@ func (i *dmsInstance) RunSetPathCommand(path, value, valueType string, filterRul
 
 	queryPath := injectFilterRules(path, filterRules)
 
-	args := []string{dmsClientPath, "-a", i.bindAddress, "--insecure", "set", "--update", fmt.Sprintf("%s:::%s:::%s", queryPath, valueType, value)}
+	args := []string{dmsClientPath, "-a", i.bindAddress, "--insecure", "--timeout", dmsClientTimeout, "set", "--update", fmt.Sprintf("%s:::%s:::%s", queryPath, valueType, value)}
 	log.Log.V(2).Info("dmsInstance.RunSetPathCommand()", "args", strings.Join(args, " "))
 
 	command := i.execInterface.Command(args[0], args[1:]...)


### PR DESCRIPTION
The dmsc binary (gnmic-based gNMI client) defaults to a 10-second gRPC deadline. On hosts with many NICs (e.g., 12 BF3 SuperNICs), concurrent mlxconfig calls through the DMS pipeline (dmsc → dmsd → dmspe → mlxconfig) contend for device access and routinely take 6-11 seconds. Commands that exceed the 10s deadline cause dmsc to exit with status 1, surfacing as "failed to run get path command: exit status 1" during Spectrum-X NV config validation — even though the underlying mlxconfig command would succeed given more time.

Pass --timeout 300s to dmsc for get and set operations. The timeout is not set for gNOI commands (os install/activate) as those use a separate code path (gnoic) with its own timeout handling.