### PR TITLE
fix for build_image CI workflow

### DIFF
--- a/.github/workflows/build-test-lint.yml
+++ b/.github/workflows/build-test-lint.yml
@@ -44,6 +44,15 @@ jobs:
         uses: actions/checkout@v6
       - name: Run tests
         run: make test
+  build-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Build image
+        run: make docker-build
   go-check:
     runs-on: ubuntu-latest
     needs: build

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ COPY ./ ./
 #RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/maintenance-manager/main.go
 RUN --mount=type=cache,target=/go/pkg/mod/ GO_GCFLAGS=${GCFLAGS} make build-manager
 
-FROM ${BASE_IMAGE_DOCA_FULL_RT_HOST:-nvcr.io/nvstaging/doca/doca:full-rt-3.4.0-amd64-host-dev}
+FROM ${BASE_IMAGE_DOCA_FULL_RT_HOST:-nvcr.io/nvidia/doca/doca:3.3.0-full-rt-host}
 
 ARG TARGETARCH
 

--- a/Dockerfile.nic-configuration-daemon
+++ b/Dockerfile.nic-configuration-daemon
@@ -26,7 +26,7 @@ COPY ./ ./
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN --mount=type=cache,target=/go/pkg/mod/ GO_GCFLAGS=${GCFLAGS} make build-daemon
 
-FROM ${BASE_IMAGE_DOCA_FULL_RT_HOST:-nvcr.io/nvstaging/doca/doca:full-rt-3.4.0-amd64-host-dev}
+FROM ${BASE_IMAGE_DOCA_FULL_RT_HOST:-nvcr.io/nvidia/doca/doca:3.3.0-full-rt-host}
 
 ARG TARGETARCH
 


### PR DESCRIPTION
Let's use publicly available images by default to allow this workflow when pushing from forks.
It's okay if the image is not latest-and-greatest as this is mostly a build test