### PR TITLE
Filter out VF/SF representors from PF interface name discovery

### DIFF
--- a/pkg/devicediscovery/utils.go
+++ b/pkg/devicediscovery/utils.go
@@ -36,6 +36,10 @@ import (
 
 const pciDevicesPath = "/sys/bus/pci/devices"
 
+// physPortNameRegex matches physical port names like "p0", "p1" — the PF uplink interfaces.
+// VF/SF representors have names like "pf0vf0", "pf0sf0" which do NOT match this pattern.
+var physPortNameRegex = regexp.MustCompile(`^p\d+$`)
+
 type DeviceDiscoveryUtils interface {
 	// GetPCIDevices returns a list of PCI devices on the host
 	GetPCIDevices() ([]*pci.Device, error)
@@ -228,8 +232,32 @@ func (d *deviceDiscoveryUtils) IsZeroTrust(pciAddr string) (bool, error) {
 	return false, fmt.Errorf("IsZeroTrustDevice(): failed to parse mlxprivhost output")
 }
 
+// isPhysicalPort checks if a network interface under a PCI device is a physical port (PF uplink)
+// rather than a VF/SF representor. It reads the phys_port_name sysfs attribute:
+// - PF uplinks have phys_port_name like "p0", "p1"
+// - Representors have phys_port_name like "pf0vf0", "pf0sf0"
+// Returns true if the interface is a physical port or if phys_port_name cannot be determined
+// (backward compatibility for devices that don't expose this attribute).
+func isPhysicalPort(basePath, pciAddr, ifaceName string) bool {
+	physPortNamePath := filepath.Join(basePath, pciAddr, "net", ifaceName, "phys_port_name")
+	data, err := os.ReadFile(physPortNamePath)
+	if err != nil {
+		// File doesn't exist or can't be read — assume it's a physical port for backward compatibility
+		return true
+	}
+	portName := strings.TrimSpace(string(data))
+	if portName == "" {
+		return true
+	}
+	return physPortNameRegex.MatchString(portName)
+}
+
 func getNetNames(pciAddr string) ([]string, error) {
-	netDir := filepath.Join(pciDevicesPath, pciAddr, "net")
+	return getNetNamesFromPath(pciDevicesPath, pciAddr)
+}
+
+func getNetNamesFromPath(basePath, pciAddr string) ([]string, error) {
+	netDir := filepath.Join(basePath, pciAddr, "net")
 	if _, err := os.Lstat(netDir); err != nil {
 		return nil, fmt.Errorf("GetNetNames(): no net directory under pci device %s: %q", pciAddr, err)
 	}
@@ -241,7 +269,10 @@ func getNetNames(pciAddr string) ([]string, error) {
 
 	names := make([]string, 0)
 	for _, f := range fInfos {
-		names = append(names, f.Name())
+		name := f.Name()
+		if isPhysicalPort(basePath, pciAddr, name) {
+			names = append(names, name)
+		}
 	}
 
 	return names, nil

--- a/pkg/devicediscovery/utils_test.go
+++ b/pkg/devicediscovery/utils_test.go
@@ -16,6 +16,8 @@ limitations under the License.
 package devicediscovery
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -268,6 +270,126 @@ var _ = Describe("HostUtils", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(zeroTrust).To(BeFalse())
+		})
+	})
+
+	Describe("isPhysicalPort", func() {
+		var tmpDir string
+
+		BeforeEach(func() {
+			var err error
+			tmpDir, err = os.MkdirTemp("", "pci-test-*")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			Expect(os.RemoveAll(tmpDir)).To(Succeed())
+		})
+
+		createPhysPortName := func(pciAddr, ifaceName, portName string) {
+			dir := filepath.Join(tmpDir, pciAddr, "net", ifaceName)
+			Expect(os.MkdirAll(dir, 0755)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(dir, "phys_port_name"), []byte(portName+"\n"), 0644)).To(Succeed())
+		}
+
+		It("should return true for physical port p0", func() {
+			createPhysPortName(pciAddress, "eth_rail0", "p0")
+			Expect(isPhysicalPort(tmpDir, pciAddress, "eth_rail0")).To(BeTrue())
+		})
+
+		It("should return true for physical port p1", func() {
+			createPhysPortName(pciAddress, "eth_rail1", "p1")
+			Expect(isPhysicalPort(tmpDir, pciAddress, "eth_rail1")).To(BeTrue())
+		})
+
+		It("should return false for VF representor pf0vf0", func() {
+			createPhysPortName(pciAddress, "eth1", "pf0vf0")
+			Expect(isPhysicalPort(tmpDir, pciAddress, "eth1")).To(BeFalse())
+		})
+
+		It("should return false for SF representor pf0sf0", func() {
+			createPhysPortName(pciAddress, "en3f0pf0sf0", "pf0sf0")
+			Expect(isPhysicalPort(tmpDir, pciAddress, "en3f0pf0sf0")).To(BeFalse())
+		})
+
+		It("should return true when phys_port_name file does not exist", func() {
+			dir := filepath.Join(tmpDir, pciAddress, "net", "eth0")
+			Expect(os.MkdirAll(dir, 0755)).To(Succeed())
+			Expect(isPhysicalPort(tmpDir, pciAddress, "eth0")).To(BeTrue())
+		})
+
+		It("should return true when phys_port_name is empty", func() {
+			createPhysPortName(pciAddress, "eth0", "")
+			Expect(isPhysicalPort(tmpDir, pciAddress, "eth0")).To(BeTrue())
+		})
+	})
+
+	Describe("getNetNamesFromPath", func() {
+		var tmpDir string
+
+		BeforeEach(func() {
+			var err error
+			tmpDir, err = os.MkdirTemp("", "pci-test-*")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			Expect(os.RemoveAll(tmpDir)).To(Succeed())
+		})
+
+		createIface := func(pciAddr, ifaceName, physPortName string) {
+			dir := filepath.Join(tmpDir, pciAddr, "net", ifaceName)
+			Expect(os.MkdirAll(dir, 0755)).To(Succeed())
+			if physPortName != "" {
+				Expect(os.WriteFile(filepath.Join(dir, "phys_port_name"), []byte(physPortName+"\n"), 0644)).To(Succeed())
+			}
+		}
+
+		It("should return single interface", func() {
+			createIface(pciAddress, "eth0", "p0")
+			names, err := getNetNamesFromPath(tmpDir, pciAddress)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(names).To(ConsistOf("eth0"))
+		})
+
+		It("should filter out VF representors and return only PF", func() {
+			createIface(pciAddress, "eth1", "pf0vf0")
+			createIface(pciAddress, "eth_rail1", "p0")
+			names, err := getNetNamesFromPath(tmpDir, pciAddress)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(names).To(ConsistOf("eth_rail1"))
+		})
+
+		It("should filter out multiple representors", func() {
+			createIface(pciAddress, "eth1", "pf0vf0")
+			createIface(pciAddress, "eth2", "pf0vf1")
+			createIface(pciAddress, "eth_rail1", "p0")
+			names, err := getNetNamesFromPath(tmpDir, pciAddress)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(names).To(ConsistOf("eth_rail1"))
+		})
+
+		It("should return all interfaces when phys_port_name is not available", func() {
+			// No phys_port_name file — isPhysicalPort returns true for backward compat
+			createIface(pciAddress, "eth0", "")
+			createIface(pciAddress, "eth1", "")
+			names, err := getNetNamesFromPath(tmpDir, pciAddress)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(names).To(ConsistOf("eth0", "eth1"))
+		})
+
+		It("should return empty list when all interfaces are representors", func() {
+			createIface(pciAddress, "eth1", "pf0vf0")
+			createIface(pciAddress, "eth2", "pf0vf1")
+			names, err := getNetNamesFromPath(tmpDir, pciAddress)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(names).To(BeEmpty())
+		})
+
+		It("should return error when net directory does not exist", func() {
+			names, err := getNetNamesFromPath(tmpDir, pciAddress)
+			Expect(err).To(HaveOccurred())
+			Expect(names).To(BeNil())
 		})
 	})
 })


### PR DESCRIPTION
On hosts with eSwitch in switchdev mode, each PCI PF address exposes multiple entries under /sys/bus/pci/devices/<pci>/net/ — the PF uplink (e.g., eth_rail1) and VF representors (e.g., eth1). Since os.ReadDir returns entries alphabetically and GetInterfaceName() picks the first one, it returns the representor instead of the actual PF interface. This causes incorrect interface names in NicDeviceStatus, breaking DMS commands, Spectrum-X configuration, and QoS settings.

Filter interfaces by reading the phys_port_name sysfs attribute. PF uplinks have names matching "p<N>" (p0, p1), while representors have names like "pf0vf0" or "pf0sf0". Fall back to returning all interfaces when phys_port_name is not available, for backward compatibility with devices that don't expose this attribute.