### PR TITLE
Allow non-zero PCI domain in NicSelector PCI address validation

### DIFF
--- a/api/v1alpha1/nicconfigurationtemplate_types.go
+++ b/api/v1alpha1/nicconfigurationtemplate_types.go
@@ -24,7 +24,7 @@ type NicSelectorSpec struct {
 	// Type of the NIC to be selected, e.g. 101d,1015,a2d6 etc.
 	NicType string `json:"nicType"`
 	// Array of PCI addresses to be selected, e.g. "0000:03:00.0"
-	// +kubebuilder:validation:items:Pattern=`^0000:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-7]$`
+	// +kubebuilder:validation:items:Pattern=`^[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-7]$`
 	PciAddresses []string `json:"pciAddresses,omitempty"`
 	// Serial numbers of the NICs to be selected, e.g. MT2116X09299
 	SerialNumbers []string `json:"serialNumbers,omitempty"`

--- a/config/crd/bases/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
+++ b/config/crd/bases/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
@@ -55,7 +55,7 @@ spec:
                   pciAddresses:
                     description: Array of PCI addresses to be selected, e.g. "0000:03:00.0"
                     items:
-                      pattern: ^0000:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-7]$
+                      pattern: ^[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-7]$
                       type: string
                     type: array
                   serialNumbers:

--- a/config/crd/bases/configuration.net.nvidia.com_nicfirmwaretemplates.yaml
+++ b/config/crd/bases/configuration.net.nvidia.com_nicfirmwaretemplates.yaml
@@ -56,7 +56,7 @@ spec:
                   pciAddresses:
                     description: Array of PCI addresses to be selected, e.g. "0000:03:00.0"
                     items:
-                      pattern: ^0000:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-7]$
+                      pattern: ^[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-7]$
                       type: string
                     type: array
                   serialNumbers:

--- a/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
+++ b/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
@@ -55,7 +55,7 @@ spec:
                   pciAddresses:
                     description: Array of PCI addresses to be selected, e.g. "0000:03:00.0"
                     items:
-                      pattern: ^0000:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-7]$
+                      pattern: ^[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-7]$
                       type: string
                     type: array
                   serialNumbers:

--- a/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicfirmwaretemplates.yaml
+++ b/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicfirmwaretemplates.yaml
@@ -56,7 +56,7 @@ spec:
                   pciAddresses:
                     description: Array of PCI addresses to be selected, e.g. "0000:03:00.0"
                     items:
-                      pattern: ^0000:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-7]$
+                      pattern: ^[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-7]$
                       type: string
                     type: array
                   serialNumbers:


### PR DESCRIPTION
The kubebuilder validation pattern for pciAddresses hardcoded domain 0000, silently rejecting valid PCI addresses on systems with multiple PCI host bridges or PCIe switches (e.g., 0001:03:00.0). Relax the domain segment from literal "0000" to [0-9a-fA-F]{4}.