### PR TITLE
Retry mlxvpd on failure and log its combined output at V(2)

### DIFF
--- a/pkg/devicediscovery/utils.go
+++ b/pkg/devicediscovery/utils.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/Mellanox/rdmamap"
 	"github.com/jaypipes/ghw"
@@ -35,6 +36,31 @@ import (
 )
 
 const pciDevicesPath = "/sys/bus/pci/devices"
+
+const mlxvpdMaxAttempts = 3
+
+// mlxvpdBackoff is a var (not const) so tests can override it to keep runs fast.
+var mlxvpdBackoff = 500 * time.Millisecond
+
+// runCommandWithRetry runs `name args...` up to maxAttempts times, sleeping backoff
+// between failed attempts. Returns combined stdout+stderr from the last attempt and
+// its error. A fresh Cmd is built each iteration (execUtils.Cmd is single-use).
+func runCommandWithRetry(execInterface execUtils.Interface, name string, args []string, maxAttempts int, backoff time.Duration) ([]byte, error) {
+	var output []byte
+	var err error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		output, err = execInterface.Command(name, args...).CombinedOutput()
+		log.Log.V(2).Info("command output", "command", name, "attempt", attempt, "output", string(output))
+		if err == nil {
+			return output, nil
+		}
+		if attempt < maxAttempts {
+			log.Log.V(1).Info("command failed, retrying", "command", name, "attempt", attempt, "error", err)
+			time.Sleep(backoff)
+		}
+	}
+	return output, err
+}
 
 // physPortNameRegex matches physical port names like "p0", "p1" — the PF uplink interfaces.
 // VF/SF representors have names like "pf0vf0", "pf0sf0" which do NOT match this pattern.
@@ -80,11 +106,10 @@ func (d *deviceDiscoveryUtils) GetPCIDevices() ([]*pci.Device, error) {
 
 // GetVPD uses mlxvpd util to retrieve Part Number, Serial Number, Model Name of the PCI device
 func (d *deviceDiscoveryUtils) GetVPD(pciAddr string) (*types.VPD, error) {
-	log.Log.Info("HostUtils.GetPartAndSerialNumber()", "pciAddr", pciAddr)
-	cmd := d.execInterface.Command("mlxvpd", "-d", pciAddr)
-	output, err := utils.RunCommand(cmd)
+	log.Log.Info("HostUtils.GetVPD()", "pciAddr", pciAddr)
+	output, err := runCommandWithRetry(d.execInterface, "mlxvpd", []string{"-d", pciAddr}, mlxvpdMaxAttempts, mlxvpdBackoff)
 	if err != nil {
-		log.Log.Error(err, "GetPartAndSerialNumber(): Failed to run mlxvpd")
+		log.Log.Error(err, "GetVPD(): Failed to run mlxvpd")
 		return nil, err
 	}
 

--- a/pkg/devicediscovery/utils_test.go
+++ b/pkg/devicediscovery/utils_test.go
@@ -16,9 +16,11 @@ limitations under the License.
 package devicediscovery
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -31,6 +33,17 @@ const pciAddress = "0000:03:00.0"
 var _ = Describe("HostUtils", func() {
 	//nolint:dupl
 	Describe("GetVPD", func() {
+		var originalBackoff time.Duration
+
+		BeforeEach(func() {
+			originalBackoff = mlxvpdBackoff
+			mlxvpdBackoff = 1 * time.Millisecond
+		})
+
+		AfterEach(func() {
+			mlxvpdBackoff = originalBackoff
+		})
+
 		It("should return part, serial and model name", func() {
 			partNumber := "MCX623106AE-CDAT"
 			serialNumber := "MT2235J01129"
@@ -39,7 +52,7 @@ var _ = Describe("HostUtils", func() {
 			fakeExec := &execTesting.FakeExec{}
 
 			fakeCmd := &execTesting.FakeCmd{}
-			fakeCmd.OutputScript = append(fakeCmd.OutputScript, func() ([]byte, []byte, error) {
+			fakeCmd.CombinedOutputScript = append(fakeCmd.CombinedOutputScript, func() ([]byte, []byte, error) {
 				return []byte("  VPD-KEYWORD    DESCRIPTION             VALUE\n" +
 						"  -----------    -----------             -----\n" +
 						"Read Only Section:\n" +
@@ -74,7 +87,7 @@ var _ = Describe("HostUtils", func() {
 			fakeExec := &execTesting.FakeExec{}
 
 			fakeCmd := &execTesting.FakeCmd{}
-			fakeCmd.OutputScript = append(fakeCmd.OutputScript, func() ([]byte, []byte, error) {
+			fakeCmd.CombinedOutputScript = append(fakeCmd.CombinedOutputScript, func() ([]byte, []byte, error) {
 				return []byte("  SN             Serial Number           MT2235J01129\n"), nil, nil
 			})
 
@@ -95,7 +108,7 @@ var _ = Describe("HostUtils", func() {
 			Expect(vpd).To(BeNil())
 
 			fakeCmd = &execTesting.FakeCmd{}
-			fakeCmd.OutputScript = append(fakeCmd.OutputScript, func() ([]byte, []byte, error) {
+			fakeCmd.CombinedOutputScript = append(fakeCmd.CombinedOutputScript, func() ([]byte, []byte, error) {
 				return []byte("  PN             Part Number             MCX623106AE-CDAT\n"), nil, nil
 			})
 
@@ -118,7 +131,7 @@ var _ = Describe("HostUtils", func() {
 			fakeExec := &execTesting.FakeExec{}
 
 			fakeCmd := &execTesting.FakeCmd{}
-			fakeCmd.OutputScript = append(fakeCmd.OutputScript, func() ([]byte, []byte, error) {
+			fakeCmd.CombinedOutputScript = append(fakeCmd.CombinedOutputScript, func() ([]byte, []byte, error) {
 				return []byte("  VPD-KEYWORD    DESCRIPTION             VALUE\n" +
 						"  -----------    -----------             -----\n" +
 						"Read Only Section:\n" +
@@ -146,6 +159,77 @@ var _ = Describe("HostUtils", func() {
 			Expect(vpd.PartNumber).To(Equal(partNumber))
 			Expect(vpd.SerialNumber).To(Equal(serialNumber))
 			Expect(vpd.ModelName).To(Equal(""))
+		})
+		It("should retry and succeed on the 2nd attempt", func() {
+			partNumber := "MCX623106AE-CDAT"
+			serialNumber := "MT2235J01129"
+
+			fakeExec := &execTesting.FakeExec{}
+
+			failingCmd := &execTesting.FakeCmd{}
+			failingCmd.CombinedOutputScript = append(failingCmd.CombinedOutputScript, func() ([]byte, []byte, error) {
+				return nil, nil, errors.New("exit status 2")
+			})
+
+			successCmd := &execTesting.FakeCmd{}
+			successCmd.CombinedOutputScript = append(successCmd.CombinedOutputScript, func() ([]byte, []byte, error) {
+				return []byte("  PN             Part Number             " + partNumber + "\n" +
+						"  SN             Serial Number           " + serialNumber + "\n"),
+					nil, nil
+			})
+
+			cmds := []exec.Cmd{failingCmd, successCmd}
+			fakeExec.CommandScript = append(fakeExec.CommandScript,
+				func(cmd string, args ...string) exec.Cmd {
+					Expect(cmd).To(Equal("mlxvpd"))
+					return cmds[0]
+				},
+				func(cmd string, args ...string) exec.Cmd {
+					Expect(cmd).To(Equal("mlxvpd"))
+					return cmds[1]
+				},
+			)
+
+			h := &deviceDiscoveryUtils{
+				execInterface: fakeExec,
+			}
+
+			vpd, err := h.GetVPD(pciAddress)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(vpd.PartNumber).To(Equal(partNumber))
+			Expect(vpd.SerialNumber).To(Equal(serialNumber))
+			Expect(fakeExec.CommandCalls).To(Equal(2))
+		})
+		It("should retry up to maxAttempts and return an error", func() {
+			fakeExec := &execTesting.FakeExec{}
+
+			newFailingCmd := func() *execTesting.FakeCmd {
+				c := &execTesting.FakeCmd{}
+				c.CombinedOutputScript = append(c.CombinedOutputScript, func() ([]byte, []byte, error) {
+					return []byte("mlxvpd: failed to read VPD"), nil, errors.New("exit status 2")
+				})
+				return c
+			}
+
+			cmds := []exec.Cmd{newFailingCmd(), newFailingCmd(), newFailingCmd()}
+			for i := range cmds {
+				c := cmds[i]
+				fakeExec.CommandScript = append(fakeExec.CommandScript, func(cmd string, args ...string) exec.Cmd {
+					Expect(cmd).To(Equal("mlxvpd"))
+					return c
+				})
+			}
+
+			h := &deviceDiscoveryUtils{
+				execInterface: fakeExec,
+			}
+
+			vpd, err := h.GetVPD(pciAddress)
+
+			Expect(err).To(HaveOccurred())
+			Expect(vpd).To(BeNil())
+			Expect(fakeExec.CommandCalls).To(Equal(mlxvpdMaxAttempts))
 		})
 	})
 	//nolint:dupl


### PR DESCRIPTION
Discovery on some setups sporadically fails with `exit status 2` from mlxvpd. Retry up to 3 times with 500ms backoff, and capture stdout+stderr at log level V(2) for diagnosis.