### PR TITLE
devicediscovery: parse model name from full IDTAG and log discovered status

### DIFF
--- a/pkg/devicediscovery/devicediscovery.go
+++ b/pkg/devicediscovery/devicediscovery.go
@@ -106,8 +106,11 @@ func (d deviceDiscovery) DiscoverNicDevices() (map[string]v1alpha1.NicDevice, er
 				return nil, err
 			}
 
-			// Trim the model name to the first word, e.g. ConnectX-6 or BlueField-2
-			shortName := strings.SplitN(vpd.ModelName, " ", 2)[0]
+			// mlxvpd's IDTAG "Board Id" is a long marketing string like
+			//   "NVIDIA ConnectX-9 C9180 HHHL SuperNIC, 800Gbs XDR IB / 800GbE (default), ..."
+			// The portion before the first comma is the product name; everything after is
+			// feature/packaging detail we don't want in the CR.
+			modelName := strings.TrimSpace(strings.SplitN(vpd.ModelName, ",", 2)[0])
 
 			dpu := false
 			if isBlueField {
@@ -125,13 +128,15 @@ func (d deviceDiscovery) DiscoverNicDevices() (map[string]v1alpha1.NicDevice, er
 				Type:            device.Product.ID,
 				SerialNumber:    vpd.SerialNumber,
 				PartNumber:      vpd.PartNumber,
-				ModelName:       shortName,
+				ModelName:       modelName,
 				PSID:            psid,
 				FirmwareVersion: firmwareVersion,
 				SuperNIC:        utils.ContainsIgnoreCase(vpd.ModelName, consts.SuperNIC),
 				DPU:             dpu,
 				Ports:           []v1alpha1.NicDevicePortSpec{},
 			}
+
+			log.Log.Info("Discovered NIC device", "address", device.Address, "status", deviceStatus)
 
 			statuses[vpd.SerialNumber] = deviceStatus
 		}

--- a/pkg/devicediscovery/devicediscovery_test.go
+++ b/pkg/devicediscovery/devicediscovery_test.go
@@ -453,7 +453,7 @@ var _ = Describe("DeviceDiscovery", func() {
 	})
 
 	Context("when parsing model name and SuperNIC flag", func() {
-		It("should shorten model name and set SuperNIC", func() {
+		It("should truncate model name at first comma and set SuperNIC", func() {
 			mockUtils.On("GetPCIDevices").Return([]*pci.Device{
 				{
 					Address: "0000:00:00.0",
@@ -463,7 +463,11 @@ var _ = Describe("DeviceDiscovery", func() {
 				},
 			}, nil)
 			mockUtils.On("IsSriovVF", "0000:00:00.0").Return(false)
-			mockUtils.On("GetVPD", "0000:00:00.0").Return(&types.VPD{PartNumber: "part-number", SerialNumber: "serial-number", ModelName: "ConnectX-8 SuperNIC"}, nil)
+			mockUtils.On("GetVPD", "0000:00:00.0").Return(&types.VPD{
+				PartNumber:   "part-number",
+				SerialNumber: "serial-number",
+				ModelName:    "NVIDIA ConnectX-8 C8180 HHHL SuperNIC, 800Gbs XDR IB / 800GbE (default), Single-cage OSFP",
+			}, nil)
 			mockUtils.On("GetFirmwareVersionAndPSID", "0000:00:00.0").Return("fw-version", "psid", nil)
 			mockUtils.On("GetInterfaceName", "0000:00:00.0").Return("eth0")
 			mockUtils.On("GetRDMADeviceName", "0000:00:00.0").Return("mlx5_0")
@@ -474,7 +478,7 @@ var _ = Describe("DeviceDiscovery", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(devicesBySerial).To(HaveKey("serial-number"))
 			discoveredDevice := devicesBySerial["serial-number"]
-			Expect(discoveredDevice.Status.ModelName).To(Equal("ConnectX-8"))
+			Expect(discoveredDevice.Status.ModelName).To(Equal("NVIDIA ConnectX-8 C8180 HHHL SuperNIC"))
 			Expect(discoveredDevice.Status.SuperNIC).To(BeTrue())
 		})
 	})


### PR DESCRIPTION
mlxvpd's IDTAG "Board Id" is a comma-separated marketing string like "NVIDIA ConnectX-9 C9180 HHHL SuperNIC, 800Gbs XDR IB / 800GbE (default), ...". Taking only the first whitespace-delimited token reduced it to "NVIDIA", which is uninformative in the NicDevice CR.

Split on the first comma instead so the product name survives ("NVIDIA ConnectX-9 C9180 HHHL SuperNIC") while feature/packaging detail is dropped. SuperNIC detection continues to match against the raw VPD value.

Also log the full discovered NicDeviceStatus (address, node, type, serial, part number, model name, PSID, firmware version, SuperNIC, DPU) once per unique serial number, to aid diagnosis of grouping anomalies.