### PR TITLE
firmware: bind BF PFs to mlx5_core before BFB install

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -106,6 +106,9 @@ const (
 
 	SupportedNicFirmwareConfigmap = "nic-configuration-operator-supported-nic-firmware"
 	Mlx5ModuleVersionPath         = "/sys/bus/pci/drivers/mlx5_core/module/version"
+	Mlx5CoreDriverName            = "mlx5_core"
+	PCIDevicesSysfsPath           = "/sys/bus/pci/devices"
+	Mlx5CoreDriverBindPath        = "/sys/bus/pci/drivers/mlx5_core/bind"
 
 	FwConfigNotAppliedAfterRebootErrorMsg = "firmware configuration failed to apply after reboot"
 

--- a/pkg/devicediscovery/utils_test.go
+++ b/pkg/devicediscovery/utils_test.go
@@ -28,7 +28,11 @@ import (
 	execTesting "k8s.io/utils/exec/testing"
 )
 
-const pciAddress = "0000:03:00.0"
+const (
+	pciAddress   = "0000:03:00.0"
+	partNumber   = "MCX623106AE-CDAT"
+	serialNumber = "MT2235J01129"
+)
 
 var _ = Describe("HostUtils", func() {
 	//nolint:dupl
@@ -45,8 +49,6 @@ var _ = Describe("HostUtils", func() {
 		})
 
 		It("should return part, serial and model name", func() {
-			partNumber := "MCX623106AE-CDAT"
-			serialNumber := "MT2235J01129"
 			modelName := "ConnectX-6 Dx EN adapter card, 100GbE, Dual-port QSFP56, PCIe 4.0 x16, Crypto, No Secure Boot"
 
 			fakeExec := &execTesting.FakeExec{}
@@ -57,11 +59,11 @@ var _ = Describe("HostUtils", func() {
 						"  -----------    -----------             -----\n" +
 						"Read Only Section:\n" +
 						"\n" +
-						"  PN             Part Number             MCX623106AE-CDAT\n" +
+						"  PN             Part Number             " + partNumber + "\n" +
 						"  EC             Revision                AB\n" +
-						"  SN             Serial Number           MT2235J01129\n" +
+						"  SN             Serial Number           " + serialNumber + "\n" +
 						"  V3             N/A                     3869145f5722ed118000b83fd2193152\n" +
-						"  IDTAG          Board Id                ConnectX-6 Dx EN adapter card, 100GbE, Dual-port QSFP56, PCIe 4.0 x16, Crypto, No Secure Boot\n"),
+						"  IDTAG          Board Id                " + modelName + "\n"),
 					nil, nil
 			})
 
@@ -88,7 +90,7 @@ var _ = Describe("HostUtils", func() {
 
 			fakeCmd := &execTesting.FakeCmd{}
 			fakeCmd.CombinedOutputScript = append(fakeCmd.CombinedOutputScript, func() ([]byte, []byte, error) {
-				return []byte("  SN             Serial Number           MT2235J01129\n"), nil, nil
+				return []byte("  SN             Serial Number           " + serialNumber + "\n"), nil, nil
 			})
 
 			fakeExec.CommandScript = append(fakeExec.CommandScript, func(cmd string, args ...string) exec.Cmd {
@@ -109,7 +111,7 @@ var _ = Describe("HostUtils", func() {
 
 			fakeCmd = &execTesting.FakeCmd{}
 			fakeCmd.CombinedOutputScript = append(fakeCmd.CombinedOutputScript, func() ([]byte, []byte, error) {
-				return []byte("  PN             Part Number             MCX623106AE-CDAT\n"), nil, nil
+				return []byte("  PN             Part Number             " + partNumber + "\n"), nil, nil
 			})
 
 			fakeExec.CommandScript = append(fakeExec.CommandScript, func(cmd string, args ...string) exec.Cmd {
@@ -125,9 +127,6 @@ var _ = Describe("HostUtils", func() {
 			Expect(vpd).To(BeNil())
 		})
 		It("should set empty model name when IDTAG is absent", func() {
-			partNumber := "MCX623106AE-CDAT"
-			serialNumber := "MT2235J01129"
-
 			fakeExec := &execTesting.FakeExec{}
 
 			fakeCmd := &execTesting.FakeCmd{}
@@ -161,9 +160,6 @@ var _ = Describe("HostUtils", func() {
 			Expect(vpd.ModelName).To(Equal(""))
 		})
 		It("should retry and succeed on the 2nd attempt", func() {
-			partNumber := "MCX623106AE-CDAT"
-			serialNumber := "MT2235J01129"
-
 			fakeExec := &execTesting.FakeExec{}
 
 			failingCmd := &execTesting.FakeCmd{}

--- a/pkg/firmware/manager.go
+++ b/pkg/firmware/manager.go
@@ -391,6 +391,18 @@ func (f firmwareManager) installBlueFieldFirmware(ctx context.Context, device *v
 		return err
 	}
 
+	// Workaround for a DMS bug: `os install` / `os activate` unconditionally unbinds every
+	// PCI function of the device, which fails with ENODEV if a function is already unbound
+	// (e.g. manually unbound by an operator). Rebind any managed PF that is currently unbound
+	// so the DMS unbind step finds each function in the expected state.
+	for _, port := range device.Status.Ports {
+		if err := f.utils.EnsureDeviceBoundToMlx5Core(port.PCI); err != nil {
+			log.Log.Error(err, "failed to ensure PCI function is bound to mlx5_core before BFB install",
+				"device", device.Name, "pci", port.PCI)
+			return err
+		}
+	}
+
 	err = dmsClient.InstallBFB(ctx, version, fwFilePath)
 	if err != nil {
 		log.Log.Error(err, "failed to install BFB", "device", device.Name)

--- a/pkg/firmware/manager_test.go
+++ b/pkg/firmware/manager_test.go
@@ -489,6 +489,7 @@ var _ = Describe("FirmwareManager", func() {
 				fwUtilsMock.On("GetFirmwareVersionsFromDevice", pci).
 					Return("", "", errors.New("version check failed")).Once()
 				dmsManagerMock.On("GetDMSClientBySerialNumber", testSerial).Return(dmsClientMock, nil).Once()
+				fwUtilsMock.On("EnsureDeviceBoundToMlx5Core", pci).Return(nil).Once()
 				dmsClientMock.On("InstallBFB", mock.Anything, fwVersion, expectedBFBPath).Return(nil).Once()
 
 				_, err := manager.InstallFirmware(context.Background(), device, &types.FirmwareInstallOptions{Version: fwVersion, SkipReset: true})
@@ -502,10 +503,42 @@ var _ = Describe("FirmwareManager", func() {
 				fwUtilsMock.On("GetFirmwareVersionsFromDevice", pci).
 					Return("", "", errors.New("version check failed")).Once()
 				dmsManagerMock.On("GetDMSClientBySerialNumber", testSerial).Return(dmsClientMock, nil).Once()
+				fwUtilsMock.On("EnsureDeviceBoundToMlx5Core", pci).Return(nil).Once()
 				dmsClientMock.On("InstallBFB", mock.Anything, fwVersion, expectedBFBPath).Return(nil).Once()
 
 				_, err := manager.InstallFirmware(context.Background(), device, &types.FirmwareInstallOptions{Version: fwVersion, SkipReset: true})
 				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should ensure every managed PF is bound before InstallBFB", func() {
+				device := createBlueFieldDevice(consts.BlueField3DeviceID)
+				secondPCI := "0000:3b:00.1"
+				device.Status.Ports = append(device.Status.Ports, v1alpha1.NicDevicePortSpec{PCI: secondPCI})
+				expectedBFBPath := path.Join(bfbCacheDir, bfbFileName)
+
+				fwUtilsMock.On("GetFirmwareVersionsFromDevice", pci).
+					Return("", "", errors.New("version check failed")).Once()
+				dmsManagerMock.On("GetDMSClientBySerialNumber", testSerial).Return(dmsClientMock, nil).Once()
+				fwUtilsMock.On("EnsureDeviceBoundToMlx5Core", pci).Return(nil).Once()
+				fwUtilsMock.On("EnsureDeviceBoundToMlx5Core", secondPCI).Return(nil).Once()
+				dmsClientMock.On("InstallBFB", mock.Anything, fwVersion, expectedBFBPath).Return(nil).Once()
+
+				_, err := manager.InstallFirmware(context.Background(), device, &types.FirmwareInstallOptions{Version: fwVersion, SkipReset: true})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should abort BFB install when a PF fails to bind", func() {
+				device := createBlueFieldDevice(consts.BlueField3DeviceID)
+				bindErr := errors.New("bind write failed")
+
+				fwUtilsMock.On("GetFirmwareVersionsFromDevice", pci).
+					Return("", "", errors.New("version check failed")).Once()
+				dmsManagerMock.On("GetDMSClientBySerialNumber", testSerial).Return(dmsClientMock, nil).Once()
+				fwUtilsMock.On("EnsureDeviceBoundToMlx5Core", pci).Return(bindErr).Once()
+				// InstallBFB must not be called if binding fails — no mock expectation set.
+
+				_, err := manager.InstallFirmware(context.Background(), device, &types.FirmwareInstallOptions{Version: fwVersion, SkipReset: true})
+				Expect(err).To(MatchError(bindErr))
 			})
 
 			It("should return error when BFB file not found", func() {
@@ -543,6 +576,7 @@ var _ = Describe("FirmwareManager", func() {
 				fwUtilsMock.On("GetFirmwareVersionsFromDevice", pci).
 					Return("", "", errors.New("version check failed")).Once()
 				dmsManagerMock.On("GetDMSClientBySerialNumber", testSerial).Return(dmsClientMock, nil).Once()
+				fwUtilsMock.On("EnsureDeviceBoundToMlx5Core", pci).Return(nil).Once()
 				dmsClientMock.On("InstallBFB", mock.Anything, fwVersion, expectedBFBPath).Return(installError).Once()
 
 				_, err := manager.InstallFirmware(context.Background(), device, &types.FirmwareInstallOptions{Version: fwVersion, SkipReset: true})

--- a/pkg/firmware/mocks/FirmwareUtils.go
+++ b/pkg/firmware/mocks/FirmwareUtils.go
@@ -67,6 +67,24 @@ func (_m *FirmwareUtils) DownloadFile(url string, destPath string) error {
 	return r0
 }
 
+// EnsureDeviceBoundToMlx5Core provides a mock function with given fields: pciAddress
+func (_m *FirmwareUtils) EnsureDeviceBoundToMlx5Core(pciAddress string) error {
+	ret := _m.Called(pciAddress)
+
+	if len(ret) == 0 {
+		panic("no return value specified for EnsureDeviceBoundToMlx5Core")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(pciAddress)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // GetDocaSpcXCCVersion provides a mock function with given fields: docaSpcXCCPath
 func (_m *FirmwareUtils) GetDocaSpcXCCVersion(docaSpcXCCPath string) (string, error) {
 	ret := _m.Called(docaSpcXCCPath)

--- a/pkg/firmware/utils.go
+++ b/pkg/firmware/utils.go
@@ -20,6 +20,7 @@ import (
 	"archive/zip"
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -66,7 +67,18 @@ type FirmwareUtils interface {
 	// GetInstalledDebPackageVersion retrieves the version from the installed .deb package
 	// Return empty string if the package is not installed
 	GetInstalledDebPackageVersion(packageName string) string
+	// EnsureDeviceBoundToMlx5Core verifies that the given PCI device is bound to mlx5_core,
+	// and binds it if it is currently unbound. Returns an error if the device is bound to a
+	// different driver or if the bind write fails.
+	EnsureDeviceBoundToMlx5Core(pciAddress string) error
 }
+
+// pciDevicesSysfsPath and mlx5CoreBindPath are package-level vars so tests can point them
+// at a fake sysfs tree. In production they resolve to the real sysfs paths from consts.
+var (
+	pciDevicesSysfsPath = consts.PCIDevicesSysfsPath
+	mlx5CoreBindPath    = consts.Mlx5CoreDriverBindPath
+)
 
 type utils struct {
 	execInterface execUtils.Interface
@@ -481,6 +493,36 @@ func (u *utils) GetInstalledDebPackageVersion(packageName string) string {
 	installedVersion := strings.Trim(string(output), "'\"\n")
 	log.Log.V(2).Info("GetInstalledDebPackageVersion(): Installed version of package", "package", packageName, "version", installedVersion)
 	return installedVersion
+}
+
+// EnsureDeviceBoundToMlx5Core verifies that the given PCI device is bound to mlx5_core,
+// and binds it if it is currently unbound. Returns an error if the device is bound to a
+// different driver or if the bind write fails.
+//
+// Workaround for a DMS bug where "os install" / "os activate" unconditionally unbinds every
+// PCI function of the device, which fails with ENODEV if a function is already unbound.
+func (u *utils) EnsureDeviceBoundToMlx5Core(pciAddress string) error {
+	log.Log.V(2).Info("FirmwareUtils.EnsureDeviceBoundToMlx5Core()", "pciAddress", pciAddress)
+
+	driverLink := filepath.Join(pciDevicesSysfsPath, pciAddress, "driver")
+	target, err := os.Readlink(driverLink)
+	switch {
+	case err == nil:
+		currentDriver := filepath.Base(target)
+		if currentDriver == consts.Mlx5CoreDriverName {
+			return nil
+		}
+		return fmt.Errorf("PCI device %s is bound to driver %q, expected %q",
+			pciAddress, currentDriver, consts.Mlx5CoreDriverName)
+	case errors.Is(err, os.ErrNotExist):
+		log.Log.Info("PCI device is unbound, binding to mlx5_core before FW install", "pciAddress", pciAddress)
+		if err := os.WriteFile(mlx5CoreBindPath, []byte(pciAddress), 0200); err != nil {
+			return fmt.Errorf("failed to bind PCI device %s to mlx5_core: %w", pciAddress, err)
+		}
+		return nil
+	default:
+		return fmt.Errorf("failed to read driver link for PCI device %s: %w", pciAddress, err)
+	}
 }
 
 func newFirmwareUtils() FirmwareUtils {

--- a/pkg/firmware/utils_test.go
+++ b/pkg/firmware/utils_test.go
@@ -922,6 +922,89 @@ var _ = Describe("utils", func() {
 			})
 		})
 	})
+
+	Describe("EnsureDeviceBoundToMlx5Core", func() {
+		const pciAddr = "0000:75:00.0"
+
+		var (
+			devicesDir  string
+			driversDir  string
+			bindFile    string
+			origDevices string
+			origBind    string
+		)
+
+		BeforeEach(func() {
+			// Build a fake sysfs tree:
+			//   <tmpDir>/devices/<pci>/   (driver symlink added per-case)
+			//   <tmpDir>/drivers/mlx5_core/bind
+			devicesDir = filepath.Join(tmpDir, "devices")
+			driversDir = filepath.Join(tmpDir, "drivers")
+			Expect(os.MkdirAll(filepath.Join(devicesDir, pciAddr), 0755)).To(Succeed())
+			Expect(os.MkdirAll(filepath.Join(driversDir, consts.Mlx5CoreDriverName), 0755)).To(Succeed())
+			Expect(os.MkdirAll(filepath.Join(driversDir, "other_driver"), 0755)).To(Succeed())
+
+			// Real sysfs bind is write-only (0200). We use 0600 so the test can also
+			// read the file back to assert whether a rebind was attempted.
+			bindFile = filepath.Join(driversDir, consts.Mlx5CoreDriverName, "bind")
+			Expect(os.WriteFile(bindFile, nil, 0600)).To(Succeed())
+
+			origDevices = pciDevicesSysfsPath
+			origBind = mlx5CoreBindPath
+			pciDevicesSysfsPath = devicesDir
+			mlx5CoreBindPath = bindFile
+		})
+
+		AfterEach(func() {
+			pciDevicesSysfsPath = origDevices
+			mlx5CoreBindPath = origBind
+		})
+
+		It("should be a no-op when the device is already bound to mlx5_core", func() {
+			driverLink := filepath.Join(devicesDir, pciAddr, "driver")
+			Expect(os.Symlink(filepath.Join(driversDir, consts.Mlx5CoreDriverName), driverLink)).To(Succeed())
+
+			err := testedUtils.EnsureDeviceBoundToMlx5Core(pciAddr)
+			Expect(err).NotTo(HaveOccurred())
+
+			// bind file must remain empty — no rebind attempted
+			data, readErr := os.ReadFile(bindFile)
+			Expect(readErr).NotTo(HaveOccurred())
+			Expect(data).To(BeEmpty())
+		})
+
+		It("should bind the device when it is currently unbound", func() {
+			// No driver symlink under the device dir — simulates unbound state.
+			err := testedUtils.EnsureDeviceBoundToMlx5Core(pciAddr)
+			Expect(err).NotTo(HaveOccurred())
+
+			data, readErr := os.ReadFile(bindFile)
+			Expect(readErr).NotTo(HaveOccurred())
+			Expect(string(data)).To(Equal(pciAddr))
+		})
+
+		It("should return an error when the device is bound to a different driver", func() {
+			driverLink := filepath.Join(devicesDir, pciAddr, "driver")
+			Expect(os.Symlink(filepath.Join(driversDir, "other_driver"), driverLink)).To(Succeed())
+
+			err := testedUtils.EnsureDeviceBoundToMlx5Core(pciAddr)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("bound to driver \"other_driver\""))
+
+			data, readErr := os.ReadFile(bindFile)
+			Expect(readErr).NotTo(HaveOccurred())
+			Expect(data).To(BeEmpty())
+		})
+
+		It("should return an error when the bind sysfs write fails", func() {
+			// Point the bind path at a non-existent file so WriteFile fails.
+			mlx5CoreBindPath = filepath.Join(driversDir, "does-not-exist", "bind")
+
+			err := testedUtils.EnsureDeviceBoundToMlx5Core(pciAddr)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to bind PCI device"))
+		})
+	})
 })
 
 func newTestFirmwareUtils() FirmwareUtils {


### PR DESCRIPTION
DMS's os install/os activate unconditionally unbinds every PCI function of the device, which fails with ENODEV when a function is already unbound (e.g. an operator manually unbound a PF before triggering firmware update). The failure surfaces as "failed to install BFB" and aborts the upgrade.

Add FirmwareUtils.EnsureDeviceBoundToMlx5Core: reads the device's driver symlink under /sys/bus/pci/devices, no-ops when already bound to mlx5_core, writes the PCI address to .../drivers/mlx5_core/bind when unbound, and errors when bound to a different driver. installBlueFieldFirmware invokes it for each port in device.Status.Ports[] before dmsClient.InstallBFB.

This is a workaround for a DMS bug; remove once DMS tolerates already-unbound functions.

Also: promote duplicated part/serial-number string literals in devicediscovery/utils_test.go to file-level constants to satisfy goconst.