### PR TITLE
Support N-port NICs in nvconfig param generation

### DIFF
--- a/pkg/configuration/configvalidation.go
+++ b/pkg/configuration/configvalidation.go
@@ -21,7 +21,6 @@ import (
 	"reflect"
 	"slices"
 	"strconv"
-	"strings"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/record"
@@ -85,7 +84,7 @@ func (v *configValidationImpl) ConstructNvParamMapFromTemplate(
 	desiredParameters := map[string]string{}
 
 	template := device.Spec.Configuration.Template
-	secondPortPresent := len(device.Status.Ports) > 1
+	portCount := len(device.Status.Ports)
 
 	desiredParameters[consts.SriovEnabledParam] = consts.NvParamFalse
 	desiredParameters[consts.SriovNumOfVfsParam] = "0"
@@ -98,10 +97,14 @@ func (v *configValidationImpl) ConstructNvParamMapFromTemplate(
 	_, canChangeLinkType := query.DefaultConfig[consts.LinkTypeP1Param]
 	if canChangeLinkType {
 		linkType := nvParamLinkTypeFromName(string(template.LinkType))
-		desiredParameters[consts.LinkTypeP1Param] = linkType
-		_, hasLinkTypeP2Param := query.DefaultConfig[consts.LinkTypeP2Param]
-		if secondPortPresent && hasLinkTypeP2Param {
-			desiredParameters[consts.LinkTypeP2Param] = linkType
+		// Emit LINK_TYPE_P<n> for every discovered port. Firmware may expose
+		// fewer slots than the device has ports (e.g. BF3 DPU mode), so gate
+		// each entry on a presence check in the query output.
+		for portIdx := 1; portIdx <= portCount; portIdx++ {
+			name := consts.PortParam(consts.LinkTypeParamBase, portIdx)
+			if _, ok := query.DefaultConfig[name]; ok {
+				desiredParameters[name] = linkType
+			}
 		}
 	} else {
 		desiredLinkType := string(device.Spec.Configuration.Template.LinkType)
@@ -161,25 +164,20 @@ func (v *configValidationImpl) ConstructNvParamMapFromTemplate(
 			return desiredParameters, err
 		}
 
-		desiredParameters[consts.RoceCcPrioMaskP1Param] = "255"
-		desiredParameters[consts.CnpDscpP1Param] = "4"
-		desiredParameters[consts.Cnp802pPrioP1Param] = "6"
-
-		if secondPortPresent {
-			desiredParameters[consts.RoceCcPrioMaskP2Param] = "255"
-			desiredParameters[consts.CnpDscpP2Param] = "4"
-			desiredParameters[consts.Cnp802pPrioP2Param] = "6"
+		// Apply RoCE optimization to every discovered port. Matches the
+		// historical P1/P2 behavior, which emits these params unconditionally.
+		for portIdx := 1; portIdx <= portCount; portIdx++ {
+			desiredParameters[consts.PortParam(consts.RoceCcPrioMaskParamBase, portIdx)] = "255"
+			desiredParameters[consts.PortParam(consts.CnpDscpParamBase, portIdx)] = "4"
+			desiredParameters[consts.PortParam(consts.Cnp802pPrioParamBase, portIdx)] = "6"
 		}
 
 		// qos settings are applied as runtime configuration
 	} else {
-		applyDefaultNvConfigValueIfExists(consts.RoceCcPrioMaskP1Param, desiredParameters, query)
-		applyDefaultNvConfigValueIfExists(consts.CnpDscpP1Param, desiredParameters, query)
-		applyDefaultNvConfigValueIfExists(consts.Cnp802pPrioP1Param, desiredParameters, query)
-		if secondPortPresent {
-			applyDefaultNvConfigValueIfExists(consts.RoceCcPrioMaskP2Param, desiredParameters, query)
-			applyDefaultNvConfigValueIfExists(consts.CnpDscpP2Param, desiredParameters, query)
-			applyDefaultNvConfigValueIfExists(consts.Cnp802pPrioP2Param, desiredParameters, query)
+		for portIdx := 1; portIdx <= portCount; portIdx++ {
+			applyDefaultNvConfigValueIfExists(consts.PortParam(consts.RoceCcPrioMaskParamBase, portIdx), desiredParameters, query)
+			applyDefaultNvConfigValueIfExists(consts.PortParam(consts.CnpDscpParamBase, portIdx), desiredParameters, query)
+			applyDefaultNvConfigValueIfExists(consts.PortParam(consts.Cnp802pPrioParamBase, portIdx), desiredParameters, query)
 		}
 	}
 
@@ -201,8 +199,8 @@ func (v *configValidationImpl) ConstructNvParamMapFromTemplate(
 		applyDefaultNvConfigValueIfExists(consts.AtsEnabledParam, desiredParameters, query)
 	}
 	for _, rawParam := range template.RawNvConfig {
-		// Ignore second port params if device has a single port
-		if strings.HasSuffix(rawParam.Name, consts.SecondPortPrefix) && !secondPortPresent {
+		// Drop _Pn params whose port is beyond the device's port count.
+		if n, ok := consts.PortSuffixNum(rawParam.Name); ok && n > portCount {
 			continue
 		}
 

--- a/pkg/configuration/configvalidation_test.go
+++ b/pkg/configuration/configvalidation_test.go
@@ -406,6 +406,107 @@ var _ = Describe("ConfigValidationImpl", func() {
 			Expect(nvParams).To(HaveKeyWithValue("TEST_P1", "test"))
 			Expect(nvParams).To(HaveKeyWithValue("TEST_P2", "test"))
 		})
+		It("should emit link type and RoCE params for every port on a quad-port device", func() {
+			mockConfigurationUtils.On("GetPCILinkSpeed", mock.Anything).Return(16, nil)
+
+			device := &v1alpha1.NicDevice{
+				Spec: v1alpha1.NicDeviceSpec{
+					Configuration: &v1alpha1.NicDeviceConfigurationSpec{
+						Template: &v1alpha1.ConfigurationTemplateSpec{
+							NumVfs:   0,
+							LinkType: consts.Ethernet,
+							RoceOptimized: &v1alpha1.RoceOptimizedSpec{
+								Enabled: true,
+							},
+							RawNvConfig: []v1alpha1.NvConfigParam{
+								{Name: "CUSTOM_PARAM_P1", Value: "raw1"},
+								{Name: "CUSTOM_PARAM_P4", Value: "raw4"},
+								{Name: "CUSTOM_PARAM_P5", Value: "raw5"},
+								{Name: "CUSTOM_PARAM_NO_SUFFIX", Value: "rawN"},
+							},
+						},
+					},
+				},
+				Status: v1alpha1.NicDeviceStatus{
+					Ports: []v1alpha1.NicDevicePortSpec{
+						{PCI: "0000:03:00.0"},
+						{PCI: "0000:03:00.1"},
+						{PCI: "0000:03:00.2"},
+						{PCI: "0000:03:00.3"},
+					},
+				},
+			}
+
+			query := types.NewNvConfigQuery()
+			// Firmware exposes LINK_TYPE for all four ports.
+			query.DefaultConfig = map[string][]string{
+				"LINK_TYPE_P1": {"2"},
+				"LINK_TYPE_P2": {"2"},
+				"LINK_TYPE_P3": {"2"},
+				"LINK_TYPE_P4": {"2"},
+			}
+
+			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, query)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Link type emitted for every port with a firmware-declared slot.
+			for _, name := range []string{"LINK_TYPE_P1", "LINK_TYPE_P2", "LINK_TYPE_P3", "LINK_TYPE_P4"} {
+				Expect(nvParams).To(HaveKeyWithValue(name, consts.NvParamLinkTypeEthernet))
+			}
+
+			// RoCE optimization emitted for all four ports.
+			for _, name := range []string{"ROCE_CC_PRIO_MASK_P1", "ROCE_CC_PRIO_MASK_P2", "ROCE_CC_PRIO_MASK_P3", "ROCE_CC_PRIO_MASK_P4"} {
+				Expect(nvParams).To(HaveKeyWithValue(name, "255"))
+			}
+			for _, name := range []string{"CNP_DSCP_P1", "CNP_DSCP_P2", "CNP_DSCP_P3", "CNP_DSCP_P4"} {
+				Expect(nvParams).To(HaveKeyWithValue(name, "4"))
+			}
+			for _, name := range []string{"CNP_802P_PRIO_P1", "CNP_802P_PRIO_P2", "CNP_802P_PRIO_P3", "CNP_802P_PRIO_P4"} {
+				Expect(nvParams).To(HaveKeyWithValue(name, "6"))
+			}
+
+			// rawNvConfig: _P1..P4 and non-suffixed entries kept; _P5 dropped.
+			Expect(nvParams).To(HaveKeyWithValue("CUSTOM_PARAM_P1", "raw1"))
+			Expect(nvParams).To(HaveKeyWithValue("CUSTOM_PARAM_P4", "raw4"))
+			Expect(nvParams).To(HaveKeyWithValue("CUSTOM_PARAM_NO_SUFFIX", "rawN"))
+			Expect(nvParams).NotTo(HaveKey("CUSTOM_PARAM_P5"))
+		})
+		It("should skip LINK_TYPE_Pn for ports firmware does not declare a slot for", func() {
+			mockConfigurationUtils.On("GetPCILinkSpeed", mock.Anything).Return(16, nil)
+
+			device := &v1alpha1.NicDevice{
+				Spec: v1alpha1.NicDeviceSpec{
+					Configuration: &v1alpha1.NicDeviceConfigurationSpec{
+						Template: &v1alpha1.ConfigurationTemplateSpec{
+							NumVfs:   0,
+							LinkType: consts.Ethernet,
+						},
+					},
+				},
+				Status: v1alpha1.NicDeviceStatus{
+					Ports: []v1alpha1.NicDevicePortSpec{
+						{PCI: "0000:03:00.0"},
+						{PCI: "0000:03:00.1"},
+						{PCI: "0000:03:00.2"},
+						{PCI: "0000:03:00.3"},
+					},
+				},
+			}
+
+			query := types.NewNvConfigQuery()
+			// Firmware exposes only P1 and P3, not P2 or P4.
+			query.DefaultConfig = map[string][]string{
+				"LINK_TYPE_P1": {"2"},
+				"LINK_TYPE_P3": {"2"},
+			}
+
+			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, query)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nvParams).To(HaveKeyWithValue("LINK_TYPE_P1", consts.NvParamLinkTypeEthernet))
+			Expect(nvParams).To(HaveKeyWithValue("LINK_TYPE_P3", consts.NvParamLinkTypeEthernet))
+			Expect(nvParams).NotTo(HaveKey("LINK_TYPE_P2"))
+			Expect(nvParams).NotTo(HaveKey("LINK_TYPE_P4"))
+		})
 		It("should report an error when LinkType cannot be changed and template differs from the actual status", func() {
 			mockConfigurationUtils.On("GetLinkType", mock.Anything).Return(consts.Ethernet)
 			mockConfigurationUtils.On("GetPCILinkSpeed", mock.Anything).Return(16, nil)

--- a/pkg/configuration/manager.go
+++ b/pkg/configuration/manager.go
@@ -507,16 +507,16 @@ func (h configurationManager) queryNvConfigs(ctx context.Context, device *v1alph
 }
 
 // getRawNvConfigParams extracts rawNvConfig params from the device template,
-// filtering out _P2 suffixed params for single-port devices.
+// dropping _Pn params whose port index is beyond the device's port count.
 func getRawNvConfigParams(device *v1alpha1.NicDevice) map[string]string {
 	template := device.Spec.Configuration.Template
 	if template == nil || len(template.RawNvConfig) == 0 {
 		return nil
 	}
-	secondPortPresent := len(device.Status.Ports) > 1
+	portCount := len(device.Status.Ports)
 	params := make(map[string]string, len(template.RawNvConfig))
 	for _, rawParam := range template.RawNvConfig {
-		if strings.HasSuffix(rawParam.Name, consts.SecondPortPrefix) && !secondPortPresent {
+		if n, ok := consts.PortSuffixNum(rawParam.Name); ok && n > portCount {
 			continue
 		}
 		params[rawParam.Name] = rawParam.Value

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -15,6 +15,11 @@ limitations under the License.
 
 package consts
 
+import (
+	"strconv"
+	"strings"
+)
+
 const (
 	MellanoxVendor       = "15b3"
 	BlueField3DeviceID   = "a2dc"
@@ -95,6 +100,14 @@ const (
 	AdvancedPCISettingsParam = "ADVANCED_PCI_SETTINGS"
 	BF3OperationModeParam    = "INTERNAL_CPU_OFFLOAD_ENGINE"
 
+	// Base names for port-indexed nvconfig parameters. The firmware exposes
+	// one parameter per port as "<base>_P<n>" (n is 1-indexed). Use PortParam
+	// to construct the concrete name for a given port.
+	LinkTypeParamBase       = "LINK_TYPE"
+	RoceCcPrioMaskParamBase = "ROCE_CC_PRIO_MASK"
+	CnpDscpParamBase        = "CNP_DSCP"
+	Cnp802pPrioParamBase    = "CNP_802P_PRIO"
+
 	SecondPortPrefix = "P2"
 
 	EnvBaremetal = "Baremetal"
@@ -169,3 +182,30 @@ const (
 	// InterfaceNameSpecEmptyReason indicates the interface name template spec was removed
 	InterfaceNameSpecEmptyReason = "InterfaceNameSpecEmpty"
 )
+
+// PortParam returns the nvconfig parameter name for the given port-indexed
+// base, e.g. PortParam("LINK_TYPE", 3) -> "LINK_TYPE_P3". portNum is 1-indexed.
+func PortParam(base string, portNum int) string {
+	return base + "_P" + strconv.Itoa(portNum)
+}
+
+// PortSuffixNum parses a trailing "_P<n>" suffix (n >= 1, digits only) and
+// returns the port number. Returns (0, false) when the name does not carry
+// a port suffix (e.g. "SRIOV_EN", "MAX_ACC_OUT_READ").
+func PortSuffixNum(paramName string) (int, bool) {
+	idx := strings.LastIndex(paramName, "_P")
+	if idx < 0 || idx+2 >= len(paramName) {
+		return 0, false
+	}
+	digits := paramName[idx+2:]
+	for _, r := range digits {
+		if r < '0' || r > '9' {
+			return 0, false
+		}
+	}
+	n, err := strconv.Atoi(digits)
+	if err != nil || n < 1 {
+		return 0, false
+	}
+	return n, true
+}

--- a/pkg/consts/consts_test.go
+++ b/pkg/consts/consts_test.go
@@ -1,0 +1,72 @@
+/*
+2026 NVIDIA CORPORATION & AFFILIATES
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package consts
+
+import "testing"
+
+func TestPortParam(t *testing.T) {
+	cases := []struct {
+		base string
+		n    int
+		want string
+	}{
+		{"LINK_TYPE", 1, "LINK_TYPE_P1"},
+		{"LINK_TYPE", 4, "LINK_TYPE_P4"},
+		{"LINK_TYPE", 8, "LINK_TYPE_P8"},
+		{"ROCE_CC_PRIO_MASK", 3, "ROCE_CC_PRIO_MASK_P3"},
+		{"CNP_DSCP", 10, "CNP_DSCP_P10"},
+	}
+	for _, c := range cases {
+		got := PortParam(c.base, c.n)
+		if got != c.want {
+			t.Errorf("PortParam(%q, %d) = %q, want %q", c.base, c.n, got, c.want)
+		}
+	}
+}
+
+func TestPortSuffixNum(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+		ok   bool
+	}{
+		{"LINK_TYPE_P1", 1, true},
+		{"LINK_TYPE_P2", 2, true},
+		{"LINK_TYPE_P4", 4, true},
+		{"LINK_TYPE_P10", 10, true},
+		{"ROCE_CC_PRIO_MASK_P8", 8, true},
+		// A leading _Px should match the last occurrence.
+		{"FOO_P1_P3", 3, true},
+
+		// Not port-suffixed.
+		{"SRIOV_EN", 0, false},
+		{"MAX_ACC_OUT_READ", 0, false},
+		{"INTERNAL_CPU_MODEL", 0, false},
+		{"", 0, false},
+		{"_P", 0, false},
+		{"_P0", 0, false},
+		{"LINK_TYPE_P", 0, false},
+		{"LINK_TYPE_PA", 0, false},
+		{"LINK_TYPE_P1A", 0, false},
+		{"SOMETHING_P2_EXTRA", 0, false},
+	}
+	for _, c := range cases {
+		got, ok := PortSuffixNum(c.in)
+		if ok != c.ok || got != c.want {
+			t.Errorf("PortSuffixNum(%q) = (%d, %v), want (%d, %v)", c.in, got, ok, c.want, c.ok)
+		}
+	}
+}


### PR DESCRIPTION
Generalize ConstructNvParamMapFromTemplate and getRawNvConfigParams to iterate over len(device.Status.Ports) instead of hardcoding P1/P2, so quad- and octo-port ConnectX-9 / BlueField NICs get LINK_TYPE_Pn, ROCE_CC_PRIO_MASK_Pn, CNP_DSCP_Pn, CNP_802P_PRIO_Pn emitted for every port, and rawNvConfig _Pn entries are dropped only when n exceeds the discovered port count. Add PortParam / PortSuffixNum helpers in pkg/consts; keep existing P1/P2 constants for library API compatibility. Dual- and single-port behavior is unchanged.