### PR TITLE
Identify NICs by PCI device address instead of serial number

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ spec:
 ### NICDevice
 
 The NICDevice CRD is created automatically by the configuration daemon and represents a specific NVIDIA NIC on a specific K8s node.
-The name of the device combines the node name, device type and its serial number for easier tracking.
+The name of the device combines the node name, device type and its PCI device address (`Domain:Bus:Device`, with `:` and `.` replaced by `-`). PCI device address is used for uniqueness because serial numbers are not guaranteed unique on systems with embedded NICs that share a flashed VPD image (e.g. HGX B300).
 
 `FirmwareUpdateInProgress` status condition can be used for tracking the state of the FW validation/update on a specific device. If an error occurs during FW update, it will be reflected in this field.
 `ConfigUpdateInProgress` status condition can be used for tracking the state of the FW configuration update on a specific device. If an error occurs during FW configuration update, it will be reflected in this field.
@@ -248,7 +248,7 @@ for more information refer to [api-reference](docs/api-reference.md).
 apiVersion: configuration.net.nvidia.com/v1alpha1
 kind: NicDevice
 metadata:
-   name: co-node-25-101b-mt2232t13210
+   name: co-node-25-101b-0000-04-00
    namespace: nic-configuration-operator
 spec:
    firmware:

--- a/api/v1alpha1/nicconfigurationtemplate_types.go
+++ b/api/v1alpha1/nicconfigurationtemplate_types.go
@@ -26,7 +26,11 @@ type NicSelectorSpec struct {
 	// Array of PCI addresses to be selected, e.g. "0000:03:00.0"
 	// +kubebuilder:validation:items:Pattern=`^[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-7]$`
 	PciAddresses []string `json:"pciAddresses,omitempty"`
-	// Serial numbers of the NICs to be selected, e.g. MT2116X09299
+	// Serial numbers of the NICs to be selected, e.g. MT2116X09299. Note: serial numbers
+	// are not guaranteed unique — on systems with embedded NICs that share a flashed VPD
+	// image (e.g. HGX B300), multiple physical cards report the same serial, and this
+	// selector will match all of them. Use `pciAddresses` for precise per-card selection
+	// on such systems.
 	SerialNumbers []string `json:"serialNumbers,omitempty"`
 	// Part numbers of the NICs to be selected, e.g. MCX713106AEHEA_QP1
 	PartNumbers []string `json:"partNumbers,omitempty"`

--- a/api/v1alpha1/nicdevice_types.go
+++ b/api/v1alpha1/nicdevice_types.go
@@ -74,7 +74,11 @@ type NicDeviceStatus struct {
 	Node string `json:"node"`
 	// Type of device, e.g. ConnectX7
 	Type string `json:"type"`
-	// Serial number of the device, e.g. MT2116X09299
+	// SerialNumber of the device, e.g. MT2116X09299. Informational only — not guaranteed
+	// unique across all cards on a host: on systems with embedded NICs sharing a flashed
+	// VPD image (e.g. HGX B300) multiple cards will report the same serial number. The
+	// operator identifies NICs uniquely by their PCI device address (the `pci` field on
+	// the first entry in `ports`, with the function digit stripped).
 	SerialNumber string `json:"serialNumber"`
 	// Part number of the device, e.g. MCX713106AEHEA_QP1
 	PartNumber string `json:"partNumber"`

--- a/config/crd/bases/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
+++ b/config/crd/bases/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
@@ -59,7 +59,12 @@ spec:
                       type: string
                     type: array
                   serialNumbers:
-                    description: Serial numbers of the NICs to be selected, e.g. MT2116X09299
+                    description: |-
+                      Serial numbers of the NICs to be selected, e.g. MT2116X09299. Note: serial numbers
+                      are not guaranteed unique — on systems with embedded NICs that share a flashed VPD
+                      image (e.g. HGX B300), multiple physical cards report the same serial, and this
+                      selector will match all of them. Use `pciAddresses` for precise per-card selection
+                      on such systems.
                     items:
                       type: string
                     type: array

--- a/config/crd/bases/configuration.net.nvidia.com_nicdevices.yaml
+++ b/config/crd/bases/configuration.net.nvidia.com_nicdevices.yaml
@@ -379,7 +379,12 @@ spec:
                 description: Product Serial ID of the device, e.g. MT_0000000221
                 type: string
               serialNumber:
-                description: Serial number of the device, e.g. MT2116X09299
+                description: |-
+                  SerialNumber of the device, e.g. MT2116X09299. Informational only — not guaranteed
+                  unique across all cards on a host: on systems with embedded NICs sharing a flashed
+                  VPD image (e.g. HGX B300) multiple cards will report the same serial number. The
+                  operator identifies NICs uniquely by their PCI device address (the `pci` field on
+                  the first entry in `ports`, with the function digit stripped).
                 type: string
               superNIC:
                 description: SuperNIC indicates if the device is a SuperNIC

--- a/config/crd/bases/configuration.net.nvidia.com_nicfirmwaretemplates.yaml
+++ b/config/crd/bases/configuration.net.nvidia.com_nicfirmwaretemplates.yaml
@@ -60,7 +60,12 @@ spec:
                       type: string
                     type: array
                   serialNumbers:
-                    description: Serial numbers of the NICs to be selected, e.g. MT2116X09299
+                    description: |-
+                      Serial numbers of the NICs to be selected, e.g. MT2116X09299. Note: serial numbers
+                      are not guaranteed unique — on systems with embedded NICs that share a flashed VPD
+                      image (e.g. HGX B300), multiple physical cards report the same serial, and this
+                      selector will match all of them. Use `pciAddresses` for precise per-card selection
+                      on such systems.
                     items:
                       type: string
                     type: array

--- a/config/samples/configuration.net_v1alpha1_nicconfigurationtemplate.yaml
+++ b/config/samples/configuration.net_v1alpha1_nicconfigurationtemplate.yaml
@@ -28,6 +28,8 @@ spec:
     pciAddresses:
       - "0000:03:00.0"
       - “0000:04:00.0”
+    # Note: serial numbers are not guaranteed unique on systems with embedded NICs
+    # that share a flashed VPD image (e.g. HGX B300). Prefer pciAddresses there.
     serialNumbers:
       - "MT2116X09299"
   resetToDefault: false # if set, template is ignored, device configuration should reset

--- a/config/samples/configuration.net_v1alpha1_nicdevice.yaml
+++ b/config/samples/configuration.net_v1alpha1_nicdevice.yaml
@@ -17,7 +17,7 @@
 apiVersion: configuration.net.nvidia.com/v1alpha1
 kind: NicDevice
 metadata:
-  name: co-node-25-101b-mt2232t13210
+  name: co-node-25-101b-0000-04-00
   namespace: nic-configuration-operator
 spec:
   configuration:

--- a/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
+++ b/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
@@ -59,7 +59,12 @@ spec:
                       type: string
                     type: array
                   serialNumbers:
-                    description: Serial numbers of the NICs to be selected, e.g. MT2116X09299
+                    description: |-
+                      Serial numbers of the NICs to be selected, e.g. MT2116X09299. Note: serial numbers
+                      are not guaranteed unique — on systems with embedded NICs that share a flashed VPD
+                      image (e.g. HGX B300), multiple physical cards report the same serial, and this
+                      selector will match all of them. Use `pciAddresses` for precise per-card selection
+                      on such systems.
                     items:
                       type: string
                     type: array

--- a/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicdevices.yaml
+++ b/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicdevices.yaml
@@ -379,7 +379,12 @@ spec:
                 description: Product Serial ID of the device, e.g. MT_0000000221
                 type: string
               serialNumber:
-                description: Serial number of the device, e.g. MT2116X09299
+                description: |-
+                  SerialNumber of the device, e.g. MT2116X09299. Informational only — not guaranteed
+                  unique across all cards on a host: on systems with embedded NICs sharing a flashed
+                  VPD image (e.g. HGX B300) multiple cards will report the same serial number. The
+                  operator identifies NICs uniquely by their PCI device address (the `pci` field on
+                  the first entry in `ports`, with the function digit stripped).
                 type: string
               superNIC:
                 description: SuperNIC indicates if the device is a SuperNIC

--- a/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicfirmwaretemplates.yaml
+++ b/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicfirmwaretemplates.yaml
@@ -60,7 +60,12 @@ spec:
                       type: string
                     type: array
                   serialNumbers:
-                    description: Serial numbers of the NICs to be selected, e.g. MT2116X09299
+                    description: |-
+                      Serial numbers of the NICs to be selected, e.g. MT2116X09299. Note: serial numbers
+                      are not guaranteed unique — on systems with embedded NICs that share a flashed VPD
+                      image (e.g. HGX B300), multiple physical cards report the same serial, and this
+                      selector will match all of them. Use `pciAddresses` for precise per-card selection
+                      on such systems.
                     items:
                       type: string
                     type: array

--- a/docs/examples/example-nicconfigurationtemplate-connectx6dx.yaml
+++ b/docs/examples/example-nicconfigurationtemplate-connectx6dx.yaml
@@ -29,6 +29,8 @@ spec:
     pciAddresses:
       - "0000:03:00.0"
       - “0000:04:00.0”
+    # Note: serial numbers are not guaranteed unique on systems with embedded NICs
+    # that share a flashed VPD image (e.g. HGX B300). Prefer pciAddresses there.
     serialNumbers:
       - "MT2116X09299"
     # partNumbers:

--- a/docs/nic-configuration-library.md
+++ b/docs/nic-configuration-library.md
@@ -193,8 +193,12 @@ Provides per-device DMS client lookup. This is the interface used by all consumi
 
 ```go
 type DMSManager interface {
-    // GetDMSClientBySerialNumber returns DMS client for a device
-    GetDMSClientBySerialNumber(serialNumber string) (DMSClient, error)
+    // GetDMSClientByPCIAddress returns the DMS client for a device identified by its
+    // PCI device address (Domain:Bus:Device, function stripped). This is unique
+    // per physical NIC even on systems where cards share a flashed serial number
+    // (e.g. HGX B300). Derive the key from device.Status.Ports[0].PCI via
+    // pkg/utils.PCIDeviceAddress.
+    GetDMSClientByPCIAddress(pciDeviceAddr string) (DMSClient, error)
 }
 ```
 
@@ -582,7 +586,7 @@ type NicDevice struct {
 type NicDeviceStatus struct {
     Node            string              // Node where device is located
     Type            string              // Device type (e.g., "ConnectX7")
-    SerialNumber    string              // Serial number (e.g., "MT2116X09299")
+    SerialNumber    string              // Serial number (e.g., "MT2116X09299"). Not guaranteed unique — embedded NICs on HGX B300 share a flashed SN; identify NICs by the PCI device address of Ports[0] instead.
     PartNumber      string              // Part number (e.g., "MCX713106AEHEA_QP1")
     PSID            string              // Product Serial ID (e.g., "MT_0000000221")
     FirmwareVersion string              // Installed firmware version (e.g., "22.31.1014")

--- a/internal/controller/devicediscovery_controller.go
+++ b/internal/controller/devicediscovery_controller.go
@@ -37,6 +37,7 @@ import (
 	"github.com/Mellanox/nic-configuration-operator/pkg/devicediscovery"
 	"github.com/Mellanox/nic-configuration-operator/pkg/helper"
 	"github.com/Mellanox/nic-configuration-operator/pkg/host"
+	"github.com/Mellanox/nic-configuration-operator/pkg/utils"
 )
 
 var deviceDiscoveryReconcileTime = time.Minute * 5
@@ -52,9 +53,15 @@ type DeviceDiscoveryController struct {
 	namespace       string
 }
 
-// Constructs a unique CR name based on the device's type and serial number
-func (d *DeviceDiscoveryController) getCRName(deviceType string, serialNumber string) string {
-	return strings.ToLower(d.nodeName + "-" + deviceType + "-" + serialNumber)
+// crNameSanitizer replaces PCI-address punctuation (:, .) with DNS-1123-safe dashes.
+var crNameSanitizer = strings.NewReplacer(":", "-", ".", "-")
+
+// getCRName constructs a unique CR name based on the node name, device's type, and PCI
+// device address (Domain:Bus:Device). The `:` and `.` characters in the PCI address are
+// replaced with `-` so the resulting name is DNS-1123-compliant.
+// Example: node=co-node-25, deviceType=101b, pciDeviceAddr=0000:04:00 → co-node-25-101b-0000-04-00.
+func (d *DeviceDiscoveryController) getCRName(deviceType string, pciDeviceAddr string) string {
+	return strings.ToLower(d.nodeName + "-" + deviceType + "-" + crNameSanitizer.Replace(pciDeviceAddr))
 }
 
 func setInitialsConditionsForDevice(device *v1alpha1.NicDevice) {
@@ -134,7 +141,12 @@ func (d *DeviceDiscoveryController) reconcile(ctx context.Context) error {
 	}
 
 	for _, nicDeviceCR := range list.Items {
-		observedDevice, exists := observedDevices[nicDeviceCR.Status.SerialNumber]
+		if len(nicDeviceCR.Status.Ports) == 0 {
+			log.Log.V(2).Info("NicDevice CR has no ports, skipping reconciliation", "device", nicDeviceCR.Name)
+			continue
+		}
+		pciKey := utils.PCIDeviceAddress(nicDeviceCR.Status.Ports[0].PCI)
+		observedDevice, exists := observedDevices[pciKey]
 
 		if !exists {
 			log.Log.V(2).Info("device doesn't exist on the node anymore, deleting", "device", nicDeviceCR.Name)
@@ -173,13 +185,13 @@ func (d *DeviceDiscoveryController) reconcile(ctx context.Context) error {
 		}
 
 		// Device was processed, cleaning it from the map
-		delete(observedDevices, nicDeviceCR.Status.SerialNumber)
+		delete(observedDevices, pciKey)
 	}
 
 	// Remaining devices don't have CR representation, need to create a CR
-	for _, observedDevice := range observedDevices {
+	for pciKey, observedDevice := range observedDevices {
 		deviceStatus := observedDevice.Status
-		deviceName := d.getCRName(deviceStatus.Type, deviceStatus.SerialNumber)
+		deviceName := d.getCRName(deviceStatus.Type, pciKey)
 		device := &v1alpha1.NicDevice{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      deviceName,
@@ -193,16 +205,12 @@ func (d *DeviceDiscoveryController) reconcile(ctx context.Context) error {
 			continue
 		}
 		err = d.Create(ctx, device)
-		if err != nil {
-			log.Log.Error(err, "failed to create device", "device", device)
-			continue
-		}
-
 		if apierrors.IsAlreadyExists(err) {
-			// Device already exists but was not matched by SerialNumber, which means the status was not applied properly
+			// Device already exists but was not matched by PCI address, which means the status was not applied properly
+			// on a previous reconcile. Re-fetch so the status update below runs against the live object.
 			err = d.Get(ctx, types.NamespacedName{Name: device.Name, Namespace: device.Namespace}, device)
 			if err != nil {
-				log.Log.Error(err, "failed to get NicDevice obj", "device", device)
+				log.Log.Error(err, "failed to get existing NicDevice obj", "device", device)
 				continue
 			}
 		} else if err != nil {

--- a/internal/controller/devicediscovery_controller_test.go
+++ b/internal/controller/devicediscovery_controller_test.go
@@ -75,17 +75,21 @@ var _ = Describe("DeviceDiscoveryController", func() {
 	})
 
 	Describe("getCRName", func() {
-		It("should return the correct CR name", func() {
-			name := deviceRegistry.getCRName("nic", "123456")
-			Expect(name).To(Equal("test-node-nic-123456"))
+		It("should sanitize colons and dots in the PCI device address", func() {
+			name := deviceRegistry.getCRName("nic", "0000:3b:00")
+			Expect(name).To(Equal("test-node-nic-0000-3b-00"))
 		})
 
-		It("should return the correct CR name for capitalized strings", func() {
-			name := deviceRegistry.getCRName("NIC", "123456")
-			Expect(name).To(Equal("test-node-nic-123456"))
+		It("should lowercase the device type and the PCI address", func() {
+			name := deviceRegistry.getCRName("NIC", "0000:3B:00")
+			Expect(name).To(Equal("test-node-nic-0000-3b-00"))
+		})
 
-			name = deviceRegistry.getCRName("nic", "SERIALNUMBER")
-			Expect(name).To(Equal("test-node-nic-serialnumber"))
+		It("should also sanitize a full BDF if one is passed", func() {
+			// The function arg is documented as the trimmed PCI device, but a caller
+			// could pass a full BDF — make sure both colons and dots are sanitized.
+			name := deviceRegistry.getCRName("nic", "0000:3b:00.0")
+			Expect(name).To(Equal("test-node-nic-0000-3b-00-0"))
 		})
 	})
 
@@ -106,7 +110,8 @@ var _ = Describe("DeviceDiscoveryController", func() {
 		Context("when there are existing NicDevice CRs", func() {
 			deviceType := "connectx6"
 			serialNumber := "123456"
-			deviceName := "test-node-connectx6-123456"
+			pciDevKey := "0000:3b:00"
+			deviceName := "test-node-connectx6-0000-3b-00"
 			BeforeEach(func() {
 				existingDevice := &v1alpha1.NicDevice{
 					ObjectMeta: metav1.ObjectMeta{
@@ -131,10 +136,10 @@ var _ = Describe("DeviceDiscoveryController", func() {
 				fwVersion := "test-fw-version"
 
 				deviceDiscovery.On("DiscoverNicDevices").Return(map[string]v1alpha1.NicDevice{
-					"123456": {
+					pciDevKey: {
 						Status: v1alpha1.NicDeviceStatus{
 							Node:            nodeName,
-							SerialNumber:    "123456",
+							SerialNumber:    serialNumber,
 							Type:            "connectx6",
 							Ports:           []v1alpha1.NicDevicePortSpec{{PCI: "0000:3b:00.0"}},
 							PartNumber:      partNumber,
@@ -188,13 +193,14 @@ var _ = Describe("DeviceDiscoveryController", func() {
 			})
 
 			It("should create new CRs for new devices", func() {
-				serialNumber := "new-serial-num"
+				newPciDevKey := "0000:81:00"
+				newSerial := "new-serial-num"
 
 				// Add a new device that does not have a CR representation
 				deviceDiscovery.On("DiscoverNicDevices").Return(map[string]v1alpha1.NicDevice{
-					serialNumber: {
+					newPciDevKey: {
 						Status: v1alpha1.NicDeviceStatus{
-							SerialNumber: serialNumber,
+							SerialNumber: newSerial,
 							Type:         deviceType,
 							Ports:        []v1alpha1.NicDevicePortSpec{{PCI: "0000:81:00.0"}},
 						},
@@ -207,18 +213,18 @@ var _ = Describe("DeviceDiscoveryController", func() {
 				Eventually(func() (string, error) {
 					device := &v1alpha1.NicDevice{}
 					err := k8sClient.Get(ctx, client.ObjectKey{
-						Name:      deviceRegistry.getCRName(deviceType, serialNumber),
+						Name:      deviceRegistry.getCRName(deviceType, newPciDevKey),
 						Namespace: namespaceName,
 					}, device)
 					if err != nil {
 						return "", nil
 					}
 					return device.Status.SerialNumber, err
-				}, timeout).Should(Equal(serialNumber))
+				}, timeout).Should(Equal(newSerial))
 
 				device := &v1alpha1.NicDevice{}
 				err = k8sClient.Get(ctx, client.ObjectKey{
-					Name:      deviceRegistry.getCRName(deviceType, serialNumber),
+					Name:      deviceRegistry.getCRName(deviceType, newPciDevKey),
 					Namespace: namespaceName,
 				}, device)
 				Expect(err).NotTo(HaveOccurred())

--- a/pkg/configuration/utils.go
+++ b/pkg/configuration/utils.go
@@ -160,7 +160,7 @@ func (h *configurationUtils) GetMaxReadRequestSize(pciAddr string) (int, error) 
 func (h *configurationUtils) GetQoSSettings(device *v1alpha1.NicDevice, interfaceName string) (*v1alpha1.QosSpec, error) {
 	log.Log.Info("ConfigurationUtils.GetTrustAndPFC()", "device", device.Name)
 
-	dmsClient, err := h.dmsManager.GetDMSClientBySerialNumber(device.Status.SerialNumber)
+	dmsClient, err := dms.GetDMSClientForDevice(h.dmsManager, device)
 	if err != nil {
 		log.Log.Error(err, "GetTrustAndPFC(): failed to get DMS client", "device", device.Name)
 		return nil, err
@@ -227,7 +227,7 @@ func (h *configurationUtils) SetMaxReadRequestSize(pciAddr string, maxReadReques
 func (h *configurationUtils) SetQoSSettings(device *v1alpha1.NicDevice, spec *v1alpha1.QosSpec) error {
 	log.Log.Info("ConfigurationUtils.SetTrustAndPFC()", "device", device.Name, "spec", spec)
 
-	dmsClient, err := h.dmsManager.GetDMSClientBySerialNumber(device.Status.SerialNumber)
+	dmsClient, err := dms.GetDMSClientForDevice(h.dmsManager, device)
 	if err != nil {
 		log.Log.Error(err, "SetTrustAndPFC(): failed to get DMS client", "device", device.Name)
 		return err

--- a/pkg/configuration/utils_test.go
+++ b/pkg/configuration/utils_test.go
@@ -257,7 +257,7 @@ var _ = Describe("ConfigurationUtils", func() {
 
 			mockDMSManager := &mocks.DMSManager{}
 			mockDMSClient := &mocks.DMSClient{}
-			mockDMSManager.On("GetDMSClientBySerialNumber", "serialnumber").Return(mockDMSClient, nil)
+			mockDMSManager.On("GetDMSClientByPCIAddress", "0000:03:00").Return(mockDMSClient, nil)
 			mockDMSClient.On("GetQoSSettings", "enp3s0f0np0").Return(&v1alpha1.QosSpec{Trust: trust, PFC: pfc}, nil)
 
 			h := &configurationUtils{
@@ -281,7 +281,7 @@ var _ = Describe("ConfigurationUtils", func() {
 
 			mockDMSManager := &mocks.DMSManager{}
 			mockDMSClient := &mocks.DMSClient{}
-			mockDMSManager.On("GetDMSClientBySerialNumber", "serialnumber").Return(mockDMSClient, nil)
+			mockDMSManager.On("GetDMSClientByPCIAddress", "0000:03:00").Return(mockDMSClient, nil)
 			mockDMSClient.On("GetQoSSettings", "enp3s0f0np0").Return(&v1alpha1.QosSpec{}, nil)
 
 			h := &configurationUtils{

--- a/pkg/devicediscovery/devicediscovery.go
+++ b/pkg/devicediscovery/devicediscovery.go
@@ -30,7 +30,8 @@ import (
 )
 
 type DeviceDiscovery interface {
-	// DiscoverNicDevices discovers Nvidia NIC devices on the host and returns back a map of serial numbers to NicDevice objects
+	// DiscoverNicDevices discovers Nvidia NIC devices on the host and returns back a map of
+	// PCI device addresses (Domain:Bus:Device, function stripped) to NicDevice objects.
 	DiscoverNicDevices() (map[string]v1alpha1.NicDevice, error)
 }
 
@@ -41,7 +42,11 @@ type deviceDiscovery struct {
 	nodeName string
 }
 
-// DiscoverNicDevices uses host utils to discover Nvidia NIC devices on the host and returns back a map of serial numbers to NicDevice objects
+// DiscoverNicDevices uses host utils to discover Nvidia NIC devices on the host and returns back a map of
+// PCI device addresses (Domain:Bus:Device, function stripped) to NicDevice objects. PCI functions that share
+// the same Domain:Bus:Device are ports of the same physical NIC and are merged into one NicDevice. Keying
+// by PCI device address (rather than serial number) is required on systems where multiple cards share a
+// flashed VPD image (e.g. embedded NICs on HGX B300).
 func (d deviceDiscovery) DiscoverNicDevices() (map[string]v1alpha1.NicDevice, error) {
 	log.Log.Info("ConfigurationManager.DiscoverNicDevices()")
 
@@ -51,7 +56,6 @@ func (d deviceDiscovery) DiscoverNicDevices() (map[string]v1alpha1.NicDevice, er
 		return nil, err
 	}
 
-	// Intermediate map for grouping ports by serial number
 	statuses := make(map[string]v1alpha1.NicDeviceStatus)
 
 	for _, device := range pciDevices {
@@ -96,8 +100,8 @@ func (d deviceDiscovery) DiscoverNicDevices() (map[string]v1alpha1.NicDevice, er
 			continue
 		}
 
-		// Devices with the same serial number are ports of the same NIC, so grouping them
-		deviceStatus, ok := statuses[vpd.SerialNumber]
+		pciKey := utils.PCIDeviceAddress(device.Address)
+		deviceStatus, ok := statuses[pciKey]
 
 		if !ok {
 			firmwareVersion, psid, err := d.utils.GetFirmwareVersionAndPSID(device.Address)
@@ -137,8 +141,6 @@ func (d deviceDiscovery) DiscoverNicDevices() (map[string]v1alpha1.NicDevice, er
 			}
 
 			log.Log.Info("Discovered NIC device", "address", device.Address, "status", deviceStatus)
-
-			statuses[vpd.SerialNumber] = deviceStatus
 		}
 
 		networkInterface := d.utils.GetInterfaceName(device.Address)
@@ -150,13 +152,12 @@ func (d deviceDiscovery) DiscoverNicDevices() (map[string]v1alpha1.NicDevice, er
 			RdmaInterface:    rdmaInterface,
 		})
 
-		statuses[deviceStatus.SerialNumber] = deviceStatus
+		statuses[pciKey] = deviceStatus
 	}
 
-	// Wrap statuses into NicDevice objects
 	devices := make(map[string]v1alpha1.NicDevice, len(statuses))
-	for serial, status := range statuses {
-		devices[serial] = v1alpha1.NicDevice{
+	for pciKey, status := range statuses {
+		devices[pciKey] = v1alpha1.NicDevice{
 			Status: status,
 		}
 	}

--- a/pkg/devicediscovery/devicediscovery_test.go
+++ b/pkg/devicediscovery/devicediscovery_test.go
@@ -191,10 +191,10 @@ var _ = Describe("DeviceDiscovery", func() {
 					},
 				}
 
-				Expect(devices).To(HaveKey("serial-number"))
-				Expect(devices["serial-number"].Status).To(Equal(expectedDeviceStatus))
+				Expect(devices).To(HaveKey("0000:00:00"))
+				Expect(devices["0000:00:00"].Status).To(Equal(expectedDeviceStatus))
 				// Verify that the returned device has the correct nodeName
-				Expect(devices["serial-number"].Status.Node).To(Equal("test-node"))
+				Expect(devices["0000:00:00"].Status.Node).To(Equal("test-node"))
 
 				mockUtils.AssertExpectations(GinkgoT())
 			})
@@ -203,6 +203,7 @@ var _ = Describe("DeviceDiscovery", func() {
 
 	Context("when discovering several mellanox device", func() {
 		BeforeEach(func() {
+			// Two distinct physical NICs at different PCI devices.
 			mockUtils.On("GetPCIDevices").Return([]*pci.Device{
 				{
 					Address: "0000:00:00.0",
@@ -211,7 +212,7 @@ var _ = Describe("DeviceDiscovery", func() {
 					Class:   &pcidb.Class{ID: "02"},
 				},
 				{
-					Address: "0000:00:00.1",
+					Address: "0000:01:00.0",
 					Vendor:  &pcidb.Vendor{ID: consts.MellanoxVendor},
 					Product: &pcidb.Product{ID: "test-id", Name: "Mellanox Device"},
 					Class:   &pcidb.Class{ID: "02"},
@@ -231,7 +232,7 @@ var _ = Describe("DeviceDiscovery", func() {
 			mockUtils.On("GetRDMADeviceName", "0000:00:00.0").
 				Return("mlx5_0")
 
-			mockUtils.On("IsSriovVF", "0000:00:00.1").Return(true)
+			mockUtils.On("IsSriovVF", "0000:01:00.0").Return(true)
 
 			devices, err := manager.DiscoverNicDevices()
 			Expect(err).NotTo(HaveOccurred())
@@ -254,8 +255,8 @@ var _ = Describe("DeviceDiscovery", func() {
 				},
 			}
 
-			Expect(devices).To(HaveKey("serial-number"))
-			Expect(devices["serial-number"].Status).To(Equal(expectedDeviceStatus))
+			Expect(devices).To(HaveKey("0000:00:00"))
+			Expect(devices["0000:00:00"].Status).To(Equal(expectedDeviceStatus))
 			mockUtils.AssertExpectations(GinkgoT())
 		})
 
@@ -271,9 +272,9 @@ var _ = Describe("DeviceDiscovery", func() {
 			mockUtils.On("GetRDMADeviceName", "0000:00:00.0").
 				Return("mlx5_0")
 
-			mockUtils.On("IsSriovVF", "0000:00:00.1").
+			mockUtils.On("IsSriovVF", "0000:01:00.0").
 				Return(false)
-			mockUtils.On("GetVPD", "0000:00:00.1").
+			mockUtils.On("GetVPD", "0000:01:00.0").
 				Return(nil, errors.New("serial number error"))
 
 			devices, err := manager.DiscoverNicDevices()
@@ -294,11 +295,11 @@ var _ = Describe("DeviceDiscovery", func() {
 			mockUtils.On("GetRDMADeviceName", "0000:00:00.0").
 				Return("mlx5_0")
 
-			mockUtils.On("IsSriovVF", "0000:00:00.1").
+			mockUtils.On("IsSriovVF", "0000:01:00.0").
 				Return(false)
-			mockUtils.On("GetVPD", "0000:00:00.1").
+			mockUtils.On("GetVPD", "0000:01:00.0").
 				Return(&types.VPD{PartNumber: "part-number", SerialNumber: "serial-number-2", ModelName: ""}, nil)
-			mockUtils.On("GetFirmwareVersionAndPSID", "0000:00:00.1").
+			mockUtils.On("GetFirmwareVersionAndPSID", "0000:01:00.0").
 				Return("", "", errors.New("firmware error"))
 
 			devices, err := manager.DiscoverNicDevices()
@@ -319,15 +320,15 @@ var _ = Describe("DeviceDiscovery", func() {
 			mockUtils.On("GetRDMADeviceName", "0000:00:00.0").
 				Return("mlx5_0")
 
-			mockUtils.On("IsSriovVF", "0000:00:00.1").
+			mockUtils.On("IsSriovVF", "0000:01:00.0").
 				Return(false)
-			mockUtils.On("GetVPD", "0000:00:00.1").
+			mockUtils.On("GetVPD", "0000:01:00.0").
 				Return(&types.VPD{PartNumber: "part-number", SerialNumber: "serial-number-2", ModelName: ""}, nil)
-			mockUtils.On("GetFirmwareVersionAndPSID", "0000:00:00.1").
+			mockUtils.On("GetFirmwareVersionAndPSID", "0000:01:00.0").
 				Return("fw-version", "psid", nil)
-			mockUtils.On("GetInterfaceName", "0000:00:00.1").
+			mockUtils.On("GetInterfaceName", "0000:01:00.0").
 				Return("eth1")
-			mockUtils.On("GetRDMADeviceName", "0000:00:00.1").
+			mockUtils.On("GetRDMADeviceName", "0000:01:00.0").
 				Return("mlx5_1")
 
 			devices, err := manager.DiscoverNicDevices()
@@ -364,16 +365,17 @@ var _ = Describe("DeviceDiscovery", func() {
 				DPU:             false,
 				Ports: []v1alpha1.NicDevicePortSpec{
 					{
-						PCI:              "0000:00:00.1",
+						PCI:              "0000:01:00.0",
 						NetworkInterface: "eth1",
 						RdmaInterface:    "mlx5_1",
 					},
 				},
 			}
 
-			Expect(devices).To(HaveKey("serial-number"))
-			Expect(devices["serial-number"].Status).To(Equal(expectedDeviceStatus1))
-			Expect(devices["serial-number-2"].Status).To(Equal(expectedDeviceStatus2))
+			Expect(devices).To(HaveKey("0000:00:00"))
+			Expect(devices["0000:00:00"].Status).To(Equal(expectedDeviceStatus1))
+			Expect(devices).To(HaveKey("0000:01:00"))
+			Expect(devices["0000:01:00"].Status).To(Equal(expectedDeviceStatus2))
 
 			mockUtils.AssertExpectations(GinkgoT())
 		})
@@ -445,10 +447,121 @@ var _ = Describe("DeviceDiscovery", func() {
 				},
 			}
 
-			Expect(devices).To(HaveKey("serial-number"))
-			Expect(devices[sameSerialNumber].Status).To(Equal(expectedDeviceStatus))
+			Expect(devices).To(HaveKey("0000:00:00"))
+			Expect(devices["0000:00:00"].Status).To(Equal(expectedDeviceStatus))
+			_ = sameSerialNumber // kept for readability of mock setup above
 
 			mockUtils.AssertExpectations(GinkgoT())
+		})
+	})
+
+	Context("when multiple NICs share the same flashed serial number (HGX B300)", func() {
+		It("should return one device per PCI device key, not collapse by SN", func() {
+			sharedSerial := "shared-sn"
+
+			mockUtils.On("GetPCIDevices").Return([]*pci.Device{
+				{
+					Address: "0000:3b:00.0",
+					Vendor:  &pcidb.Vendor{ID: consts.MellanoxVendor},
+					Product: &pcidb.Product{ID: "cx9", Name: "ConnectX-9"},
+					Class:   &pcidb.Class{ID: "02"},
+				},
+				{
+					Address: "0000:3c:00.0",
+					Vendor:  &pcidb.Vendor{ID: consts.MellanoxVendor},
+					Product: &pcidb.Product{ID: "cx9", Name: "ConnectX-9"},
+					Class:   &pcidb.Class{ID: "02"},
+				},
+			}, nil)
+
+			for _, addr := range []string{"0000:3b:00.0", "0000:3c:00.0"} {
+				mockUtils.On("IsSriovVF", addr).Return(false)
+				mockUtils.On("GetVPD", addr).
+					Return(&types.VPD{PartNumber: "part-number", SerialNumber: sharedSerial, ModelName: ""}, nil)
+				mockUtils.On("GetFirmwareVersionAndPSID", addr).Return("fw-version", "psid", nil)
+				mockUtils.On("GetInterfaceName", addr).Return("eth0")
+				mockUtils.On("GetRDMADeviceName", addr).Return("mlx5_0")
+			}
+
+			devices, err := manager.DiscoverNicDevices()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(devices).To(HaveLen(2))
+			Expect(devices).To(HaveKey("0000:3b:00"))
+			Expect(devices).To(HaveKey("0000:3c:00"))
+			Expect(devices["0000:3b:00"].Status.SerialNumber).To(Equal(sharedSerial))
+			Expect(devices["0000:3c:00"].Status.SerialNumber).To(Equal(sharedSerial))
+		})
+	})
+
+	Context("when a ConnectX-9 card exposes four PCI functions (2 eth + 2 IB)", func() {
+		It("should group all four functions into a single device with four ports", func() {
+			sn := "cx9-sn"
+			pciDevs := make([]*pci.Device, 0, 4)
+			for _, fn := range []string{"0", "1", "2", "3"} {
+				pciDevs = append(pciDevs, &pci.Device{
+					Address: "0001:03:00." + fn,
+					Vendor:  &pcidb.Vendor{ID: consts.MellanoxVendor},
+					Product: &pcidb.Product{ID: "cx9", Name: "ConnectX-9"},
+					Class:   &pcidb.Class{ID: "02"},
+				})
+			}
+			mockUtils.On("GetPCIDevices").Return(pciDevs, nil)
+
+			for _, fn := range []string{"0", "1", "2", "3"} {
+				addr := "0001:03:00." + fn
+				mockUtils.On("IsSriovVF", addr).Return(false)
+				mockUtils.On("GetVPD", addr).
+					Return(&types.VPD{PartNumber: "part-number", SerialNumber: sn, ModelName: ""}, nil)
+				mockUtils.On("GetInterfaceName", addr).Return("eth" + fn)
+				mockUtils.On("GetRDMADeviceName", addr).Return("mlx5_" + fn)
+			}
+			// FW/PSID only queried on first function.
+			mockUtils.On("GetFirmwareVersionAndPSID", "0001:03:00.0").Return("fw-version", "psid", nil)
+
+			devices, err := manager.DiscoverNicDevices()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(devices).To(HaveLen(1))
+			Expect(devices).To(HaveKey("0001:03:00"))
+			Expect(devices["0001:03:00"].Status.Ports).To(HaveLen(4))
+		})
+	})
+
+	Context("when two cards have the same bus:dev but different PCI domains", func() {
+		It("should return two distinct devices", func() {
+			mockUtils.On("GetPCIDevices").Return([]*pci.Device{
+				{
+					Address: "0001:03:00.0",
+					Vendor:  &pcidb.Vendor{ID: consts.MellanoxVendor},
+					Product: &pcidb.Product{ID: "cx9", Name: "ConnectX-9"},
+					Class:   &pcidb.Class{ID: "02"},
+				},
+				{
+					Address: "0004:03:00.0",
+					Vendor:  &pcidb.Vendor{ID: consts.MellanoxVendor},
+					Product: &pcidb.Product{ID: "cx9", Name: "ConnectX-9"},
+					Class:   &pcidb.Class{ID: "02"},
+				},
+			}, nil)
+
+			mockUtils.On("IsSriovVF", "0001:03:00.0").Return(false)
+			mockUtils.On("GetVPD", "0001:03:00.0").
+				Return(&types.VPD{PartNumber: "part-number", SerialNumber: "sn-a", ModelName: ""}, nil)
+			mockUtils.On("GetFirmwareVersionAndPSID", "0001:03:00.0").Return("fw-version", "psid", nil)
+			mockUtils.On("GetInterfaceName", "0001:03:00.0").Return("eth0")
+			mockUtils.On("GetRDMADeviceName", "0001:03:00.0").Return("mlx5_0")
+
+			mockUtils.On("IsSriovVF", "0004:03:00.0").Return(false)
+			mockUtils.On("GetVPD", "0004:03:00.0").
+				Return(&types.VPD{PartNumber: "part-number", SerialNumber: "sn-b", ModelName: ""}, nil)
+			mockUtils.On("GetFirmwareVersionAndPSID", "0004:03:00.0").Return("fw-version", "psid", nil)
+			mockUtils.On("GetInterfaceName", "0004:03:00.0").Return("eth1")
+			mockUtils.On("GetRDMADeviceName", "0004:03:00.0").Return("mlx5_1")
+
+			devices, err := manager.DiscoverNicDevices()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(devices).To(HaveLen(2))
+			Expect(devices).To(HaveKey("0001:03:00"))
+			Expect(devices).To(HaveKey("0004:03:00"))
 		})
 	})
 
@@ -474,10 +587,10 @@ var _ = Describe("DeviceDiscovery", func() {
 
 			manager := deviceDiscovery{utils: &mockUtils, nvConfigUtils: nvmmocks.NewNVConfigUtils(GinkgoT()), nodeName: "test-node"}
 
-			devicesBySerial, err := manager.DiscoverNicDevices()
+			devicesByPCI, err := manager.DiscoverNicDevices()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(devicesBySerial).To(HaveKey("serial-number"))
-			discoveredDevice := devicesBySerial["serial-number"]
+			Expect(devicesByPCI).To(HaveKey("0000:00:00"))
+			discoveredDevice := devicesByPCI["0000:00:00"]
 			Expect(discoveredDevice.Status.ModelName).To(Equal("NVIDIA ConnectX-8 C8180 HHHL SuperNIC"))
 			Expect(discoveredDevice.Status.SuperNIC).To(BeTrue())
 		})
@@ -509,9 +622,9 @@ var _ = Describe("DeviceDiscovery", func() {
 
 			manager := deviceDiscovery{utils: &mockUtils, nvConfigUtils: nvConfigUtilsMock, nodeName: "test-node"}
 
-			devicesBySerial, err := manager.DiscoverNicDevices()
+			devicesByPCI, err := manager.DiscoverNicDevices()
 			Expect(err).NotTo(HaveOccurred())
-			discoveredDevice := devicesBySerial["serial-number"]
+			discoveredDevice := devicesByPCI["0000:00:00"]
 			Expect(discoveredDevice.Status.DPU).To(BeTrue())
 		})
 

--- a/pkg/dms/dms.go
+++ b/pkg/dms/dms.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/Mellanox/nic-configuration-operator/api/v1alpha1"
+	"github.com/Mellanox/nic-configuration-operator/pkg/utils"
 )
 
 const (
@@ -38,8 +39,20 @@ const (
 
 // DMSManager provides per-device DMS client lookup (used by all consumers)
 type DMSManager interface {
-	// GetDMSClientBySerialNumber returns the DMS client for a specific device identified by its serial number
-	GetDMSClientBySerialNumber(serialNumber string) (DMSClient, error)
+	// GetDMSClientByPCIAddress returns the DMS client for a device identified by its PCI
+	// device address (Domain:Bus:Device, function stripped). This is the NIC uniqueness
+	// key used throughout the operator; it remains unique on systems where multiple cards
+	// share a flashed serial number (e.g. embedded NICs on HGX B300).
+	GetDMSClientByPCIAddress(pciDeviceAddr string) (DMSClient, error)
+}
+
+// GetDMSClientForDevice is a convenience wrapper that derives the PCI device key
+// from device.Status.Ports[0].PCI and looks up the DMS client for it.
+func GetDMSClientForDevice(mgr DMSManager, device *v1alpha1.NicDevice) (DMSClient, error) {
+	if device == nil || len(device.Status.Ports) == 0 {
+		return nil, fmt.Errorf("device has no ports")
+	}
+	return mgr.GetDMSClientByPCIAddress(utils.PCIDeviceAddress(device.Status.Ports[0].PCI))
 }
 
 // DMSServer extends DMSManager with server lifecycle management
@@ -101,20 +114,20 @@ func NewExternalDMSManager(devices []v1alpha1.NicDevice, address string, authPar
 			authParams:    authParams,
 			execInterface: execUtils.New(),
 		}
-		clients[device.Status.SerialNumber] = client
+		clients[utils.PCIDeviceAddress(device.Status.Ports[0].PCI)] = client
 	}
 	return &externalDMSManager{clients: clients}
 }
 
-// GetDMSClientBySerialNumber returns the DMS client for a specific device identified by its serial number
-func (m *externalDMSManager) GetDMSClientBySerialNumber(serialNumber string) (DMSClient, error) {
-	log.Log.V(2).Info("GetDMSClientBySerialNumber", "serialNumber", serialNumber)
-	client, ok := m.clients[serialNumber]
+// GetDMSClientByPCIAddress returns the DMS client for a device identified by its PCI device address.
+func (m *externalDMSManager) GetDMSClientByPCIAddress(pciDeviceAddr string) (DMSClient, error) {
+	log.Log.V(2).Info("GetDMSClientByPCIAddress", "pciDeviceAddr", pciDeviceAddr)
+	client, ok := m.clients[pciDeviceAddr]
 	if !ok {
-		log.Log.V(2).Info("No DMS client found", "serialNumber", serialNumber)
-		return nil, fmt.Errorf("no DMS client found for device with serial number %s", serialNumber)
+		log.Log.V(2).Info("No DMS client found", "pciDeviceAddr", pciDeviceAddr)
+		return nil, fmt.Errorf("no DMS client found for device with PCI address %s", pciDeviceAddr)
 	}
-	log.Log.V(2).Info("Found DMS client", "serialNumber", serialNumber)
+	log.Log.V(2).Info("Found DMS client", "pciDeviceAddr", pciDeviceAddr)
 	return client, nil
 }
 
@@ -231,7 +244,7 @@ func (m *dmsServer) StartDMSServer(devices []v1alpha1.NicDevice) error {
 			authParams:    []string{"--insecure"},
 			execInterface: m.execInterface,
 		}
-		m.clients[device.Status.SerialNumber] = client
+		m.clients[utils.PCIDeviceAddress(device.Status.Ports[0].PCI)] = client
 	}
 
 	log.Log.Info("Started DMS server", "bind_address", bindAddress, "targetPCI", targetPCI, "clientCount", len(m.clients))
@@ -262,9 +275,9 @@ func (m *dmsServer) IsRunning() bool {
 	return m.running.Load()
 }
 
-// GetDMSClientBySerialNumber returns the DMS client for a specific device identified by its serial number
-func (m *dmsServer) GetDMSClientBySerialNumber(serialNumber string) (DMSClient, error) {
-	log.Log.V(2).Info("GetDMSClientBySerialNumber", "serialNumber", serialNumber)
+// GetDMSClientByPCIAddress returns the DMS client for a device identified by its PCI device address.
+func (m *dmsServer) GetDMSClientByPCIAddress(pciDeviceAddr string) (DMSClient, error) {
+	log.Log.V(2).Info("GetDMSClientByPCIAddress", "pciDeviceAddr", pciDeviceAddr)
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
 
@@ -272,13 +285,13 @@ func (m *dmsServer) GetDMSClientBySerialNumber(serialNumber string) (DMSClient, 
 		return nil, fmt.Errorf("DMS server is not running")
 	}
 
-	client, ok := m.clients[serialNumber]
+	client, ok := m.clients[pciDeviceAddr]
 	if !ok {
-		log.Log.V(2).Info("No DMS client found", "serialNumber", serialNumber)
-		return nil, fmt.Errorf("no DMS client found for device with serial number %s", serialNumber)
+		log.Log.V(2).Info("No DMS client found", "pciDeviceAddr", pciDeviceAddr)
+		return nil, fmt.Errorf("no DMS client found for device with PCI address %s", pciDeviceAddr)
 	}
 
-	log.Log.V(2).Info("Found DMS client", "serialNumber", serialNumber)
+	log.Log.V(2).Info("Found DMS client", "pciDeviceAddr", pciDeviceAddr)
 	return client, nil
 }
 

--- a/pkg/dms/dms_test.go
+++ b/pkg/dms/dms_test.go
@@ -123,17 +123,17 @@ var _ = Describe("DMSServer", func() {
 				err := server.StartDMSServer(testDevices)
 				Expect(err).NotTo(HaveOccurred())
 
-				// Verify clients were created for both devices
+				// Verify clients were created for both devices, keyed by PCI device address.
 				Expect(server.clients).To(HaveLen(2))
-				Expect(server.clients).To(HaveKey("test-serial-1"))
-				Expect(server.clients).To(HaveKey("test-serial-2"))
+				Expect(server.clients).To(HaveKey("0000:01:00"))
+				Expect(server.clients).To(HaveKey("0000:02:00"))
 
 				// Verify server is running
 				Expect(server.running.Load()).To(BeTrue())
 
 				// Verify clients have correct target PCI
-				Expect(server.clients["test-serial-1"].targetPCI).To(Equal("0000:01:00.0"))
-				Expect(server.clients["test-serial-2"].targetPCI).To(Equal("0000:02:00.0"))
+				Expect(server.clients["0000:01:00"].targetPCI).To(Equal("0000:01:00.0"))
+				Expect(server.clients["0000:02:00"].targetPCI).To(Equal("0000:02:00.0"))
 			})
 
 			It("should not start another server if already running", func() {
@@ -329,7 +329,7 @@ var _ = Describe("DMSServer", func() {
 		})
 	})
 
-	Describe("GetDMSClientBySerialNumber", func() {
+	Describe("GetDMSClientByPCIAddress", func() {
 		Context("when server is running and the device exists", func() {
 			BeforeEach(func() {
 				client := &dmsClient{
@@ -339,14 +339,14 @@ var _ = Describe("DMSServer", func() {
 					authParams:    []string{"--insecure"},
 					execInterface: fakeExec,
 				}
-				server.clients[testStatuses[0].SerialNumber] = client
+				server.clients["0000:01:00"] = client
 				server.running.Store(true)
 			})
 
 			It("should return the client for the device", func() {
-				client, err := server.GetDMSClientBySerialNumber(testStatuses[0].SerialNumber)
+				client, err := server.GetDMSClientByPCIAddress("0000:01:00")
 				Expect(err).NotTo(HaveOccurred())
-				Expect(client).To(Equal(server.clients[testStatuses[0].SerialNumber]))
+				Expect(client).To(Equal(server.clients["0000:01:00"]))
 			})
 		})
 
@@ -356,7 +356,7 @@ var _ = Describe("DMSServer", func() {
 			})
 
 			It("should return an error", func() {
-				client, err := server.GetDMSClientBySerialNumber("non-existent-serial")
+				client, err := server.GetDMSClientByPCIAddress("0000:ff:ff")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("no DMS client found for device"))
 				Expect(client).To(BeNil())
@@ -365,7 +365,7 @@ var _ = Describe("DMSServer", func() {
 
 		Context("when server is not running", func() {
 			It("should return an error", func() {
-				client, err := server.GetDMSClientBySerialNumber(testStatuses[0].SerialNumber)
+				client, err := server.GetDMSClientByPCIAddress("0000:01:00")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("DMS server is not running"))
 				Expect(client).To(BeNil())
@@ -395,14 +395,14 @@ var _ = Describe("ExternalDMSManager", func() {
 
 	It("should create clients for all devices", func() {
 		mgr := NewExternalDMSManager(extTestDevices, "remotehost:9339", []string{"--insecure"})
-		client, err := mgr.GetDMSClientBySerialNumber("test-serial-1")
+		client, err := mgr.GetDMSClientByPCIAddress("0000:01:00")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(client).NotTo(BeNil())
 	})
 
-	It("should return error for unknown serial number", func() {
+	It("should return error for unknown PCI address", func() {
 		mgr := NewExternalDMSManager(extTestDevices, "remotehost:9339", []string{"--insecure"})
-		client, err := mgr.GetDMSClientBySerialNumber("unknown-serial")
+		client, err := mgr.GetDMSClientByPCIAddress("0000:ff:ff")
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("no DMS client found for device"))
 		Expect(client).To(BeNil())
@@ -411,7 +411,7 @@ var _ = Describe("ExternalDMSManager", func() {
 	It("should pass custom auth params to clients", func() {
 		authParams := []string{"--tls-ca", "/path/ca.pem", "--tls-cert", "/path/cert.pem", "--tls-key", "/path/key.pem"}
 		mgr := NewExternalDMSManager(extTestDevices, "remotehost:9339", authParams)
-		client, err := mgr.GetDMSClientBySerialNumber("test-serial-1")
+		client, err := mgr.GetDMSClientByPCIAddress("0000:01:00")
 		Expect(err).NotTo(HaveOccurred())
 		// Verify auth params are stored on the client
 		dmsC := client.(*dmsClient)

--- a/pkg/dms/mocks/DMSManager.go
+++ b/pkg/dms/mocks/DMSManager.go
@@ -12,21 +12,21 @@ type DMSManager struct {
 	mock.Mock
 }
 
-// GetDMSClientBySerialNumber provides a mock function with given fields: serialNumber
-func (_m *DMSManager) GetDMSClientBySerialNumber(serialNumber string) (dms.DMSClient, error) {
-	ret := _m.Called(serialNumber)
+// GetDMSClientByPCIAddress provides a mock function with given fields: pciDeviceAddr
+func (_m *DMSManager) GetDMSClientByPCIAddress(pciDeviceAddr string) (dms.DMSClient, error) {
+	ret := _m.Called(pciDeviceAddr)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetDMSClientBySerialNumber")
+		panic("no return value specified for GetDMSClientByPCIAddress")
 	}
 
 	var r0 dms.DMSClient
 	var r1 error
 	if rf, ok := ret.Get(0).(func(string) (dms.DMSClient, error)); ok {
-		return rf(serialNumber)
+		return rf(pciDeviceAddr)
 	}
 	if rf, ok := ret.Get(0).(func(string) dms.DMSClient); ok {
-		r0 = rf(serialNumber)
+		r0 = rf(pciDeviceAddr)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(dms.DMSClient)
@@ -34,7 +34,7 @@ func (_m *DMSManager) GetDMSClientBySerialNumber(serialNumber string) (dms.DMSCl
 	}
 
 	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(serialNumber)
+		r1 = rf(pciDeviceAddr)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/dms/mocks/DMSServer.go
+++ b/pkg/dms/mocks/DMSServer.go
@@ -14,21 +14,21 @@ type DMSServer struct {
 	mock.Mock
 }
 
-// GetDMSClientBySerialNumber provides a mock function with given fields: serialNumber
-func (_m *DMSServer) GetDMSClientBySerialNumber(serialNumber string) (dms.DMSClient, error) {
-	ret := _m.Called(serialNumber)
+// GetDMSClientByPCIAddress provides a mock function with given fields: pciDeviceAddr
+func (_m *DMSServer) GetDMSClientByPCIAddress(pciDeviceAddr string) (dms.DMSClient, error) {
+	ret := _m.Called(pciDeviceAddr)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetDMSClientBySerialNumber")
+		panic("no return value specified for GetDMSClientByPCIAddress")
 	}
 
 	var r0 dms.DMSClient
 	var r1 error
 	if rf, ok := ret.Get(0).(func(string) (dms.DMSClient, error)); ok {
-		return rf(serialNumber)
+		return rf(pciDeviceAddr)
 	}
 	if rf, ok := ret.Get(0).(func(string) dms.DMSClient); ok {
-		r0 = rf(serialNumber)
+		r0 = rf(pciDeviceAddr)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(dms.DMSClient)
@@ -36,7 +36,7 @@ func (_m *DMSServer) GetDMSClientBySerialNumber(serialNumber string) (dms.DMSCli
 	}
 
 	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(serialNumber)
+		r1 = rf(pciDeviceAddr)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/firmware/manager.go
+++ b/pkg/firmware/manager.go
@@ -385,7 +385,7 @@ func (f firmwareManager) getVersionFromFirmwareFile(device *v1alpha1.NicDevice, 
 
 // installBlueFieldFirmware installs firmware on a BlueField device via DMS
 func (f firmwareManager) installBlueFieldFirmware(ctx context.Context, device *v1alpha1.NicDevice, version string, fwFilePath string) error {
-	dmsClient, err := f.dmsManager.GetDMSClientBySerialNumber(device.Status.SerialNumber)
+	dmsClient, err := dms.GetDMSClientForDevice(f.dmsManager, device)
 	if err != nil {
 		log.Log.Error(err, "failed to get DMS client", "device", device.Name)
 		return err

--- a/pkg/firmware/manager_test.go
+++ b/pkg/firmware/manager_test.go
@@ -488,7 +488,7 @@ var _ = Describe("FirmwareManager", func() {
 
 				fwUtilsMock.On("GetFirmwareVersionsFromDevice", pci).
 					Return("", "", errors.New("version check failed")).Once()
-				dmsManagerMock.On("GetDMSClientBySerialNumber", testSerial).Return(dmsClientMock, nil).Once()
+				dmsManagerMock.On("GetDMSClientByPCIAddress", "0000:3b:00").Return(dmsClientMock, nil).Once()
 				fwUtilsMock.On("EnsureDeviceBoundToMlx5Core", pci).Return(nil).Once()
 				dmsClientMock.On("InstallBFB", mock.Anything, fwVersion, expectedBFBPath).Return(nil).Once()
 
@@ -502,7 +502,7 @@ var _ = Describe("FirmwareManager", func() {
 
 				fwUtilsMock.On("GetFirmwareVersionsFromDevice", pci).
 					Return("", "", errors.New("version check failed")).Once()
-				dmsManagerMock.On("GetDMSClientBySerialNumber", testSerial).Return(dmsClientMock, nil).Once()
+				dmsManagerMock.On("GetDMSClientByPCIAddress", "0000:3b:00").Return(dmsClientMock, nil).Once()
 				fwUtilsMock.On("EnsureDeviceBoundToMlx5Core", pci).Return(nil).Once()
 				dmsClientMock.On("InstallBFB", mock.Anything, fwVersion, expectedBFBPath).Return(nil).Once()
 
@@ -518,7 +518,7 @@ var _ = Describe("FirmwareManager", func() {
 
 				fwUtilsMock.On("GetFirmwareVersionsFromDevice", pci).
 					Return("", "", errors.New("version check failed")).Once()
-				dmsManagerMock.On("GetDMSClientBySerialNumber", testSerial).Return(dmsClientMock, nil).Once()
+				dmsManagerMock.On("GetDMSClientByPCIAddress", "0000:3b:00").Return(dmsClientMock, nil).Once()
 				fwUtilsMock.On("EnsureDeviceBoundToMlx5Core", pci).Return(nil).Once()
 				fwUtilsMock.On("EnsureDeviceBoundToMlx5Core", secondPCI).Return(nil).Once()
 				dmsClientMock.On("InstallBFB", mock.Anything, fwVersion, expectedBFBPath).Return(nil).Once()
@@ -533,7 +533,7 @@ var _ = Describe("FirmwareManager", func() {
 
 				fwUtilsMock.On("GetFirmwareVersionsFromDevice", pci).
 					Return("", "", errors.New("version check failed")).Once()
-				dmsManagerMock.On("GetDMSClientBySerialNumber", testSerial).Return(dmsClientMock, nil).Once()
+				dmsManagerMock.On("GetDMSClientByPCIAddress", "0000:3b:00").Return(dmsClientMock, nil).Once()
 				fwUtilsMock.On("EnsureDeviceBoundToMlx5Core", pci).Return(bindErr).Once()
 				// InstallBFB must not be called if binding fails — no mock expectation set.
 
@@ -561,7 +561,7 @@ var _ = Describe("FirmwareManager", func() {
 
 				fwUtilsMock.On("GetFirmwareVersionsFromDevice", pci).
 					Return("", "", errors.New("version check failed")).Once()
-				dmsManagerMock.On("GetDMSClientBySerialNumber", testSerial).Return(nil, dmsError).Once()
+				dmsManagerMock.On("GetDMSClientByPCIAddress", "0000:3b:00").Return(nil, dmsError).Once()
 
 				_, err := manager.InstallFirmware(context.Background(), device, &types.FirmwareInstallOptions{Version: fwVersion, SkipReset: true})
 				Expect(err).To(HaveOccurred())
@@ -575,7 +575,7 @@ var _ = Describe("FirmwareManager", func() {
 
 				fwUtilsMock.On("GetFirmwareVersionsFromDevice", pci).
 					Return("", "", errors.New("version check failed")).Once()
-				dmsManagerMock.On("GetDMSClientBySerialNumber", testSerial).Return(dmsClientMock, nil).Once()
+				dmsManagerMock.On("GetDMSClientByPCIAddress", "0000:3b:00").Return(dmsClientMock, nil).Once()
 				fwUtilsMock.On("EnsureDeviceBoundToMlx5Core", pci).Return(nil).Once()
 				dmsClientMock.On("InstallBFB", mock.Anything, fwVersion, expectedBFBPath).Return(installError).Once()
 

--- a/pkg/spectrumx/spectrumx.go
+++ b/pkg/spectrumx/spectrumx.go
@@ -323,7 +323,7 @@ func (m *spectrumXConfigManager) RuntimeConfigApplied(device *v1alpha1.NicDevice
 		return false, fmt.Errorf("spectrumx config not found for version %s", spcXSpec.Version)
 	}
 
-	dmsClient, err := m.dmsManager.GetDMSClientBySerialNumber(device.Status.SerialNumber)
+	dmsClient, err := dms.GetDMSClientForDevice(m.dmsManager, device)
 	if err != nil {
 		log.Log.Error(err, "RuntimeConfigApplied(): failed to get DMS client", "device", device.Name)
 		return false, err
@@ -477,7 +477,7 @@ func (m *spectrumXConfigManager) ApplyRuntimeConfig(device *v1alpha1.NicDevice) 
 		return &types.RuntimeConfigurationApplyResult{Status: types.ApplyStatusFailed}, fmt.Errorf("spectrumx config not found for version %s", spcXSpec.Version)
 	}
 
-	dmsClient, err := m.dmsManager.GetDMSClientBySerialNumber(device.Status.SerialNumber)
+	dmsClient, err := dms.GetDMSClientForDevice(m.dmsManager, device)
 	if err != nil {
 		log.Log.Error(err, "ApplyRuntimeConfig(): failed to get DMS client", "device", device.Name)
 		return &types.RuntimeConfigurationApplyResult{Status: types.ApplyStatusFailed}, err

--- a/pkg/spectrumx/spectrumx_test.go
+++ b/pkg/spectrumx/spectrumx_test.go
@@ -202,7 +202,7 @@ var _ = Describe("SpectrumXConfigManager", func() {
 		}
 
 		beforeDevice()
-		dmsMgr.On("GetDMSClientBySerialNumber", device.Status.SerialNumber).Return(&dmsCli, nil).Maybe()
+		dmsMgr.On("GetDMSClientByPCIAddress", "0000:00:00").Return(&dmsCli, nil).Maybe()
 	})
 
 	Describe("GetBreakoutMlxConfig", func() {

--- a/pkg/utils/pci.go
+++ b/pkg/utils/pci.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/vishvananda/netlink"
 )
@@ -37,4 +38,18 @@ func GetPciAddressFromLink(link netlink.Link) (string, error) {
 	}
 	// The last element of the path is the PCI address
 	return filepath.Base(realPath), nil
+}
+
+// PCIDeviceAddress returns the Domain:Bus:Device portion of a PCI BDF,
+// stripping the trailing .Function. Returns the input unchanged if no
+// dot is present. Used as the NIC uniqueness key: all PCI functions
+// of one physical card share the same Domain:Bus:Device, so this
+// collapses multi-function NICs onto a single identifier while
+// remaining unique across cards (including embedded NICs that share
+// a flashed VPD image, e.g. on HGX B300).
+func PCIDeviceAddress(pciBDF string) string {
+	if i := strings.LastIndex(pciBDF, "."); i > 0 {
+		return pciBDF[:i]
+	}
+	return pciBDF
 }


### PR DESCRIPTION
On HGX B300, multiple ConnectX NICs are soldered onto a single baseboard and flashed with the same VPD image during NVIDIA manufacturing, so they report identical serial numbers. The operator was keying ports-into- devices, the DMS client map, and CR names by SN, collapsing all embedded cards into a single NicDevice and routing every card's DMS calls to one client (last-write-wins).

Switch the uniqueness key to the PCI device address (Domain:Bus:Device, function stripped) across discovery, the reconciler, DMS client lookup, and CR naming. Ports of the same physical card share Dom:Bus:Dev and differ only by function, so the key naturally groups multi-function NICs (including 4-PF ConnectX-9 cards) while staying unique across cards on B300.

- pkg/utils: new PCIDeviceAddress helper
- pkg/devicediscovery: return map keyed by PCI device
- controller: sanitize PCI key for DNS-1123 CR names (co-node-25-101b-0000-04-00)
- pkg/dms: rename GetDMSClientBySerialNumber → GetDMSClientByPCIAddress; add GetDMSClientForDevice helper
- api: keep Status.SerialNumber populated (informational); note non-uniqueness on SerialNumber/SerialNumbers field comments