### PR TITLE
devicediscovery: fall back to mstvpd when mlxvpd fails

### DIFF
--- a/pkg/devicediscovery/utils.go
+++ b/pkg/devicediscovery/utils.go
@@ -141,7 +141,7 @@ func (d *deviceDiscoveryUtils) GetVPD(pciAddr string) (*types.VPD, error) {
 
 	vpd, mstvpdErr := d.getVPDViaMstvpd(pciAddr)
 	if mstvpdErr != nil {
-		return nil, fmt.Errorf("both mlxvpd and mstvpd failed: mlxvpd: %w; mstvpd: %v", mlxvpdErr, mstvpdErr)
+		return nil, fmt.Errorf("both mlxvpd and mstvpd failed: mlxvpd: %w; mstvpd: %w", mlxvpdErr, mstvpdErr)
 	}
 	return vpd, nil
 }

--- a/pkg/devicediscovery/utils.go
+++ b/pkg/devicediscovery/utils.go
@@ -104,46 +104,86 @@ func (d *deviceDiscoveryUtils) GetPCIDevices() ([]*pci.Device, error) {
 	return pciRegistry.Devices, nil
 }
 
-// GetVPD uses mlxvpd util to retrieve Part Number, Serial Number, Model Name of the PCI device
+// vpdOutputPatterns is the set of line-regexes used to extract fields from one
+// VPD tool's output. Each pattern must have a single capture group for the value.
+type vpdOutputPatterns struct {
+	partNumber   *regexp.Regexp
+	serialNumber *regexp.Regexp
+	modelName    *regexp.Regexp
+}
+
+// mlxvpd output is a 3-column table: "  PN             Part Number             <value>"
+var mlxvpdPatterns = vpdOutputPatterns{
+	partNumber:   regexp.MustCompile(`^\s*` + consts.PartNumberPrefix + `\s+` + consts.PartNumberDescription + `\s+(.+)$`),
+	serialNumber: regexp.MustCompile(`^\s*` + consts.SerialNumberPrefix + `\s+` + consts.SerialNumberDescription + `\s+(.+)$`),
+	modelName:    regexp.MustCompile(`^\s*` + consts.ModelNamePrefix + `\s+` + consts.ModelNameDescription + `\s+(.+)$`),
+}
+
+// mstvpd output is "KEY: <value>" with model name under "ID:" (no Board Id / IDTAG column).
+var mstvpdPatterns = vpdOutputPatterns{
+	partNumber:   regexp.MustCompile(`^\s*PN:\s+(.+)$`),
+	serialNumber: regexp.MustCompile(`^\s*SN:\s+(.+)$`),
+	modelName:    regexp.MustCompile(`^\s*ID:\s+(.+)$`),
+}
+
+// GetVPD retrieves Part Number, Serial Number, and Model Name for a PCI device.
+// Primary: mlxvpd (MFT). Fallback: mstvpd (mstflint) — used when mlxvpd fails all
+// retries or its output is unparseable. MFT 4.36 segfaults on BlueField-4 PF0;
+// mstvpd reads /sys/bus/pci/devices/<pci>/vpd directly and is hardware-agnostic.
 func (d *deviceDiscoveryUtils) GetVPD(pciAddr string) (*types.VPD, error) {
 	log.Log.Info("HostUtils.GetVPD()", "pciAddr", pciAddr)
+
+	vpd, mlxvpdErr := d.getVPDViaMlxvpd(pciAddr)
+	if mlxvpdErr == nil {
+		return vpd, nil
+	}
+	log.Log.Info("GetVPD(): mlxvpd failed, falling back to mstvpd", "pciAddr", pciAddr, "error", mlxvpdErr.Error())
+
+	vpd, mstvpdErr := d.getVPDViaMstvpd(pciAddr)
+	if mstvpdErr != nil {
+		return nil, fmt.Errorf("both mlxvpd and mstvpd failed: mlxvpd: %w; mstvpd: %v", mlxvpdErr, mstvpdErr)
+	}
+	return vpd, nil
+}
+
+func (d *deviceDiscoveryUtils) getVPDViaMlxvpd(pciAddr string) (*types.VPD, error) {
 	output, err := runCommandWithRetry(d.execInterface, "mlxvpd", []string{"-d", pciAddr}, mlxvpdMaxAttempts, mlxvpdBackoff)
 	if err != nil {
-		log.Log.Error(err, "GetVPD(): Failed to run mlxvpd")
-		return nil, err
+		return nil, fmt.Errorf("mlxvpd failed after %d attempts: %w", mlxvpdMaxAttempts, err)
 	}
+	return parseVPDOutput(output, mlxvpdPatterns)
+}
 
-	// Parse the output for PN, SN and IDTAG
-	// The output format is tabular with columns: VPD-KEYWORD, DESCRIPTION, VALUE
-	// Example line: "  PN             Part Number             MCX623106AE-CDAT"
-	scanner := bufio.NewScanner(strings.NewReader(string(output)))
+func (d *deviceDiscoveryUtils) getVPDViaMstvpd(pciAddr string) (*types.VPD, error) {
+	output, err := d.execInterface.Command("mstvpd", pciAddr).CombinedOutput()
+	log.Log.V(2).Info("command output", "command", "mstvpd", "output", string(output))
+	if err != nil {
+		return nil, fmt.Errorf("mstvpd failed: %w", err)
+	}
+	return parseVPDOutput(output, mstvpdPatterns)
+}
+
+// parseVPDOutput scans VPD tool output line-by-line, extracting the first
+// capture group of each matching regex. Returns an error if PN or SN is missing.
+func parseVPDOutput(output []byte, p vpdOutputPatterns) (*types.VPD, error) {
 	var partNumber, serialNumber, modelName string
 
-	// Compile regex patterns for each VPD field we care about
-	// Pattern: keyword + whitespace + description + whitespace + value (capture group)
-	pnRegex := regexp.MustCompile(`^\s*` + consts.PartNumberPrefix + `\s+` + consts.PartNumberDescription + `\s+(.+)$`)
-	snRegex := regexp.MustCompile(`^\s*` + consts.SerialNumberPrefix + `\s+` + consts.SerialNumberDescription + `\s+(.+)$`)
-	modelRegex := regexp.MustCompile(`^\s*` + consts.ModelNamePrefix + `\s+` + consts.ModelNameDescription + `\s+(.+)$`)
-
+	scanner := bufio.NewScanner(strings.NewReader(string(output)))
 	for scanner.Scan() {
 		line := scanner.Text()
-
-		if matches := pnRegex.FindStringSubmatch(line); len(matches) > 1 {
-			partNumber = strings.TrimSpace(matches[1])
-		} else if matches := snRegex.FindStringSubmatch(line); len(matches) > 1 {
-			serialNumber = strings.TrimSpace(matches[1])
-		} else if matches := modelRegex.FindStringSubmatch(line); len(matches) > 1 {
-			modelName = strings.TrimSpace(matches[1])
+		if m := p.partNumber.FindStringSubmatch(line); len(m) > 1 {
+			partNumber = strings.TrimSpace(m[1])
+		} else if m := p.serialNumber.FindStringSubmatch(line); len(m) > 1 {
+			serialNumber = strings.TrimSpace(m[1])
+		} else if m := p.modelName.FindStringSubmatch(line); len(m) > 1 {
+			modelName = strings.TrimSpace(m[1])
 		}
 	}
-
 	if err := scanner.Err(); err != nil {
-		log.Log.Error(err, "GetPartAndSerialNumber(): Error reading mlxvpd output")
-		return nil, err
+		return nil, fmt.Errorf("reading VPD output: %w", err)
 	}
-
 	if partNumber == "" || serialNumber == "" {
-		return nil, fmt.Errorf("GetPartAndSerialNumber(): part number (%v) or serial number (%v) is empty", partNumber, serialNumber)
+		return nil, fmt.Errorf("VPD output missing part number (%q) or serial number (%q)", partNumber, serialNumber)
 	}
 
 	return &types.VPD{

--- a/pkg/devicediscovery/utils_test.go
+++ b/pkg/devicediscovery/utils_test.go
@@ -85,43 +85,37 @@ var _ = Describe("HostUtils", func() {
 			Expect(vpd.SerialNumber).To(Equal(serialNumber))
 			Expect(vpd.ModelName).To(Equal(modelName))
 		})
-		It("should return error when PN or SN is missing", func() {
+		It("should return error when PN or SN is missing from both tools", func() {
 			fakeExec := &execTesting.FakeExec{}
 
-			fakeCmd := &execTesting.FakeCmd{}
-			fakeCmd.CombinedOutputScript = append(fakeCmd.CombinedOutputScript, func() ([]byte, []byte, error) {
+			mlxvpdCmd := &execTesting.FakeCmd{}
+			mlxvpdCmd.CombinedOutputScript = append(mlxvpdCmd.CombinedOutputScript, func() ([]byte, []byte, error) {
 				return []byte("  SN             Serial Number           " + serialNumber + "\n"), nil, nil
 			})
-
-			fakeExec.CommandScript = append(fakeExec.CommandScript, func(cmd string, args ...string) exec.Cmd {
-				Expect(cmd).To(Equal("mlxvpd"))
-				Expect(args[0]).To(Equal("-d"))
-				Expect(args[1]).To(Equal(pciAddress))
-				return fakeCmd
+			mstvpdCmd := &execTesting.FakeCmd{}
+			mstvpdCmd.CombinedOutputScript = append(mstvpdCmd.CombinedOutputScript, func() ([]byte, []byte, error) {
+				return []byte("SN:      " + serialNumber + "\n"), nil, nil
 			})
+
+			fakeExec.CommandScript = append(fakeExec.CommandScript,
+				func(cmd string, args ...string) exec.Cmd {
+					Expect(cmd).To(Equal("mlxvpd"))
+					Expect(args[0]).To(Equal("-d"))
+					Expect(args[1]).To(Equal(pciAddress))
+					return mlxvpdCmd
+				},
+				func(cmd string, args ...string) exec.Cmd {
+					Expect(cmd).To(Equal("mstvpd"))
+					Expect(args[0]).To(Equal(pciAddress))
+					return mstvpdCmd
+				},
+			)
 
 			h := &deviceDiscoveryUtils{
 				execInterface: fakeExec,
 			}
 
 			vpd, err := h.GetVPD(pciAddress)
-
-			Expect(err).To(HaveOccurred())
-			Expect(vpd).To(BeNil())
-
-			fakeCmd = &execTesting.FakeCmd{}
-			fakeCmd.CombinedOutputScript = append(fakeCmd.CombinedOutputScript, func() ([]byte, []byte, error) {
-				return []byte("  PN             Part Number             " + partNumber + "\n"), nil, nil
-			})
-
-			fakeExec.CommandScript = append(fakeExec.CommandScript, func(cmd string, args ...string) exec.Cmd {
-				Expect(cmd).To(Equal("mlxvpd"))
-				Expect(args[0]).To(Equal("-d"))
-				Expect(args[1]).To(Equal(pciAddress))
-				return fakeCmd
-			})
-
-			vpd, err = h.GetVPD(pciAddress)
 
 			Expect(err).To(HaveOccurred())
 			Expect(vpd).To(BeNil())
@@ -197,25 +191,32 @@ var _ = Describe("HostUtils", func() {
 			Expect(vpd.SerialNumber).To(Equal(serialNumber))
 			Expect(fakeExec.CommandCalls).To(Equal(2))
 		})
-		It("should retry up to maxAttempts and return an error", func() {
+		It("should retry mlxvpd up to maxAttempts, then fall back to mstvpd, and error if both fail", func() {
 			fakeExec := &execTesting.FakeExec{}
 
-			newFailingCmd := func() *execTesting.FakeCmd {
+			newFailingMlxvpd := func() exec.Cmd {
 				c := &execTesting.FakeCmd{}
 				c.CombinedOutputScript = append(c.CombinedOutputScript, func() ([]byte, []byte, error) {
 					return []byte("mlxvpd: failed to read VPD"), nil, errors.New("exit status 2")
 				})
 				return c
 			}
+			failingMstvpd := &execTesting.FakeCmd{}
+			failingMstvpd.CombinedOutputScript = append(failingMstvpd.CombinedOutputScript, func() ([]byte, []byte, error) {
+				return []byte("mstvpd: error"), nil, errors.New("exit status 2")
+			})
 
-			cmds := []exec.Cmd{newFailingCmd(), newFailingCmd(), newFailingCmd()}
-			for i := range cmds {
-				c := cmds[i]
+			for i := 0; i < mlxvpdMaxAttempts; i++ {
 				fakeExec.CommandScript = append(fakeExec.CommandScript, func(cmd string, args ...string) exec.Cmd {
 					Expect(cmd).To(Equal("mlxvpd"))
-					return c
+					return newFailingMlxvpd()
 				})
 			}
+			fakeExec.CommandScript = append(fakeExec.CommandScript, func(cmd string, args ...string) exec.Cmd {
+				Expect(cmd).To(Equal("mstvpd"))
+				Expect(args[0]).To(Equal(pciAddress))
+				return failingMstvpd
+			})
 
 			h := &deviceDiscoveryUtils{
 				execInterface: fakeExec,
@@ -225,7 +226,88 @@ var _ = Describe("HostUtils", func() {
 
 			Expect(err).To(HaveOccurred())
 			Expect(vpd).To(BeNil())
-			Expect(fakeExec.CommandCalls).To(Equal(mlxvpdMaxAttempts))
+			Expect(fakeExec.CommandCalls).To(Equal(mlxvpdMaxAttempts + 1))
+		})
+		It("should fall back to mstvpd when mlxvpd exhausts retries", func() {
+			modelName := "NVIDIA BlueField-4 B4240V 800G Liquid Cooled DPU"
+			fakeExec := &execTesting.FakeExec{}
+
+			newFailingMlxvpd := func() exec.Cmd {
+				c := &execTesting.FakeCmd{}
+				c.CombinedOutputScript = append(c.CombinedOutputScript, func() ([]byte, []byte, error) {
+					return []byte("Segmentation fault (core dumped)"), nil, errors.New("exit status 139")
+				})
+				return c
+			}
+			successMstvpd := &execTesting.FakeCmd{}
+			successMstvpd.CombinedOutputScript = append(successMstvpd.CombinedOutputScript, func() ([]byte, []byte, error) {
+				return []byte("ID:      " + modelName + "\n" +
+					"PN:      " + partNumber + "\n" +
+					"EC:      B2\n" +
+					"SN:      " + serialNumber + "\n" +
+					"V3:      f264019afb2df1118000dc73fc0521ea\n"), nil, nil
+			})
+
+			for i := 0; i < mlxvpdMaxAttempts; i++ {
+				fakeExec.CommandScript = append(fakeExec.CommandScript, func(cmd string, args ...string) exec.Cmd {
+					Expect(cmd).To(Equal("mlxvpd"))
+					return newFailingMlxvpd()
+				})
+			}
+			fakeExec.CommandScript = append(fakeExec.CommandScript, func(cmd string, args ...string) exec.Cmd {
+				Expect(cmd).To(Equal("mstvpd"))
+				Expect(args[0]).To(Equal(pciAddress))
+				return successMstvpd
+			})
+
+			h := &deviceDiscoveryUtils{
+				execInterface: fakeExec,
+			}
+
+			vpd, err := h.GetVPD(pciAddress)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(vpd.PartNumber).To(Equal(partNumber))
+			Expect(vpd.SerialNumber).To(Equal(serialNumber))
+			Expect(vpd.ModelName).To(Equal(modelName))
+			Expect(fakeExec.CommandCalls).To(Equal(mlxvpdMaxAttempts + 1))
+		})
+		It("should fall back to mstvpd when mlxvpd output is unparseable", func() {
+			fakeExec := &execTesting.FakeExec{}
+
+			// mlxvpd returns a 0 exit code but with unparseable / missing fields.
+			badMlxvpd := &execTesting.FakeCmd{}
+			badMlxvpd.CombinedOutputScript = append(badMlxvpd.CombinedOutputScript, func() ([]byte, []byte, error) {
+				return []byte("some garbage output with no PN or SN\n"), nil, nil
+			})
+			successMstvpd := &execTesting.FakeCmd{}
+			successMstvpd.CombinedOutputScript = append(successMstvpd.CombinedOutputScript, func() ([]byte, []byte, error) {
+				return []byte("PN:      " + partNumber + "\n" +
+					"SN:      " + serialNumber + "\n"), nil, nil
+			})
+
+			fakeExec.CommandScript = append(fakeExec.CommandScript,
+				func(cmd string, args ...string) exec.Cmd {
+					Expect(cmd).To(Equal("mlxvpd"))
+					return badMlxvpd
+				},
+				func(cmd string, args ...string) exec.Cmd {
+					Expect(cmd).To(Equal("mstvpd"))
+					Expect(args[0]).To(Equal(pciAddress))
+					return successMstvpd
+				},
+			)
+
+			h := &deviceDiscoveryUtils{
+				execInterface: fakeExec,
+			}
+
+			vpd, err := h.GetVPD(pciAddress)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(vpd.PartNumber).To(Equal(partNumber))
+			Expect(vpd.SerialNumber).To(Equal(serialNumber))
+			Expect(vpd.ModelName).To(Equal(""))
 		})
 	})
 	//nolint:dupl


### PR DESCRIPTION
MFT 4.36 mlxvpd segfaults reading VPD on BlueField-4 PF0 inside the container, while mstvpd (mstflint, already installed) reads /sys/bus/pci/devices/<pci>/vpd and works across hardware generations.

Try mlxvpd first with the existing 3x retry, fall back to mstvpd on any failure (command error or unparseable output). Parsing is factored out into a shared helper parameterized by per-tool regex patterns.