### PR TITLE
configuration: eliminate full mlxconfig walk from NV-config reconcile

### DIFF
--- a/pkg/configuration/configvalidation.go
+++ b/pkg/configuration/configvalidation.go
@@ -16,26 +16,32 @@ limitations under the License.
 package configuration
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 	"slices"
 	"strconv"
 
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/Mellanox/nic-configuration-operator/api/v1alpha1"
 	"github.com/Mellanox/nic-configuration-operator/pkg/consts"
 	"github.com/Mellanox/nic-configuration-operator/pkg/types"
+	"github.com/Mellanox/nic-configuration-operator/pkg/utils"
 )
 
 type configValidation interface {
-	// ConstructNvParamMapFromTemplate translates a configuration template into a set of nvconfig parameters
-	// operates under the assumption that spec validation was already carried out
-	ConstructNvParamMapFromTemplate(
-		device *v1alpha1.NicDevice, nvConfigQuery types.NvConfigQuery) (map[string]string, error)
+	// ConstructNvParamMapFromTemplate translates a configuration template into a set of
+	// nvconfig parameters. Returns only what the spec explicitly asks to set — no
+	// "resurrected" defaults. Callers apply the returned map with --with_default so
+	// unmanaged params are normalized to factory default.
+	// Operates under the assumption that spec validation was already carried out.
+	ConstructNvParamMapFromTemplate(device *v1alpha1.NicDevice) (map[string]string, error)
+	// ResolveFactoryDefaults replaces sentinel (consts.NvParamFactoryDefault) entries
+	// in `desired` with the firmware's factory default from `portConfig.DefaultConfig`,
+	// returning a new map. Entries whose names aren't in DefaultConfig are dropped.
+	// Callers MUST invoke this after queryNvConfigs and before the compare/apply loop.
+	ResolveFactoryDefaults(desired map[string]string, portConfig types.NvConfigQuery) map[string]string
 	// ValidateResetToDefault checks if device's nv config has been reset to default in current and next boots
 	// returns bool - need to perform reset
 	// returns bool - reboot required
@@ -67,20 +73,25 @@ func nvParamLinkTypeFromName(linkType string) string {
 	}
 }
 
-func applyDefaultNvConfigValueIfExists(
-	paramName string, desiredParameters map[string]string, query types.NvConfigQuery) {
-	defaultValues, found := query.DefaultConfig[paramName]
-	// Default values might not yet be available if ENABLE_PCI_OPTIMIZATIONS is disabled
-	if found {
-		// Take the default numeric value
-		desiredParameters[paramName] = defaultValues[len(defaultValues)-1]
-	}
-}
-
-// ConstructNvParamMapFromTemplate translates a configuration template into a set of nvconfig parameters
-// operates under the assumption that spec validation was already carried out
-func (v *configValidationImpl) ConstructNvParamMapFromTemplate(
-	device *v1alpha1.NicDevice, query types.NvConfigQuery) (map[string]string, error) {
+// ConstructNvParamMapFromTemplate translates a configuration template into the full
+// set of NV-config parameters this operator manages for the device. The returned map
+// is what we ask mlxconfig to write after sentinel resolution. Every managed param
+// appears either as a concrete value OR as the sentinel `consts.NvParamFactoryDefault`
+// meaning "this parameter should be at the firmware's factory default" — callers MUST
+// run the result through `ResolveFactoryDefaults` against a scoped mlxconfig query
+// before the compare/apply loop.
+//
+// This function is intentionally query-independent: it decides what's managed based on
+// spec + port count alone. Sentinels are how we keep former-feature params (e.g. RoCE
+// params after RoceOptimized goes false) in scope so the scoped query picks them up
+// and drift is detected.
+//
+// For BF devices we always emit INTERNAL_CPU_OFFLOAD_ENGINE=NIC mode — applying a
+// NicConfigurationTemplate to a BF implies NIC mode by design; DPU mode is out of
+// scope for this operator.
+//
+// Operates under the assumption that spec-level sanity validation was already done.
+func (v *configValidationImpl) ConstructNvParamMapFromTemplate(device *v1alpha1.NicDevice) (map[string]string, error) {
 	desiredParameters := map[string]string{}
 
 	template := device.Spec.Configuration.Template
@@ -93,67 +104,29 @@ func (v *configValidationImpl) ConstructNvParamMapFromTemplate(
 		desiredParameters[consts.SriovNumOfVfsParam] = strconv.Itoa(template.NumVfs)
 	}
 
-	// Link type change is not allowed on some devices
-	_, canChangeLinkType := query.DefaultConfig[consts.LinkTypeP1Param]
-	if canChangeLinkType {
-		linkType := nvParamLinkTypeFromName(string(template.LinkType))
-		// Emit LINK_TYPE_P<n> for every discovered port. Firmware may expose
-		// fewer slots than the device has ports (e.g. BF3 DPU mode), so gate
-		// each entry on a presence check in the query output.
-		for portIdx := 1; portIdx <= portCount; portIdx++ {
-			name := consts.PortParam(consts.LinkTypeParamBase, portIdx)
-			if _, ok := query.DefaultConfig[name]; ok {
-				desiredParameters[name] = linkType
-			}
-		}
-	} else {
-		desiredLinkType := string(device.Spec.Configuration.Template.LinkType)
-
-		for _, port := range device.Status.Ports {
-			if port.NetworkInterface != "" && v.utils.GetLinkType(port.NetworkInterface) != desiredLinkType {
-				err := types.IncorrectSpecError(
-					fmt.Sprintf(
-						"device does not support link type change, wrong link type provided in the template, should be: %s",
-						v.utils.GetLinkType(port.NetworkInterface)))
-				log.Log.Error(err, "incorrect spec", "device", device.Name)
-				return desiredParameters, err
-			}
-		}
+	// Emit LINK_TYPE_P<n> for every discovered port. mlxconfig rejects the set on
+	// devices that don't support link type change, surfacing a clear error upstream.
+	linkType := nvParamLinkTypeFromName(string(template.LinkType))
+	for portIdx := 1; portIdx <= portCount; portIdx++ {
+		desiredParameters[consts.PortParam(consts.LinkTypeParamBase, portIdx)] = linkType
 	}
 
-	if template.PciPerformanceOptimized != nil && template.PciPerformanceOptimized.Enabled {
-		if template.PciPerformanceOptimized.MaxAccOutRead != 0 {
-			desiredParameters[consts.MaxAccOutReadParam] = strconv.Itoa(template.PciPerformanceOptimized.MaxAccOutRead)
-		} else {
-			// MAX_ACC_OUT_READ parameter is hidden if ADVANCED_PCI_SETTINGS is disabled
-			if v.AdvancedPCISettingsEnabled(query) {
-				values, found := query.DefaultConfig[consts.MaxAccOutReadParam]
-				if !found {
-					err := types.IncorrectSpecError(
-						"Device does not support pci performance nv config parameters")
-					log.Log.Error(err, "incorrect spec", "device", device.Name, "parameter", consts.MaxAccOutReadParam)
-					return desiredParameters, err
-				}
+	// BF device implies NIC mode. Applies to BF2/BF3/BF4 — see utils.IsBlueFieldDevice.
+	if utils.IsBlueFieldDevice(device.Status.Type) {
+		desiredParameters[consts.BF3OperationModeParam] = consts.NvParamBF3NicMode
+	}
 
-				maxAccOutReadParamDefaultValue := values[len(values)-1]
-
-				// According to the PRM, setting MAX_ACC_OUT_READ to zero enables the auto mode,
-				// which applies the best suitable optimizations.
-				// However, there is a bug in certain FW versions, where the zero value is not available.
-				// In this case, until the fix is available, skipping this parameter and emitting a warning
-				if maxAccOutReadParamDefaultValue == consts.NvParamZero {
-					applyDefaultNvConfigValueIfExists(consts.MaxAccOutReadParam, desiredParameters, query)
-				} else {
-					warning := fmt.Sprintf("%s nv config parameter does not work properly on this version of FW, skipping it", consts.MaxAccOutReadParam)
-					if v.eventRecorder != nil {
-						v.eventRecorder.Event(device, v1.EventTypeWarning, "FirmwareError", warning)
-					}
-					log.Log.Error(errors.New(warning), "skipping parameter", "device", device.Name, "fw version", device.Status.FirmwareVersion)
-				}
-			}
-		}
-
-		// maxReadRequest is applied as runtime configuration
+	// PciPerformanceOptimized: only emit MAX_ACC_OUT_READ when the user asked for a
+	// specific non-zero value (explicit). Otherwise (disabled or auto/0) treat it as
+	// "should be at factory default" via the sentinel. ADVANCED_PCI_SETTINGS is only
+	// forced on when we need the hidden param visible for a concrete value.
+	if template.PciPerformanceOptimized != nil &&
+		template.PciPerformanceOptimized.Enabled &&
+		template.PciPerformanceOptimized.MaxAccOutRead != 0 {
+		desiredParameters[consts.AdvancedPCISettingsParam] = consts.NvParamTrue
+		desiredParameters[consts.MaxAccOutReadParam] = strconv.Itoa(template.PciPerformanceOptimized.MaxAccOutRead)
+	} else {
+		desiredParameters[consts.MaxAccOutReadParam] = consts.NvParamFactoryDefault
 	}
 
 	if template.RoceOptimized != nil && template.RoceOptimized.Enabled {
@@ -164,20 +137,22 @@ func (v *configValidationImpl) ConstructNvParamMapFromTemplate(
 			return desiredParameters, err
 		}
 
-		// Apply RoCE optimization to every discovered port. Matches the
-		// historical P1/P2 behavior, which emits these params unconditionally.
+		// Apply RoCE optimization to every discovered port.
 		for portIdx := 1; portIdx <= portCount; portIdx++ {
 			desiredParameters[consts.PortParam(consts.RoceCcPrioMaskParamBase, portIdx)] = "255"
 			desiredParameters[consts.PortParam(consts.CnpDscpParamBase, portIdx)] = "4"
 			desiredParameters[consts.PortParam(consts.Cnp802pPrioParamBase, portIdx)] = "6"
 		}
 
-		// qos settings are applied as runtime configuration
+		// qos settings are applied as runtime configuration.
 	} else {
+		// RoCE disabled → emit the sentinel for every port so the resolver replaces
+		// it with the FW default. This ensures cleanup when the user previously had
+		// RoCE enabled and then disabled it.
 		for portIdx := 1; portIdx <= portCount; portIdx++ {
-			applyDefaultNvConfigValueIfExists(consts.PortParam(consts.RoceCcPrioMaskParamBase, portIdx), desiredParameters, query)
-			applyDefaultNvConfigValueIfExists(consts.PortParam(consts.CnpDscpParamBase, portIdx), desiredParameters, query)
-			applyDefaultNvConfigValueIfExists(consts.PortParam(consts.Cnp802pPrioParamBase, portIdx), desiredParameters, query)
+			desiredParameters[consts.PortParam(consts.RoceCcPrioMaskParamBase, portIdx)] = consts.NvParamFactoryDefault
+			desiredParameters[consts.PortParam(consts.CnpDscpParamBase, portIdx)] = consts.NvParamFactoryDefault
+			desiredParameters[consts.PortParam(consts.Cnp802pPrioParamBase, portIdx)] = consts.NvParamFactoryDefault
 		}
 	}
 
@@ -196,18 +171,53 @@ func (v *configValidationImpl) ConstructNvParamMapFromTemplate(
 			return desiredParameters, err
 		}
 	} else {
-		applyDefaultNvConfigValueIfExists(consts.AtsEnabledParam, desiredParameters, query)
+		// GpuDirect disabled → ATS_ENABLED should be at FW default.
+		desiredParameters[consts.AtsEnabledParam] = consts.NvParamFactoryDefault
 	}
+
 	for _, rawParam := range template.RawNvConfig {
 		// Drop _Pn params whose port is beyond the device's port count.
 		if n, ok := consts.PortSuffixNum(rawParam.Name); ok && n > portCount {
 			continue
 		}
-
 		desiredParameters[rawParam.Name] = rawParam.Value
 	}
 
 	return desiredParameters, nil
+}
+
+// ResolveFactoryDefaults materializes sentinel-valued entries in `desired` against
+// the firmware's DefaultConfig from a scoped mlxconfig query, returning a new map.
+// Entries whose value is `consts.NvParamFactoryDefault` are replaced with the
+// numeric default value. Entries whose names don't appear in `portConfig.DefaultConfig`
+// are dropped (firmware doesn't expose the param — matches the existing "unsupported
+// param" tolerance in manager.go). Concrete values pass through unchanged.
+//
+// Callers MUST call this method after `queryNvConfigs` and before the compare/apply
+// loop — sentinels are not a valid mlxconfig value and will be rejected by the
+// firmware if leaked to `SetNvConfigParametersBatch`.
+func (v *configValidationImpl) ResolveFactoryDefaults(
+	desired map[string]string, portConfig types.NvConfigQuery,
+) map[string]string {
+	resolved := make(map[string]string, len(desired))
+	for name, value := range desired {
+		if value != consts.NvParamFactoryDefault {
+			resolved[name] = value
+			continue
+		}
+		defaults, found := portConfig.DefaultConfig[name]
+		if !found || len(defaults) == 0 {
+			// FW doesn't expose this param. Drop from desired so the compare loop
+			// doesn't count it as drift; downstream "param not supported" handling
+			// picks it up if ADVANCED_PCI_SETTINGS is enabled.
+			log.Log.V(2).Info("sentinel not resolvable, dropping from desired", "param", name)
+			continue
+		}
+		// DefaultConfig stores [alias, numeric] for bracketed values or [numeric] for
+		// plain scalars; the numeric slot is always the last element.
+		resolved[name] = defaults[len(defaults)-1]
+	}
+	return resolved
 }
 
 // ValidateResetToDefault checks if device's nv config has been reset to default in current and next boots
@@ -218,10 +228,6 @@ func (v *configValidationImpl) ValidateResetToDefault(nvConfig types.NvConfigQue
 	// ResetToDefault requires us to set ADVANCED_PCI_SETTINGS=true, which is not a default value
 	// Deleting this key from maps so that it doesn't interfere with comparisons
 	delete(nvConfig.DefaultConfig, consts.AdvancedPCISettingsParam)
-	// We want to retain the BF3 operation mode after reset, so not taking it into consideration
-	delete(nvConfig.DefaultConfig, consts.BF3OperationModeParam)
-	delete(nvConfig.CurrentConfig, consts.BF3OperationModeParam)
-	delete(nvConfig.NextBootConfig, consts.BF3OperationModeParam)
 
 	alreadyResetInCurrent := false
 	willResetInNextBoot := false

--- a/pkg/configuration/configvalidation_test.go
+++ b/pkg/configuration/configvalidation_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/Mellanox/nic-configuration-operator/pkg/types"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/stretchr/testify/mock"
 
 	"github.com/Mellanox/nic-configuration-operator/api/v1alpha1"
 	"github.com/Mellanox/nic-configuration-operator/pkg/consts"
@@ -43,643 +42,230 @@ var _ = Describe("ConfigValidationImpl", func() {
 	})
 
 	Describe("ConstructNvParamMapFromTemplate", func() {
-		It("should return default values if optional config is disabled", func() {
-			device := &v1alpha1.NicDevice{
+		baseDevice := func(linkType v1alpha1.LinkTypeEnum, ports int) *v1alpha1.NicDevice {
+			portSpecs := make([]v1alpha1.NicDevicePortSpec, ports)
+			for i := 0; i < ports; i++ {
+				portSpecs[i] = v1alpha1.NicDevicePortSpec{PCI: fmt.Sprintf("0000:03:00.%d", i)}
+			}
+			return &v1alpha1.NicDevice{
 				Spec: v1alpha1.NicDeviceSpec{
 					Configuration: &v1alpha1.NicDeviceConfigurationSpec{
 						Template: &v1alpha1.ConfigurationTemplateSpec{
 							NumVfs:   0,
-							LinkType: consts.Ethernet,
+							LinkType: linkType,
 						},
 					},
 				},
-				Status: v1alpha1.NicDeviceStatus{
-					Ports: []v1alpha1.NicDevicePortSpec{
-						{PCI: "0000:03:00.0"},
-						{PCI: "0000:03:00.1"},
-					},
-				},
+				Status: v1alpha1.NicDeviceStatus{Ports: portSpecs},
 			}
+		}
 
-			defaultValues := map[string][]string{
-				consts.RoceCcPrioMaskP1Param: {"testRoceCcP1"},
-				consts.CnpDscpP1Param:        {"testDscpP1"},
-				consts.Cnp802pPrioP1Param:    {"test802PrioP1"},
-				consts.RoceCcPrioMaskP2Param: {"testRoceCcP2"},
-				consts.CnpDscpP2Param:        {"testDscpP2"},
-				consts.Cnp802pPrioP2Param:    {"test802PrioP2"},
-				consts.AtsEnabledParam:       {"testAts"},
-			}
-			query := types.NewNvConfigQuery()
-			query.DefaultConfig = defaultValues
-			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, query)
+		It("emits SRIOV, LINK_TYPE per port, and sentinels for disabled RoCE/Ats/MaxAcc", func() {
+			nvParams, err := validator.ConstructNvParamMapFromTemplate(baseDevice(consts.Ethernet, 2))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nvParams).To(HaveKeyWithValue(consts.SriovEnabledParam, consts.NvParamFalse))
 			Expect(nvParams).To(HaveKeyWithValue(consts.SriovNumOfVfsParam, "0"))
-			Expect(nvParams).To(HaveKeyWithValue(consts.RoceCcPrioMaskP1Param, "testRoceCcP1"))
-			Expect(nvParams).To(HaveKeyWithValue(consts.CnpDscpP1Param, "testDscpP1"))
-			Expect(nvParams).To(HaveKeyWithValue(consts.Cnp802pPrioP1Param, "test802PrioP1"))
-			Expect(nvParams).To(HaveKeyWithValue(consts.RoceCcPrioMaskP2Param, "testRoceCcP2"))
-			Expect(nvParams).To(HaveKeyWithValue(consts.CnpDscpP2Param, "testDscpP2"))
-			Expect(nvParams).To(HaveKeyWithValue(consts.Cnp802pPrioP2Param, "test802PrioP2"))
-			Expect(nvParams).To(HaveKeyWithValue(consts.AtsEnabledParam, "testAts"))
-		})
-
-		It("should check if dual-port device has LINK_TYPE_P2 param", func() {
-			device := &v1alpha1.NicDevice{
-				Spec: v1alpha1.NicDeviceSpec{
-					Configuration: &v1alpha1.NicDeviceConfigurationSpec{
-						Template: &v1alpha1.ConfigurationTemplateSpec{
-							NumVfs:   0,
-							LinkType: consts.Ethernet,
-						},
-					},
-				},
-				Status: v1alpha1.NicDeviceStatus{
-					Ports: []v1alpha1.NicDevicePortSpec{
-						{PCI: "0000:03:00.0"},
-						{PCI: "0000:03:00.1"},
-					},
-				},
-			}
-
-			defaultValues := map[string][]string{
-				consts.LinkTypeP1Param: {"testLinkTypeP1"},
-			}
-			query := types.NewNvConfigQuery()
-			query.DefaultConfig = defaultValues
-			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, query)
-			Expect(err).NotTo(HaveOccurred())
 			Expect(nvParams).To(HaveKeyWithValue(consts.LinkTypeP1Param, consts.NvParamLinkTypeEthernet))
-			Expect(nvParams).ToNot(HaveKey(consts.LinkTypeP2Param))
+			Expect(nvParams).To(HaveKeyWithValue(consts.LinkTypeP2Param, consts.NvParamLinkTypeEthernet))
+			// Disabled optional features emit the factory-default sentinel so the
+			// resolver fills in the FW default at apply time — see ResolveFactoryDefaults.
+			for _, name := range []string{consts.RoceCcPrioMaskP1Param, consts.RoceCcPrioMaskP2Param,
+				consts.CnpDscpP1Param, consts.CnpDscpP2Param,
+				consts.Cnp802pPrioP1Param, consts.Cnp802pPrioP2Param,
+				consts.AtsEnabledParam, consts.MaxAccOutReadParam} {
+				Expect(nvParams).To(HaveKeyWithValue(name, consts.NvParamFactoryDefault))
+			}
+			// ADVANCED_PCI_SETTINGS is only emitted when MAX_ACC_OUT_READ has a concrete value.
+			Expect(nvParams).NotTo(HaveKey(consts.AdvancedPCISettingsParam))
 		})
 
-		It("should omit parameters for the second port if device is single port", func() {
-			device := &v1alpha1.NicDevice{
-				Spec: v1alpha1.NicDeviceSpec{
-					Configuration: &v1alpha1.NicDeviceConfigurationSpec{
-						Template: &v1alpha1.ConfigurationTemplateSpec{
-							NumVfs:   0,
-							LinkType: consts.Ethernet,
-						},
-					},
-				},
-				Status: v1alpha1.NicDeviceStatus{
-					Ports: []v1alpha1.NicDevicePortSpec{
-						{PCI: "0000:03:00.0"},
-					},
-				},
-			}
-			defaultValues := map[string][]string{
-				consts.RoceCcPrioMaskP1Param: {"testRoceCcP1"},
-				consts.CnpDscpP1Param:        {"testDscpP1"},
-				consts.Cnp802pPrioP1Param:    {"test802PrioP1"},
-				consts.RoceCcPrioMaskP2Param: {"testRoceCcP2"},
-				consts.CnpDscpP2Param:        {"testDscpP2"},
-				consts.Cnp802pPrioP2Param:    {"test802PrioP2"},
-				consts.AtsEnabledParam:       {"testAts"},
-			}
-			query := types.NewNvConfigQuery()
-			query.DefaultConfig = defaultValues
+		It("emits SRIOV enabled values when NumVfs > 0", func() {
+			device := baseDevice(consts.Ethernet, 1)
+			device.Spec.Configuration.Template.NumVfs = 16
 
-			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, query)
+			nvParams, err := validator.ConstructNvParamMapFromTemplate(device)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(nvParams).To(HaveKeyWithValue(consts.SriovEnabledParam, consts.NvParamFalse))
-			Expect(nvParams).To(HaveKeyWithValue(consts.SriovNumOfVfsParam, "0"))
-			Expect(nvParams).To(HaveKeyWithValue(consts.AtsEnabledParam, "testAts"))
-			Expect(nvParams).To(HaveKeyWithValue(consts.RoceCcPrioMaskP1Param, "testRoceCcP1"))
-			Expect(nvParams).To(HaveKeyWithValue(consts.CnpDscpP1Param, "testDscpP1"))
-			Expect(nvParams).To(HaveKeyWithValue(consts.Cnp802pPrioP1Param, "test802PrioP1"))
-			Expect(nvParams).To(Not(HaveKey(consts.RoceCcPrioMaskP2Param)))
-			Expect(nvParams).To(Not(HaveKey(consts.CnpDscpP2Param)))
-			Expect(nvParams).To(Not(HaveKey(consts.Cnp802pPrioP2Param)))
+			Expect(nvParams).To(HaveKeyWithValue(consts.SriovEnabledParam, consts.NvParamTrue))
+			Expect(nvParams).To(HaveKeyWithValue(consts.SriovNumOfVfsParam, "16"))
 		})
 
-		It("should construct the correct nvparam map with optional optimizations enabled", func() {
-			mockConfigurationUtils.On("GetPCILinkSpeed", mock.Anything).Return(16, nil)
-
-			device := &v1alpha1.NicDevice{
-				Spec: v1alpha1.NicDeviceSpec{
-					Configuration: &v1alpha1.NicDeviceConfigurationSpec{
-						Template: &v1alpha1.ConfigurationTemplateSpec{
-							NumVfs:   0,
-							LinkType: consts.Ethernet,
-							PciPerformanceOptimized: &v1alpha1.PciPerformanceOptimizedSpec{
-								Enabled:        true,
-								MaxAccOutRead:  1337,
-								MaxReadRequest: 1339,
-							},
-							GpuDirectOptimized: &v1alpha1.GpuDirectOptimizedSpec{
-								Enabled: true,
-								Env:     consts.EnvBaremetal,
-							},
-							RoceOptimized: &v1alpha1.RoceOptimizedSpec{
-								Enabled: true,
-								Qos: &v1alpha1.QosSpec{
-									Trust: "testTrust",
-									PFC:   "testPFC",
-								},
-							},
-						},
-					},
-				},
-				Status: v1alpha1.NicDeviceStatus{
-					Ports: []v1alpha1.NicDevicePortSpec{
-						{PCI: "0000:03:00.0"},
-						{PCI: "0000:03:00.1"},
-					},
-				},
-			}
-
-			query := types.NewNvConfigQuery()
-
-			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, query)
+		It("emits LINK_TYPE_Pn for every port unconditionally (no firmware gate)", func() {
+			// Four-port device; function must emit four LINK_TYPE entries regardless
+			// of what the firmware may or may not expose.
+			nvParams, err := validator.ConstructNvParamMapFromTemplate(baseDevice(consts.Ethernet, 4))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(nvParams).To(HaveKeyWithValue(consts.MaxAccOutReadParam, "1337"))
-			Expect(nvParams).To(HaveKeyWithValue(consts.AtsEnabledParam, "0"))
-			Expect(nvParams).To(HaveKeyWithValue(consts.RoceCcPrioMaskP1Param, "255"))
-			Expect(nvParams).To(HaveKeyWithValue(consts.CnpDscpP1Param, "4"))
-			Expect(nvParams).To(HaveKeyWithValue(consts.Cnp802pPrioP1Param, "6"))
-			Expect(nvParams).To(HaveKeyWithValue(consts.RoceCcPrioMaskP2Param, "255"))
-			Expect(nvParams).To(HaveKeyWithValue(consts.CnpDscpP2Param, "4"))
-			Expect(nvParams).To(HaveKeyWithValue(consts.Cnp802pPrioP2Param, "6"))
-		})
-
-		It("should skip the MaxAccOutRead if the default is not 0", func() {
-			mockConfigurationUtils.On("GetPCILinkSpeed", mock.Anything).Return(16, nil)
-
-			device := &v1alpha1.NicDevice{
-				Spec: v1alpha1.NicDeviceSpec{
-					Configuration: &v1alpha1.NicDeviceConfigurationSpec{
-						Template: &v1alpha1.ConfigurationTemplateSpec{
-							NumVfs:   0,
-							LinkType: consts.Ethernet,
-							PciPerformanceOptimized: &v1alpha1.PciPerformanceOptimizedSpec{
-								Enabled: true,
-							},
-						},
-					},
-				},
-				Status: v1alpha1.NicDeviceStatus{
-					Ports: []v1alpha1.NicDevicePortSpec{
-						{PCI: "0000:03:00.0"},
-					},
-				},
-			}
-
-			defaultValues := map[string][]string{
-				consts.MaxAccOutReadParam: {"notZero"},
-			}
-			query := types.NewNvConfigQuery()
-			query.DefaultConfig = defaultValues
-
-			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, query)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(nvParams).NotTo(HaveKeyWithValue(consts.MaxAccOutReadParam, consts.NvParamZero))
-		})
-
-		It("should apply MaxAccOutRead if the default is 0", func() {
-			mockConfigurationUtils.On("GetPCILinkSpeed", mock.Anything).Return(16, nil)
-
-			device := &v1alpha1.NicDevice{
-				Spec: v1alpha1.NicDeviceSpec{
-					Configuration: &v1alpha1.NicDeviceConfigurationSpec{
-						Template: &v1alpha1.ConfigurationTemplateSpec{
-							NumVfs:   0,
-							LinkType: consts.Ethernet,
-							PciPerformanceOptimized: &v1alpha1.PciPerformanceOptimizedSpec{
-								Enabled: true,
-							},
-						},
-					},
-				},
-				Status: v1alpha1.NicDeviceStatus{
-					Ports: []v1alpha1.NicDevicePortSpec{
-						{PCI: "0000:03:00.0"},
-					},
-				},
-			}
-
-			defaultValues := map[string][]string{
-				consts.MaxAccOutReadParam: {consts.NvParamZero},
-			}
-			currentValues := map[string][]string{
-				consts.AdvancedPCISettingsParam: {consts.NvParamTrue},
-			}
-			query := types.NewNvConfigQuery()
-			query.DefaultConfig = defaultValues
-			query.CurrentConfig = currentValues
-
-			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, query)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(nvParams).To(HaveKeyWithValue(consts.MaxAccOutReadParam, consts.NvParamZero))
-		})
-
-		It("should not apply MaxAccOutRead if the default is unavailable", func() {
-			mockConfigurationUtils.On("GetPCILinkSpeed", mock.Anything).Return(16, nil)
-
-			device := &v1alpha1.NicDevice{
-				Spec: v1alpha1.NicDeviceSpec{
-					Configuration: &v1alpha1.NicDeviceConfigurationSpec{
-						Template: &v1alpha1.ConfigurationTemplateSpec{
-							NumVfs:   0,
-							LinkType: consts.Ethernet,
-							PciPerformanceOptimized: &v1alpha1.PciPerformanceOptimizedSpec{
-								Enabled: true,
-							},
-						},
-					},
-				},
-				Status: v1alpha1.NicDeviceStatus{
-					Ports: []v1alpha1.NicDevicePortSpec{
-						{PCI: "0000:03:00.0"},
-					},
-				},
-			}
-
-			// MAX_ACC_OUT_READ param is unavailable if ADVANCED_PCI_SETTINGS is disabled
-			query := types.NewNvConfigQuery()
-
-			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, query)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(nvParams).ToNot(HaveKeyWithValue(consts.MaxAccOutReadParam, consts.NvParamZero))
-		})
-
-		It("should return an error when GpuOptimized is enabled without PciPerformanceOptimized", func() {
-			mockConfigurationUtils.On("GetPCILinkSpeed", mock.Anything).Return(16, nil)
-
-			device := &v1alpha1.NicDevice{
-				Spec: v1alpha1.NicDeviceSpec{
-					Configuration: &v1alpha1.NicDeviceConfigurationSpec{
-						Template: &v1alpha1.ConfigurationTemplateSpec{
-							NumVfs:   0,
-							LinkType: consts.Ethernet,
-							GpuDirectOptimized: &v1alpha1.GpuDirectOptimizedSpec{
-								Enabled: true,
-								Env:     consts.EnvBaremetal,
-							},
-						},
-					},
-				},
-				Status: v1alpha1.NicDeviceStatus{
-					Ports: []v1alpha1.NicDevicePortSpec{
-						{PCI: "0000:03:00.0"},
-					},
-				},
-			}
-
-			query := types.NewNvConfigQuery()
-
-			_, err := validator.ConstructNvParamMapFromTemplate(device, query)
-			Expect(err).To(MatchError("incorrect spec: GpuDirectOptimized should only be enabled together with PciPerformanceOptimized"))
-		})
-		It("should ignore raw config for the second port if device is single port", func() {
-			mockConfigurationUtils.On("GetPCILinkSpeed", mock.Anything).Return(16, nil)
-
-			device := &v1alpha1.NicDevice{
-				Spec: v1alpha1.NicDeviceSpec{
-					Configuration: &v1alpha1.NicDeviceConfigurationSpec{
-						Template: &v1alpha1.ConfigurationTemplateSpec{
-							NumVfs:   0,
-							LinkType: consts.Ethernet,
-							RawNvConfig: []v1alpha1.NvConfigParam{
-								{
-									Name:  "TEST_P1",
-									Value: "test",
-								},
-								{
-									Name:  "TEST_P2",
-									Value: "test",
-								},
-							},
-						},
-					},
-				},
-				Status: v1alpha1.NicDeviceStatus{
-					Ports: []v1alpha1.NicDevicePortSpec{
-						{PCI: "0000:03:00.0"},
-					},
-				},
-			}
-
-			query := types.NewNvConfigQuery()
-
-			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, query)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(nvParams).To(HaveKeyWithValue("TEST_P1", "test"))
-			Expect(nvParams).NotTo(HaveKey("TEST_P2"))
-		})
-		It("should apply raw config for the second port if device is dual port", func() {
-			mockConfigurationUtils.On("GetPCILinkSpeed", mock.Anything).Return(16, nil)
-
-			device := &v1alpha1.NicDevice{
-				Spec: v1alpha1.NicDeviceSpec{
-					Configuration: &v1alpha1.NicDeviceConfigurationSpec{
-						Template: &v1alpha1.ConfigurationTemplateSpec{
-							NumVfs:   0,
-							LinkType: consts.Ethernet,
-							RawNvConfig: []v1alpha1.NvConfigParam{
-								{
-									Name:  "TEST_P1",
-									Value: "test",
-								},
-								{
-									Name:  "TEST_P2",
-									Value: "test",
-								},
-							},
-						},
-					},
-				},
-				Status: v1alpha1.NicDeviceStatus{
-					Ports: []v1alpha1.NicDevicePortSpec{
-						{PCI: "0000:03:00.0"},
-						{PCI: "0000:03:00.1"},
-					},
-				},
-			}
-
-			query := types.NewNvConfigQuery()
-
-			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, query)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(nvParams).To(HaveKeyWithValue("TEST_P1", "test"))
-			Expect(nvParams).To(HaveKeyWithValue("TEST_P2", "test"))
-		})
-		It("should emit link type and RoCE params for every port on a quad-port device", func() {
-			mockConfigurationUtils.On("GetPCILinkSpeed", mock.Anything).Return(16, nil)
-
-			device := &v1alpha1.NicDevice{
-				Spec: v1alpha1.NicDeviceSpec{
-					Configuration: &v1alpha1.NicDeviceConfigurationSpec{
-						Template: &v1alpha1.ConfigurationTemplateSpec{
-							NumVfs:   0,
-							LinkType: consts.Ethernet,
-							RoceOptimized: &v1alpha1.RoceOptimizedSpec{
-								Enabled: true,
-							},
-							RawNvConfig: []v1alpha1.NvConfigParam{
-								{Name: "CUSTOM_PARAM_P1", Value: "raw1"},
-								{Name: "CUSTOM_PARAM_P4", Value: "raw4"},
-								{Name: "CUSTOM_PARAM_P5", Value: "raw5"},
-								{Name: "CUSTOM_PARAM_NO_SUFFIX", Value: "rawN"},
-							},
-						},
-					},
-				},
-				Status: v1alpha1.NicDeviceStatus{
-					Ports: []v1alpha1.NicDevicePortSpec{
-						{PCI: "0000:03:00.0"},
-						{PCI: "0000:03:00.1"},
-						{PCI: "0000:03:00.2"},
-						{PCI: "0000:03:00.3"},
-					},
-				},
-			}
-
-			query := types.NewNvConfigQuery()
-			// Firmware exposes LINK_TYPE for all four ports.
-			query.DefaultConfig = map[string][]string{
-				"LINK_TYPE_P1": {"2"},
-				"LINK_TYPE_P2": {"2"},
-				"LINK_TYPE_P3": {"2"},
-				"LINK_TYPE_P4": {"2"},
-			}
-
-			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, query)
-			Expect(err).NotTo(HaveOccurred())
-
-			// Link type emitted for every port with a firmware-declared slot.
 			for _, name := range []string{"LINK_TYPE_P1", "LINK_TYPE_P2", "LINK_TYPE_P3", "LINK_TYPE_P4"} {
 				Expect(nvParams).To(HaveKeyWithValue(name, consts.NvParamLinkTypeEthernet))
 			}
+		})
 
-			// RoCE optimization emitted for all four ports.
-			for _, name := range []string{"ROCE_CC_PRIO_MASK_P1", "ROCE_CC_PRIO_MASK_P2", "ROCE_CC_PRIO_MASK_P3", "ROCE_CC_PRIO_MASK_P4"} {
+		It("emits IB link type when template requests it", func() {
+			nvParams, err := validator.ConstructNvParamMapFromTemplate(baseDevice(consts.Infiniband, 2))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nvParams).To(HaveKeyWithValue(consts.LinkTypeP1Param, consts.NvParamLinkTypeInfiniband))
+			Expect(nvParams).To(HaveKeyWithValue(consts.LinkTypeP2Param, consts.NvParamLinkTypeInfiniband))
+		})
+
+		It("emits INTERNAL_CPU_OFFLOAD_ENGINE=NIC mode for BlueField devices", func() {
+			device := baseDevice(consts.Ethernet, 2)
+			device.Status.Type = consts.BlueField3DeviceID
+
+			nvParams, err := validator.ConstructNvParamMapFromTemplate(device)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nvParams).To(HaveKeyWithValue(consts.BF3OperationModeParam, consts.NvParamBF3NicMode))
+		})
+
+		It("does not emit INTERNAL_CPU_OFFLOAD_ENGINE for non-BlueField devices", func() {
+			device := baseDevice(consts.Ethernet, 2)
+			device.Status.Type = "1021" // ConnectX-7 device ID
+
+			nvParams, err := validator.ConstructNvParamMapFromTemplate(device)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nvParams).NotTo(HaveKey(consts.BF3OperationModeParam))
+		})
+
+		It("emits MAX_ACC_OUT_READ and ADVANCED_PCI_SETTINGS when PciPerf specifies a non-zero value", func() {
+			device := baseDevice(consts.Ethernet, 1)
+			device.Spec.Configuration.Template.PciPerformanceOptimized = &v1alpha1.PciPerformanceOptimizedSpec{
+				Enabled:       true,
+				MaxAccOutRead: 1337,
+			}
+
+			nvParams, err := validator.ConstructNvParamMapFromTemplate(device)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nvParams).To(HaveKeyWithValue(consts.MaxAccOutReadParam, "1337"))
+			// ADVANCED_PCI_SETTINGS=1 is included in the same batch so mlxconfig can
+			// unlock visibility of MAX_ACC_OUT_READ in one --with_default set call.
+			Expect(nvParams).To(HaveKeyWithValue(consts.AdvancedPCISettingsParam, consts.NvParamTrue))
+		})
+
+		It("emits sentinel for MAX_ACC_OUT_READ when PciPerf is enabled with auto (value 0)", func() {
+			device := baseDevice(consts.Ethernet, 1)
+			device.Spec.Configuration.Template.PciPerformanceOptimized = &v1alpha1.PciPerformanceOptimizedSpec{
+				Enabled: true,
+			}
+
+			nvParams, err := validator.ConstructNvParamMapFromTemplate(device)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nvParams).To(HaveKeyWithValue(consts.MaxAccOutReadParam, consts.NvParamFactoryDefault))
+			Expect(nvParams).NotTo(HaveKey(consts.AdvancedPCISettingsParam))
+		})
+
+		It("emits RoCE params per port when RoceOptimized is enabled", func() {
+			device := baseDevice(consts.Ethernet, 2)
+			device.Spec.Configuration.Template.RoceOptimized = &v1alpha1.RoceOptimizedSpec{Enabled: true}
+
+			nvParams, err := validator.ConstructNvParamMapFromTemplate(device)
+			Expect(err).NotTo(HaveOccurred())
+			for _, name := range []string{consts.RoceCcPrioMaskP1Param, consts.RoceCcPrioMaskP2Param} {
 				Expect(nvParams).To(HaveKeyWithValue(name, "255"))
 			}
-			for _, name := range []string{"CNP_DSCP_P1", "CNP_DSCP_P2", "CNP_DSCP_P3", "CNP_DSCP_P4"} {
+			for _, name := range []string{consts.CnpDscpP1Param, consts.CnpDscpP2Param} {
 				Expect(nvParams).To(HaveKeyWithValue(name, "4"))
 			}
-			for _, name := range []string{"CNP_802P_PRIO_P1", "CNP_802P_PRIO_P2", "CNP_802P_PRIO_P3", "CNP_802P_PRIO_P4"} {
+			for _, name := range []string{consts.Cnp802pPrioP1Param, consts.Cnp802pPrioP2Param} {
 				Expect(nvParams).To(HaveKeyWithValue(name, "6"))
 			}
-
-			// rawNvConfig: _P1..P4 and non-suffixed entries kept; _P5 dropped.
-			Expect(nvParams).To(HaveKeyWithValue("CUSTOM_PARAM_P1", "raw1"))
-			Expect(nvParams).To(HaveKeyWithValue("CUSTOM_PARAM_P4", "raw4"))
-			Expect(nvParams).To(HaveKeyWithValue("CUSTOM_PARAM_NO_SUFFIX", "rawN"))
-			Expect(nvParams).NotTo(HaveKey("CUSTOM_PARAM_P5"))
 		})
-		It("should skip LINK_TYPE_Pn for ports firmware does not declare a slot for", func() {
-			mockConfigurationUtils.On("GetPCILinkSpeed", mock.Anything).Return(16, nil)
 
-			device := &v1alpha1.NicDevice{
-				Spec: v1alpha1.NicDeviceSpec{
-					Configuration: &v1alpha1.NicDeviceConfigurationSpec{
-						Template: &v1alpha1.ConfigurationTemplateSpec{
-							NumVfs:   0,
-							LinkType: consts.Ethernet,
-						},
-					},
-				},
-				Status: v1alpha1.NicDeviceStatus{
-					Ports: []v1alpha1.NicDevicePortSpec{
-						{PCI: "0000:03:00.0"},
-						{PCI: "0000:03:00.1"},
-						{PCI: "0000:03:00.2"},
-						{PCI: "0000:03:00.3"},
-					},
-				},
+		It("emits ATS_ENABLED=0 when GpuDirectOptimized is enabled", func() {
+			device := baseDevice(consts.Ethernet, 1)
+			device.Spec.Configuration.Template.PciPerformanceOptimized = &v1alpha1.PciPerformanceOptimizedSpec{Enabled: true, MaxAccOutRead: 1}
+			device.Spec.Configuration.Template.GpuDirectOptimized = &v1alpha1.GpuDirectOptimizedSpec{
+				Enabled: true,
+				Env:     consts.EnvBaremetal,
 			}
 
-			query := types.NewNvConfigQuery()
-			// Firmware exposes only P1 and P3, not P2 or P4.
-			query.DefaultConfig = map[string][]string{
-				"LINK_TYPE_P1": {"2"},
-				"LINK_TYPE_P3": {"2"},
-			}
-
-			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, query)
+			nvParams, err := validator.ConstructNvParamMapFromTemplate(device)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(nvParams).To(HaveKeyWithValue("LINK_TYPE_P1", consts.NvParamLinkTypeEthernet))
-			Expect(nvParams).To(HaveKeyWithValue("LINK_TYPE_P3", consts.NvParamLinkTypeEthernet))
-			Expect(nvParams).NotTo(HaveKey("LINK_TYPE_P2"))
-			Expect(nvParams).NotTo(HaveKey("LINK_TYPE_P4"))
+			Expect(nvParams).To(HaveKeyWithValue(consts.AtsEnabledParam, consts.NvParamFalse))
 		})
-		It("should report an error when LinkType cannot be changed and template differs from the actual status", func() {
-			mockConfigurationUtils.On("GetLinkType", mock.Anything).Return(consts.Ethernet)
-			mockConfigurationUtils.On("GetPCILinkSpeed", mock.Anything).Return(16, nil)
 
-			device := &v1alpha1.NicDevice{
-				Spec: v1alpha1.NicDeviceSpec{
-					Configuration: &v1alpha1.NicDeviceConfigurationSpec{
-						Template: &v1alpha1.ConfigurationTemplateSpec{
-							NumVfs:   0,
-							LinkType: consts.Infiniband,
-							PciPerformanceOptimized: &v1alpha1.PciPerformanceOptimizedSpec{
-								Enabled: true,
-							},
-						},
-					},
-				},
-				Status: v1alpha1.NicDeviceStatus{
-					Ports: []v1alpha1.NicDevicePortSpec{
-						{
-							PCI:              "0000:03:00.0",
-							NetworkInterface: "enp3s0f0np0",
-						},
-						{
-							PCI:              "0000:03:00.1",
-							NetworkInterface: "enp3s0f1np1",
-						},
-					},
-				},
+		It("returns an error when GpuDirectOptimized is enabled without PciPerformanceOptimized", func() {
+			device := baseDevice(consts.Ethernet, 1)
+			device.Spec.Configuration.Template.GpuDirectOptimized = &v1alpha1.GpuDirectOptimizedSpec{
+				Enabled: true,
+				Env:     consts.EnvBaremetal,
 			}
 
-			query := types.NewNvConfigQuery()
-
-			_, err := validator.ConstructNvParamMapFromTemplate(device, query)
-			Expect(err).To(MatchError("incorrect spec: device does not support link type change, wrong link type provided in the template, should be: Ethernet"))
+			_, err := validator.ConstructNvParamMapFromTemplate(device)
+			Expect(err).To(MatchError("incorrect spec: GpuDirectOptimized should only be enabled together with PciPerformanceOptimized"))
 		})
-		It("should not report an error when LinkType can be changed and template differs from the actual status", func() {
-			mockConfigurationUtils.On("GetLinkType", mock.Anything).Return(consts.Ethernet)
-			mockConfigurationUtils.On("GetPCILinkSpeed", mock.Anything).Return(16, nil)
 
-			device := &v1alpha1.NicDevice{
-				Spec: v1alpha1.NicDeviceSpec{
-					Configuration: &v1alpha1.NicDeviceConfigurationSpec{
-						Template: &v1alpha1.ConfigurationTemplateSpec{
-							NumVfs:   0,
-							LinkType: consts.Infiniband,
-							PciPerformanceOptimized: &v1alpha1.PciPerformanceOptimizedSpec{
-								Enabled: true,
-							},
-						},
-					},
-				},
-				Status: v1alpha1.NicDeviceStatus{
-					Ports: []v1alpha1.NicDevicePortSpec{
-						{
-							PCI:              "0000:03:00.0",
-							NetworkInterface: "enp3s0f0np0",
-						},
-						{
-							PCI:              "0000:03:00.1",
-							NetworkInterface: "enp3s0f1np1",
-						},
-					},
-				},
-			}
+		It("returns an error when RoceOptimized is enabled with linkType Infiniband", func() {
+			device := baseDevice(consts.Infiniband, 1)
+			device.Spec.Configuration.Template.RoceOptimized = &v1alpha1.RoceOptimizedSpec{Enabled: true}
 
-			defaultValues := map[string][]string{
-				consts.LinkTypeP1Param: {consts.Ethernet},
-			}
-			query := types.NewNvConfigQuery()
-			query.DefaultConfig = defaultValues
-
-			_, err := validator.ConstructNvParamMapFromTemplate(device, query)
-			Expect(err).NotTo(HaveOccurred())
-		})
-		It("should not report an error when LinkType cannot be changed and template matches the actual status", func() {
-			mockConfigurationUtils.On("GetLinkType", mock.Anything).Return(consts.Infiniband)
-			mockConfigurationUtils.On("GetPCILinkSpeed", mock.Anything).Return(16, nil)
-
-			device := &v1alpha1.NicDevice{
-				Spec: v1alpha1.NicDeviceSpec{
-					Configuration: &v1alpha1.NicDeviceConfigurationSpec{
-						Template: &v1alpha1.ConfigurationTemplateSpec{
-							NumVfs:   0,
-							LinkType: consts.Infiniband,
-							PciPerformanceOptimized: &v1alpha1.PciPerformanceOptimizedSpec{
-								Enabled: true,
-							},
-						},
-					},
-				},
-				Status: v1alpha1.NicDeviceStatus{
-					Ports: []v1alpha1.NicDevicePortSpec{
-						{
-							PCI:              "0000:03:00.0",
-							NetworkInterface: "enp3s0f0np0",
-						},
-						{
-							PCI:              "0000:03:00.1",
-							NetworkInterface: "enp3s0f1np1",
-						},
-					},
-				},
-			}
-
-			query := types.NewNvConfigQuery()
-
-			_, err := validator.ConstructNvParamMapFromTemplate(device, query)
-			Expect(err).NotTo(HaveOccurred())
-		})
-		It("should return an error when RoceOptimized is enabled with linkType Infiniband", func() {
-			mockConfigurationUtils.On("GetPCILinkSpeed", mock.Anything).Return(16, nil)
-
-			device := &v1alpha1.NicDevice{
-				Spec: v1alpha1.NicDeviceSpec{
-					Configuration: &v1alpha1.NicDeviceConfigurationSpec{
-						Template: &v1alpha1.ConfigurationTemplateSpec{
-							NumVfs:   0,
-							LinkType: consts.Infiniband,
-							RoceOptimized: &v1alpha1.RoceOptimizedSpec{
-								Enabled: true,
-							},
-						},
-					},
-				},
-				Status: v1alpha1.NicDeviceStatus{
-					Ports: []v1alpha1.NicDevicePortSpec{
-						{PCI: "0000:03:00.0"},
-					},
-				},
-			}
-
-			query := types.NewNvConfigQuery()
-
-			_, err := validator.ConstructNvParamMapFromTemplate(device, query)
+			_, err := validator.ConstructNvParamMapFromTemplate(device)
 			Expect(err).To(MatchError("incorrect spec: RoceOptimized settings can only be used with link type Ethernet"))
 		})
 
-		It("should take numeric values when both numeric values and string aliases are present in nv config query", func() {
-			device := &v1alpha1.NicDevice{
-				Spec: v1alpha1.NicDeviceSpec{
-					Configuration: &v1alpha1.NicDeviceConfigurationSpec{
-						Template: &v1alpha1.ConfigurationTemplateSpec{
-							NumVfs:   0,
-							LinkType: consts.Ethernet,
-							PciPerformanceOptimized: &v1alpha1.PciPerformanceOptimizedSpec{
-								Enabled: true,
-							},
-						},
-					},
-				},
-				Status: v1alpha1.NicDeviceStatus{
-					Ports: []v1alpha1.NicDevicePortSpec{
-						{PCI: "0000:03:00.0"},
-						{PCI: "0000:03:00.1"},
-					},
-				},
+		It("passes rawNvConfig entries through and filters _Pn overrides beyond portCount", func() {
+			device := baseDevice(consts.Ethernet, 1)
+			device.Spec.Configuration.Template.RawNvConfig = []v1alpha1.NvConfigParam{
+				{Name: "TEST_P1", Value: "keep"},
+				{Name: "TEST_P2", Value: "drop"}, // beyond portCount
+				{Name: "GENERIC", Value: "keep"},
 			}
 
-			defaultValues := map[string][]string{
-				consts.MaxAccOutReadParam: {"testMaxAccOutRead", "0"},
-			}
-			currentValues := map[string][]string{
-				consts.AdvancedPCISettingsParam: {"testAdvancedPCISettings", "1"},
-			}
-			query := types.NewNvConfigQuery()
-			query.DefaultConfig = defaultValues
-			query.CurrentConfig = currentValues
-
-			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, query)
+			nvParams, err := validator.ConstructNvParamMapFromTemplate(device)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(nvParams).To(HaveKeyWithValue(consts.SriovEnabledParam, consts.NvParamFalse))
-			Expect(nvParams).To(HaveKeyWithValue(consts.SriovNumOfVfsParam, "0"))
-			Expect(nvParams).To(HaveKeyWithValue(consts.MaxAccOutReadParam, "0"))
+			Expect(nvParams).To(HaveKeyWithValue("TEST_P1", "keep"))
+			Expect(nvParams).To(HaveKeyWithValue("GENERIC", "keep"))
+			Expect(nvParams).NotTo(HaveKey("TEST_P2"))
+		})
+	})
+
+	Describe("ResolveFactoryDefaults", func() {
+		It("replaces sentinels with the numeric default from DefaultConfig", func() {
+			desired := map[string]string{
+				consts.AtsEnabledParam:       consts.NvParamFactoryDefault,
+				consts.RoceCcPrioMaskP1Param: consts.NvParamFactoryDefault,
+			}
+			portConfig := types.NewNvConfigQuery()
+			// Bracketed values store [alias, numeric]; numeric slot is last.
+			portConfig.DefaultConfig[consts.AtsEnabledParam] = []string{"false", "0"}
+			portConfig.DefaultConfig[consts.RoceCcPrioMaskP1Param] = []string{"128"}
+
+			resolved := validator.ResolveFactoryDefaults(desired, portConfig)
+			Expect(resolved).To(HaveKeyWithValue(consts.AtsEnabledParam, "0"))
+			Expect(resolved).To(HaveKeyWithValue(consts.RoceCcPrioMaskP1Param, "128"))
+		})
+
+		It("passes concrete values through unchanged", func() {
+			desired := map[string]string{
+				consts.SriovEnabledParam:  consts.NvParamTrue,
+				consts.SriovNumOfVfsParam: "16",
+				consts.LinkTypeP1Param:    consts.NvParamLinkTypeEthernet,
+			}
+			portConfig := types.NewNvConfigQuery()
+
+			resolved := validator.ResolveFactoryDefaults(desired, portConfig)
+			Expect(resolved).To(Equal(desired))
+		})
+
+		It("drops sentinel entries whose names are not in DefaultConfig", func() {
+			desired := map[string]string{
+				consts.AtsEnabledParam:   consts.NvParamFactoryDefault,
+				consts.SriovEnabledParam: consts.NvParamFalse,
+			}
+			portConfig := types.NewNvConfigQuery()
+			// DefaultConfig does not contain AtsEnabledParam — FW doesn't expose it.
+
+			resolved := validator.ResolveFactoryDefaults(desired, portConfig)
+			Expect(resolved).NotTo(HaveKey(consts.AtsEnabledParam))
+			Expect(resolved).To(HaveKeyWithValue(consts.SriovEnabledParam, consts.NvParamFalse))
+		})
+
+		It("does not mutate the input map", func() {
+			desired := map[string]string{
+				consts.AtsEnabledParam: consts.NvParamFactoryDefault,
+			}
+			portConfig := types.NewNvConfigQuery()
+			portConfig.DefaultConfig[consts.AtsEnabledParam] = []string{"0"}
+
+			_ = validator.ResolveFactoryDefaults(desired, portConfig)
+			Expect(desired).To(HaveKeyWithValue(consts.AtsEnabledParam, consts.NvParamFactoryDefault))
 		})
 	})
 

--- a/pkg/configuration/manager.go
+++ b/pkg/configuration/manager.go
@@ -107,15 +107,14 @@ func (h configurationManager) ValidateDeviceNvSpec(ctx context.Context, device *
 		return false, false, nil
 	}
 
-	nvConfigsForPorts, err := h.queryNvConfigs(ctx, device)
-	if err != nil {
-		log.Log.Error(err, "failed to query nv configs", "device", device.Name)
-		return false, false, err
-	}
-	firstPortPCIAddr := device.Status.Ports[0].PCI
-	firstPortConfig := nvConfigsForPorts[firstPortPCIAddr]
-
 	if device.Spec.Configuration.ResetToDefault {
+		// ResetToDefault needs every key for the reflect.DeepEqual compare in
+		// ValidateResetToDefault; pass nil for a full chip walk.
+		nvConfigsForPorts, err := h.queryNvConfigs(ctx, device, nil)
+		if err != nil {
+			log.Log.Error(err, "failed to query nv configs", "device", device.Name)
+			return false, false, err
+		}
 		resetNeeded := false
 		rebootNeeded := false
 		for _, nvConfig := range nvConfigsForPorts {
@@ -130,22 +129,32 @@ func (h configurationManager) ValidateDeviceNvSpec(ctx context.Context, device *
 		return resetNeeded, rebootNeeded, nil
 	}
 
-	// ConstructNvParamMapFromTemplate only uses the given nvConfig for a few default values, so we can use any port's nvConfig
-	desiredConfig, err := h.configValidation.ConstructNvParamMapFromTemplate(device, firstPortConfig)
+	desiredConfig, err := h.configValidation.ConstructNvParamMapFromTemplate(device)
 	if err != nil {
 		log.Log.Error(err, "failed to calculate desired nvconfig parameters", "device", device.Name)
 		return false, false, err
 	}
 
+	nvConfigsForPorts, err := h.queryNvConfigs(ctx, device, queryNamesForDesired(desiredConfig))
+	if err != nil {
+		log.Log.Error(err, "failed to query nv configs", "device", device.Name)
+		return false, false, err
+	}
+	firstPortConfig := nvConfigsForPorts[device.Status.Ports[0].PCI]
+
+	// Replace sentinel entries with the firmware's factory defaults. Must happen
+	// before the compare loop — sentinel strings are not valid mlxconfig values.
+	resolvedDesired := h.configValidation.ResolveFactoryDefaults(desiredConfig, firstPortConfig)
+
 	configUpdateNeeded := false
 	rebootNeeded := false
 
-	// If ADVANCED_PCI_SETTINGS are enabled in current config, unknown parameters are treated as spec error
-	// ADVANCED_PCI_SETTINGS param value is shared across all ports, so we can use any port's nvConfig for validation
+	// If ADVANCED_PCI_SETTINGS are enabled in current config, unknown parameters are treated as spec error.
+	// The param is always included in the scoped query (see queryNamesForDesired).
 	advancedPciSettingsEnabled := h.configValidation.AdvancedPCISettingsEnabled(firstPortConfig)
 
 	for _, nvConfig := range nvConfigsForPorts {
-		for parameter, desiredValue := range desiredConfig {
+		for parameter, desiredValue := range resolvedDesired {
 			currentValues, foundInCurrent := nvConfig.CurrentConfig[parameter]
 			nextValues, foundInNextBoot := nvConfig.NextBootConfig[parameter]
 			if advancedPciSettingsEnabled && !foundInCurrent {
@@ -184,7 +193,27 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 		return h.applySpectrumXNVConfiguration(ctx, device)
 	}
 
-	nvConfigsForPorts, err := h.queryNvConfigs(ctx, device)
+	if device.Spec.Configuration.ResetToDefault {
+		nvConfigsForPorts, err := h.queryNvConfigs(ctx, device, nil)
+		if err != nil {
+			log.Log.Error(err, "failed to query nv configs", "device", device.Name)
+			return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
+		}
+		firstPortPCIAddr := device.Status.Ports[0].PCI
+		return h.applyResetToDefault(device, firstPortPCIAddr, nvConfigsForPorts[firstPortPCIAddr])
+	}
+
+	if device.Spec.Configuration.Template == nil {
+		return &types.ConfigurationApplyResult{Status: types.ApplyStatusNothingToDo}, nil
+	}
+
+	desiredConfig, err := h.configValidation.ConstructNvParamMapFromTemplate(device)
+	if err != nil {
+		log.Log.Error(err, "failed to calculate desired nvconfig parameters", "device", device.Name)
+		return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
+	}
+
+	nvConfigsForPorts, err := h.queryNvConfigs(ctx, device, queryNamesForDesired(desiredConfig))
 	if err != nil {
 		log.Log.Error(err, "failed to query nv configs", "device", device.Name)
 		return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
@@ -192,17 +221,14 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 	firstPortPCIAddr := device.Status.Ports[0].PCI
 	firstPortConfig := nvConfigsForPorts[firstPortPCIAddr]
 
-	if device.Spec.Configuration.ResetToDefault {
-		return h.applyResetToDefault(device, firstPortPCIAddr, firstPortConfig)
-	}
-
-	if device.Spec.Configuration.Template == nil {
-		return &types.ConfigurationApplyResult{Status: types.ApplyStatusNothingToDo}, nil
-	}
-
-	// if ADVANCED_PCI_SETTINGS == 0, not all nv config parameters are available for configuration
-	// we enable this parameter first to unlock them
-	if !h.configValidation.AdvancedPCISettingsEnabled(firstPortConfig) {
+	// Two-phase ADVANCED_PCI_SETTINGS unlock: if the template wants it enabled but
+	// the device currently has it disabled, params hidden behind it (e.g.
+	// MAX_ACC_OUT_READ) won't be settable in the same batch. Enable it first, do a
+	// soft FW reset (or defer to reboot), then re-query and continue the normal
+	// apply flow. Gated on both "desired wants it on" and "current has it off" so
+	// we don't trigger an unnecessary reset when the device is already unlocked.
+	if desiredConfig[consts.AdvancedPCISettingsParam] == consts.NvParamTrue &&
+		!h.configValidation.AdvancedPCISettingsEnabled(firstPortConfig) {
 		log.Log.V(2).Info("AdvancedPciSettings not enabled, fw reset required", "device", device.Name)
 		err := h.nvConfigUtils.SetNvConfigParameter(firstPortPCIAddr, consts.AdvancedPCISettingsParam, consts.NvParamTrue)
 		if err != nil {
@@ -214,17 +240,15 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 			err = h.ResetNicFirmware(ctx, device)
 			if err != nil {
 				log.Log.Error(err, "Failed to reset NIC firmware, reboot required to apply ADVANCED_PCI_SETTINGS", "device", device.Name)
-				// We try to perform FW reset after setting the ADVANCED_PCI_SETTINGS to save us a reboot
-				// However, if the soft FW reset fails for some reason, we need to perform a reboot to unlock
-				// all the nv config parameters
+				// Soft reset failed; fall back to a reboot to unlock the hidden params.
 				return &types.ConfigurationApplyResult{Status: types.ApplyStatusSuccess, RebootRequired: true}, nil
 			}
 		} else {
 			return &types.ConfigurationApplyResult{Status: types.ApplyStatusSuccess, RebootRequired: true}, nil
 		}
 
-		// Query nv config again, additional options could become available
-		nvConfigsForPorts, err = h.queryNvConfigs(ctx, device)
+		// Re-query scoped — previously-hidden params are now visible.
+		nvConfigsForPorts, err = h.queryNvConfigs(ctx, device, queryNamesForDesired(desiredConfig))
 		if err != nil {
 			log.Log.Error(err, "failed to query nv configs", "device", device.Name)
 			return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
@@ -232,11 +256,8 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 		firstPortConfig = nvConfigsForPorts[firstPortPCIAddr]
 	}
 
-	desiredConfig, err := h.configValidation.ConstructNvParamMapFromTemplate(device, firstPortConfig)
-	if err != nil {
-		log.Log.Error(err, "failed to calculate desired nvconfig parameters", "device", device.Name)
-		return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
-	}
+	// Resolve sentinel entries to the firmware's factory-default values.
+	resolvedDesired := h.configValidation.ResolveFactoryDefaults(desiredConfig, firstPortConfig)
 
 	anyParamsApplied := false
 	hasUnsupportedParams := false
@@ -244,14 +265,13 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 	for pciAddr, nvConfig := range nvConfigsForPorts {
 		supportedParams := map[string]string{}
 
-		for param, value := range desiredConfig {
+		for param, value := range resolvedDesired {
 			nextValues, found := nvConfig.NextBootConfig[param]
 			if !found {
 				log.Log.Info("Parameter not found in NextBootConfig, skipping", "device", device.Name, "param", param)
 				hasUnsupportedParams = true
 				continue
 			}
-
 			if !slices.Contains(nextValues, value) {
 				supportedParams[param] = value
 			}
@@ -493,17 +513,36 @@ func (h configurationManager) ResetNicFirmware(ctx context.Context, device *v1al
 	return nil
 }
 
-func (h configurationManager) queryNvConfigs(ctx context.Context, device *v1alpha1.NicDevice) (map[string]types.NvConfigQuery, error) {
+// queryNvConfigs queries nv config for every port on the device. Passing nil for
+// names triggers a full chip walk (needed by ResetToDefault's deep compare); a
+// non-nil slice scopes the query to just those names.
+func (h configurationManager) queryNvConfigs(ctx context.Context, device *v1alpha1.NicDevice, names []string) (map[string]types.NvConfigQuery, error) {
 	nvConfigs := make(map[string]types.NvConfigQuery)
 	for _, port := range device.Status.Ports {
 		pciAddr := port.PCI
-		nvConfig, err := h.nvConfigUtils.QueryNvConfig(ctx, pciAddr, nil)
+		nvConfig, err := h.nvConfigUtils.QueryNvConfig(ctx, pciAddr, names)
 		if err != nil {
 			return nil, err
 		}
 		nvConfigs[pciAddr] = nvConfig
 	}
 	return nvConfigs, nil
+}
+
+// queryNamesForDesired returns the set of NV-config parameter names to scope a
+// mlxconfig query to. Includes every key in the desired map (so validation can
+// compare current/next-boot against desired) plus ADVANCED_PCI_SETTINGS so the
+// unsupported-param gate in ValidateDeviceNvSpec keeps working regardless of
+// whether the desired map itself includes it.
+func queryNamesForDesired(desired map[string]string) []string {
+	names := make([]string, 0, len(desired)+1)
+	for k := range desired {
+		names = append(names, k)
+	}
+	if _, ok := desired[consts.AdvancedPCISettingsParam]; !ok {
+		names = append(names, consts.AdvancedPCISettingsParam)
+	}
+	return names
 }
 
 // getRawNvConfigParams extracts rawNvConfig params from the device template,

--- a/pkg/configuration/manager_test.go
+++ b/pkg/configuration/manager_test.go
@@ -50,12 +50,19 @@ var _ = Describe("ConfigurationManager", func() {
 		BeforeEach(func() {
 			mockHostUtils = mocks.ConfigurationUtils{}
 			mockConfigValidation = mocks.ConfigValidation{}
+			// Passthrough by default — individual tests can override with a specific
+			// expectation when they care about sentinel resolution.
+			mockConfigValidation.On("ResolveFactoryDefaults", mock.Anything, mock.Anything).
+				Return(func(desired map[string]string, _ types.NvConfigQuery) map[string]string { return desired }).Maybe()
 			mockNVConfigUtils = nvconfigmocks.NewNVConfigUtils(GinkgoT())
 			manager = configurationManager{
 				configurationUtils: &mockHostUtils,
 				configValidation:   &mockConfigValidation,
 				nvConfigUtils:      mockNVConfigUtils,
 			}
+			// queryNvConfigs asks for the scoped name list when ResetToDefault is false.
+			// Tests don't care which names get used (QueryNvConfig mocks accept mock.Anything),
+			// so stub a no-op return and mark it optional for ResetToDefault-branch tests.
 			ctx = context.TODO()
 
 			device = &v1alpha1.NicDevice{
@@ -77,7 +84,9 @@ var _ = Describe("ConfigurationManager", func() {
 			Context("when QueryNvConfig returns an error", func() {
 				It("should return false, false, and the error", func() {
 					queryErr := errors.New("failed to query nv config")
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device).
+						Return(map[string]string{"param1": "value1"}, nil)
+					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, mock.Anything).
 						Return(types.NewNvConfigQuery(), queryErr)
 
 					configUpdate, reboot, err := manager.ValidateDeviceNvSpec(ctx, device)
@@ -101,7 +110,7 @@ var _ = Describe("ConfigurationManager", func() {
 						DefaultConfig:  map[string][]string{"param1": {"default1"}},
 					}
 
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, mock.Anything).
 						Return(nvConfig, nil)
 					mockConfigValidation.On("ValidateResetToDefault", nvConfig).
 						Return(true, false, nil)
@@ -123,7 +132,7 @@ var _ = Describe("ConfigurationManager", func() {
 					}
 					validationErr := errors.New("validation failed")
 
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, mock.Anything).
 						Return(nvConfig, nil)
 					mockConfigValidation.On("ValidateResetToDefault", nvConfig).
 						Return(false, false, validationErr)
@@ -140,16 +149,9 @@ var _ = Describe("ConfigurationManager", func() {
 
 			Context("when ConstructNvParamMapFromTemplate returns an error", func() {
 				It("should return false, false, and the error", func() {
-					nvConfig := types.NvConfigQuery{
-						CurrentConfig:  map[string][]string{},
-						NextBootConfig: map[string][]string{},
-						DefaultConfig:  map[string][]string{},
-					}
 					constructErr := errors.New("failed to construct desired config")
 
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
-						Return(nvConfig, nil)
-					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device).
 						Return(nil, constructErr)
 
 					configUpdate, reboot, err := manager.ValidateDeviceNvSpec(ctx, device)
@@ -157,7 +159,6 @@ var _ = Describe("ConfigurationManager", func() {
 					Expect(reboot).To(BeFalse())
 					Expect(err).To(MatchError(constructErr))
 
-					mockNVConfigUtils.AssertExpectations(GinkgoT())
 					mockConfigValidation.AssertExpectations(GinkgoT())
 				})
 			})
@@ -172,12 +173,12 @@ var _ = Describe("ConfigurationManager", func() {
 					}
 					desiredConfig := map[string]string{"param1": "value1", "param2": "value2"}
 
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, mock.Anything).
 						Return(nvConfig, nil)
-					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device).
 						Return(desiredConfig, nil)
 					mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-						Return(false)
+						Return(false).Maybe()
 
 					configUpdate, reboot, err := manager.ValidateDeviceNvSpec(ctx, device)
 					Expect(configUpdate).To(BeFalse())
@@ -199,12 +200,12 @@ var _ = Describe("ConfigurationManager", func() {
 					}
 					desiredConfig := map[string]string{"param1": "value1", "param2": "value2"}
 
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, mock.Anything).
 						Return(nvConfig, nil)
-					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device).
 						Return(desiredConfig, nil)
 					mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-						Return(false)
+						Return(false).Maybe()
 
 					configUpdate, reboot, err := manager.ValidateDeviceNvSpec(ctx, device)
 					Expect(configUpdate).To(BeFalse())
@@ -226,12 +227,12 @@ var _ = Describe("ConfigurationManager", func() {
 					}
 					desiredConfig := map[string]string{"param1": "value1", "param2": "value2"}
 
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, mock.Anything).
 						Return(nvConfig, nil)
-					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device).
 						Return(desiredConfig, nil)
 					mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-						Return(false)
+						Return(false).Maybe()
 
 					configUpdate, reboot, err := manager.ValidateDeviceNvSpec(ctx, device)
 					Expect(configUpdate).To(BeTrue())
@@ -252,12 +253,12 @@ var _ = Describe("ConfigurationManager", func() {
 					}
 					desiredConfig := map[string]string{"param1": "value1", "param2": "value2"}
 
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, mock.Anything).
 						Return(nvConfig, nil)
-					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device).
 						Return(desiredConfig, nil)
 					mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-						Return(true)
+						Return(true).Maybe()
 
 					expectedErr := types.IncorrectSpecError(
 						fmt.Sprintf("Parameter %s unsupported for device %s", "param1", device.Name))
@@ -281,12 +282,12 @@ var _ = Describe("ConfigurationManager", func() {
 					}
 					desiredConfig := map[string]string{"param1": "value1", "param2": "2"}
 
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, mock.Anything).
 						Return(nvConfig, nil)
-					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device).
 						Return(desiredConfig, nil)
 					mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-						Return(true)
+						Return(true).Maybe()
 
 					configUpdate, reboot, err := manager.ValidateDeviceNvSpec(ctx, device)
 					Expect(configUpdate).To(BeFalse())
@@ -304,12 +305,12 @@ var _ = Describe("ConfigurationManager", func() {
 					}
 					desiredConfig := map[string]string{"param1": "VaLuE1", "param2": "valUE2"}
 
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, mock.Anything).
 						Return(nvConfig, nil)
-					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device).
 						Return(desiredConfig, nil)
 					mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-						Return(true)
+						Return(true).Maybe()
 
 					configUpdate, reboot, err := manager.ValidateDeviceNvSpec(ctx, device)
 					Expect(configUpdate).To(BeFalse())
@@ -327,12 +328,12 @@ var _ = Describe("ConfigurationManager", func() {
 					}
 					desiredConfig := map[string]string{"param1": "value3", "param2": "val4"}
 
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, mock.Anything).
 						Return(nvConfig, nil)
-					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device).
 						Return(desiredConfig, nil)
 					mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-						Return(true)
+						Return(true).Maybe()
 
 					configUpdate, reboot, err := manager.ValidateDeviceNvSpec(ctx, device)
 					Expect(configUpdate).To(BeTrue())
@@ -362,10 +363,10 @@ var _ = Describe("ConfigurationManager", func() {
 						DefaultConfig:  map[string][]string{},
 					}
 
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig0, nil)
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress2, []string(nil)).Return(nvConfig1, nil)
-					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig0).Return(map[string]string{"TRACER_ENABLED": "1"}, nil)
-					mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig0).Return(false)
+					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, mock.Anything).Return(nvConfig0, nil)
+					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress2, mock.Anything).Return(nvConfig1, nil)
+					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device).Return(map[string]string{"TRACER_ENABLED": "1"}, nil)
+					mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig0).Return(false).Maybe()
 
 					configUpdate, reboot, err := manager.ValidateDeviceNvSpec(ctx, device)
 					Expect(err).To(BeNil())
@@ -390,10 +391,10 @@ var _ = Describe("ConfigurationManager", func() {
 						DefaultConfig:  map[string][]string{},
 					}
 
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig0, nil)
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress2, []string(nil)).Return(nvConfig1, nil)
-					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig0).Return(map[string]string{"TRACER_ENABLED": "1"}, nil)
-					mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig0).Return(false)
+					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, mock.Anything).Return(nvConfig0, nil)
+					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress2, mock.Anything).Return(nvConfig1, nil)
+					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device).Return(map[string]string{"TRACER_ENABLED": "1"}, nil)
+					mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig0).Return(false).Maybe()
 
 					configUpdate, reboot, err := manager.ValidateDeviceNvSpec(ctx, device)
 					Expect(err).To(BeNil())
@@ -418,10 +419,10 @@ var _ = Describe("ConfigurationManager", func() {
 						DefaultConfig:  map[string][]string{},
 					}
 
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig0, nil)
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress2, []string(nil)).Return(nvConfig1, nil)
-					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig0).Return(map[string]string{"TRACER_ENABLED": "1"}, nil)
-					mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig0).Return(true)
+					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, mock.Anything).Return(nvConfig0, nil)
+					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress2, mock.Anything).Return(nvConfig1, nil)
+					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device).Return(map[string]string{"TRACER_ENABLED": "1"}, nil)
+					mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig0).Return(true).Maybe()
 
 					configUpdate, reboot, err := manager.ValidateDeviceNvSpec(ctx, device)
 					Expect(configUpdate).To(BeFalse())
@@ -447,6 +448,10 @@ var _ = Describe("ConfigurationManager", func() {
 		BeforeEach(func() {
 			mockHostUtils = mocks.ConfigurationUtils{}
 			mockConfigValidation = mocks.ConfigValidation{}
+			// Passthrough by default — individual tests can override with a specific
+			// expectation when they care about sentinel resolution.
+			mockConfigValidation.On("ResolveFactoryDefaults", mock.Anything, mock.Anything).
+				Return(func(desired map[string]string, _ types.NvConfigQuery) map[string]string { return desired }).Maybe()
 			mockNV = nvconfigmocks.NewNVConfigUtils(GinkgoT())
 			manager = configurationManager{
 				configurationUtils: &mockHostUtils,
@@ -482,7 +487,7 @@ var _ = Describe("ConfigurationManager", func() {
 						NextBootConfig: map[string][]string{"param1": {"value1"}},
 						DefaultConfig:  map[string][]string{"param1": {"default1"}},
 					}
-					mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+					mockNV.On("QueryNvConfig", ctx, pciAddress, mock.Anything).
 						Return(nvConfig, nil)
 
 					mockNV.On("ResetNvConfig", pciAddress).Return(nil)
@@ -504,7 +509,7 @@ var _ = Describe("ConfigurationManager", func() {
 						NextBootConfig: map[string][]string{consts.BF3OperationModeParam: {consts.NvParamBF3DpuMode}},
 						DefaultConfig:  map[string][]string{consts.BF3OperationModeParam: {consts.NvParamBF3DpuMode}},
 					}
-					mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+					mockNV.On("QueryNvConfig", ctx, pciAddress, mock.Anything).
 						Return(nvConfig, nil)
 
 					mockNV.On("ResetNvConfig", pciAddress).Return(nil)
@@ -529,7 +534,7 @@ var _ = Describe("ConfigurationManager", func() {
 						NextBootConfig: map[string][]string{"param1": {"value1"}},
 						DefaultConfig:  map[string][]string{"param1": {"default1"}},
 					}
-					mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+					mockNV.On("QueryNvConfig", ctx, pciAddress, mock.Anything).
 						Return(nvConfig, nil)
 
 					resetErr := errors.New("failed to reset nv config")
@@ -548,7 +553,7 @@ var _ = Describe("ConfigurationManager", func() {
 						NextBootConfig: map[string][]string{"param1": {"value1"}},
 						DefaultConfig:  map[string][]string{"param1": {"default1"}},
 					}
-					mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+					mockNV.On("QueryNvConfig", ctx, pciAddress, mock.Anything).
 						Return(nvConfig, nil)
 
 					mockNV.On("ResetNvConfig", pciAddress).Return(nil)
@@ -569,7 +574,9 @@ var _ = Describe("ConfigurationManager", func() {
 				Context("when QueryNvConfig returns an error", func() {
 					It("should return false and the error", func() {
 						queryErr := errors.New("failed to query nv config")
-						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(types.NewNvConfigQuery(), queryErr)
+						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device).
+							Return(map[string]string{"param1": "value1"}, nil)
+						mockNV.On("QueryNvConfig", ctx, pciAddress, mock.Anything).Return(types.NewNvConfigQuery(), queryErr)
 
 						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 						Expect(result.RebootRequired).To(BeFalse())
@@ -579,110 +586,7 @@ var _ = Describe("ConfigurationManager", func() {
 					})
 				})
 
-				Context("when AdvancedPCISettingsEnabled is false", func() {
-					It("should set AdvancedPCISettingsParam and reset NIC firmware successfully", func() {
-						nvConfig := types.NvConfigQuery{
-							CurrentConfig:  map[string][]string{"param1": {"value1"}},
-							NextBootConfig: map[string][]string{"param1": {"value1"}},
-							DefaultConfig:  map[string][]string{"param1": {"default1"}},
-						}
-						desiredConfig := map[string]string{"param1": "value1"}
-
-						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
-							Return(nvConfig, nil)
-						mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-							Return(false)
-						mockNV.
-							On("SetNvConfigParameter", pciAddress, consts.AdvancedPCISettingsParam, consts.NvParamTrue).
-							Return(nil)
-						mockHostUtils.On("ResetNicFirmware", mock.Anything, pciAddress).
-							Return(nil)
-						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
-							Return(nvConfig, nil)
-						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
-							Return(desiredConfig, nil)
-
-						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
-						Expect(result.RebootRequired).To(BeFalse())
-						Expect(err).To(BeNil())
-
-						mockNV.AssertExpectations(GinkgoT())
-						mockConfigValidation.AssertExpectations(GinkgoT())
-					})
-
-					It("should return error if SetNvConfigParameter fails", func() {
-						nvConfig := types.NvConfigQuery{
-							CurrentConfig:  map[string][]string{"param1": {"value1"}},
-							NextBootConfig: map[string][]string{"param1": {"value1"}},
-							DefaultConfig:  map[string][]string{"param1": {"default1"}},
-						}
-						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig, nil)
-						mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-							Return(false)
-						setParamErr := errors.New("failed to set nv config parameter")
-						mockNV.
-							On("SetNvConfigParameter", pciAddress, consts.AdvancedPCISettingsParam, consts.NvParamTrue).
-							Return(setParamErr)
-
-						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
-						Expect(result.RebootRequired).To(BeFalse())
-						Expect(err).To(MatchError(setParamErr))
-
-						mockNV.AssertExpectations(GinkgoT())
-						mockConfigValidation.AssertExpectations(GinkgoT())
-					})
-
-					It("should request reboot if ResetNicFirmware fails", func() {
-						nvConfig := types.NvConfigQuery{
-							CurrentConfig:  map[string][]string{"param1": {"value1"}},
-							NextBootConfig: map[string][]string{"param1": {"value1"}},
-							DefaultConfig:  map[string][]string{"param1": {"default1"}},
-						}
-						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig, nil)
-						mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-							Return(false)
-						mockNV.On("SetNvConfigParameter", pciAddress, consts.AdvancedPCISettingsParam, consts.NvParamTrue).
-							Return(nil)
-						resetFirmwareErr := errors.New("failed to reset NIC firmware")
-						mockHostUtils.On("ResetNicFirmware", mock.Anything, pciAddress).Return(resetFirmwareErr)
-
-						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
-						Expect(result.RebootRequired).To(BeTrue())
-						Expect(err).To(BeNil())
-
-						mockNV.AssertExpectations(GinkgoT())
-						mockConfigValidation.AssertExpectations(GinkgoT())
-					})
-
-					It("should return error if second QueryNvConfig fails", func() {
-						nvConfig := types.NvConfigQuery{
-							CurrentConfig:  map[string][]string{"param1": {"value1"}},
-							NextBootConfig: map[string][]string{"param1": {"value1"}},
-							DefaultConfig:  map[string][]string{"param1": {"default1"}},
-						}
-
-						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
-							Return(nvConfig, nil).Times(1)
-						mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-							Return(false)
-						mockNV.On("SetNvConfigParameter", pciAddress, consts.AdvancedPCISettingsParam, consts.NvParamTrue).
-							Return(nil)
-						mockHostUtils.On("ResetNicFirmware", mock.Anything, pciAddress).
-							Return(nil)
-						secondQueryErr := errors.New("failed to query nv config again")
-						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
-							Return(types.NewNvConfigQuery(), secondQueryErr)
-
-						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
-						Expect(result.RebootRequired).To(BeFalse())
-						Expect(err).To(MatchError(secondQueryErr))
-
-						mockNV.AssertExpectations(GinkgoT())
-						mockConfigValidation.AssertExpectations(GinkgoT())
-					})
-				})
-
-				Context("when AdvancedPCISettingsEnabled is true", func() {
+				Context("when template is applied", func() {
 					It("should construct desiredConfig and apply no changes if desiredConfig matches NextBootConfig", func() {
 						nvConfig := types.NvConfigQuery{
 							CurrentConfig:  map[string][]string{"param1": {"value1"}},
@@ -691,11 +595,11 @@ var _ = Describe("ConfigurationManager", func() {
 						}
 						desiredConfig := map[string]string{"param1": "value1"}
 
-						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+						mockNV.On("QueryNvConfig", ctx, pciAddress, mock.Anything).
 							Return(nvConfig, nil)
 						mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-							Return(true)
-						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+							Return(true).Maybe()
+						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device).
 							Return(desiredConfig, nil)
 
 						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
@@ -714,11 +618,11 @@ var _ = Describe("ConfigurationManager", func() {
 						}
 						desiredConfig := map[string]string{"param1": "value2"}
 
-						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+						mockNV.On("QueryNvConfig", ctx, pciAddress, mock.Anything).
 							Return(nvConfig, nil)
 						mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-							Return(true)
-						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+							Return(true).Maybe()
+						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device).
 							Return(desiredConfig, nil)
 						mockNV.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"param1": "value2"}, false).
 							Return(nil)
@@ -732,25 +636,15 @@ var _ = Describe("ConfigurationManager", func() {
 					})
 
 					It("should return error if ConstructNvParamMapFromTemplate fails", func() {
-						nvConfig := types.NvConfigQuery{
-							CurrentConfig:  map[string][]string{"param1": {"value1"}},
-							NextBootConfig: map[string][]string{"param1": {"value1"}},
-							DefaultConfig:  map[string][]string{"param1": {"default1"}},
-						}
 						constructErr := errors.New("failed to construct desired config")
 
-						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
-							Return(nvConfig, nil)
-						mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-							Return(true)
-						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device).
 							Return(nil, constructErr)
 
 						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 						Expect(result.RebootRequired).To(BeFalse())
 						Expect(err).To(MatchError(constructErr))
 
-						mockNV.AssertExpectations(GinkgoT())
 						mockConfigValidation.AssertExpectations(GinkgoT())
 					})
 
@@ -762,11 +656,11 @@ var _ = Describe("ConfigurationManager", func() {
 						}
 						desiredConfig := map[string]string{"param1": "value1", "param2": "value2"}
 
-						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+						mockNV.On("QueryNvConfig", ctx, pciAddress, mock.Anything).
 							Return(nvConfig, nil)
 						mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-							Return(true)
-						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+							Return(true).Maybe()
+						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device).
 							Return(desiredConfig, nil)
 
 						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
@@ -786,11 +680,11 @@ var _ = Describe("ConfigurationManager", func() {
 						}
 						desiredConfig := map[string]string{"param1": "value3"}
 
-						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+						mockNV.On("QueryNvConfig", ctx, pciAddress, mock.Anything).
 							Return(nvConfig, nil)
 						mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-							Return(true)
-						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+							Return(true).Maybe()
+						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device).
 							Return(desiredConfig, nil)
 						setParamErr := errors.New("failed to set param1")
 						mockNV.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"param1": "value3"}, false).
@@ -821,10 +715,10 @@ var _ = Describe("ConfigurationManager", func() {
 							DefaultConfig:  map[string][]string{},
 						}
 
-						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig0, nil)
-						mockNV.On("QueryNvConfig", ctx, pciAddress2, []string(nil)).Return(nvConfig1, nil)
-						mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig0).Return(true)
-						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig0).Return(map[string]string{"TRACER_ENABLED": "1"}, nil)
+						mockNV.On("QueryNvConfig", ctx, pciAddress, mock.Anything).Return(nvConfig0, nil)
+						mockNV.On("QueryNvConfig", ctx, pciAddress2, mock.Anything).Return(nvConfig1, nil)
+						mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig0).Return(true).Maybe()
+						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device).Return(map[string]string{"TRACER_ENABLED": "1"}, nil)
 						// Only port2 should be updated
 						mockNV.On("SetNvConfigParametersBatch", pciAddress2, map[string]string{"TRACER_ENABLED": "1"}, false).Return(nil)
 
@@ -850,10 +744,10 @@ var _ = Describe("ConfigurationManager", func() {
 							DefaultConfig:  map[string][]string{},
 						}
 
-						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig0, nil)
-						mockNV.On("QueryNvConfig", ctx, pciAddress2, []string(nil)).Return(nvConfig1, nil)
-						mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig0).Return(true)
-						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig0).Return(map[string]string{"TRACER_ENABLED": "1"}, nil)
+						mockNV.On("QueryNvConfig", ctx, pciAddress, mock.Anything).Return(nvConfig0, nil)
+						mockNV.On("QueryNvConfig", ctx, pciAddress2, mock.Anything).Return(nvConfig1, nil)
+						mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig0).Return(true).Maybe()
+						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device).Return(map[string]string{"TRACER_ENABLED": "1"}, nil)
 
 						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 						Expect(result.RebootRequired).To(BeFalse())
@@ -875,11 +769,11 @@ var _ = Describe("ConfigurationManager", func() {
 					}
 					desiredConfig := map[string]string{"param1": "newValue3", "param2": "newValue3"}
 
-					mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+					mockNV.On("QueryNvConfig", ctx, pciAddress, mock.Anything).
 						Return(nvConfig, nil)
 					mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-						Return(true)
-					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+						Return(true).Maybe()
+					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device).
 						Return(desiredConfig, nil)
 					mockNV.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"param1": "newValue3", "param2": "newValue3"}, false).
 						Return(nil)
@@ -902,11 +796,11 @@ var _ = Describe("ConfigurationManager", func() {
 					}
 					desiredConfig := map[string]string{"param1": "value1"}
 
-					mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+					mockNV.On("QueryNvConfig", ctx, pciAddress, mock.Anything).
 						Return(nvConfig, nil)
 					mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-						Return(true)
-					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+						Return(true).Maybe()
+					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device).
 						Return(desiredConfig, nil)
 
 					result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
@@ -934,6 +828,10 @@ var _ = Describe("ConfigurationManager", func() {
 		BeforeEach(func() {
 			mockHostUtils = mocks.ConfigurationUtils{}
 			mockConfigValidation = mocks.ConfigValidation{}
+			// Passthrough by default — individual tests can override with a specific
+			// expectation when they care about sentinel resolution.
+			mockConfigValidation.On("ResolveFactoryDefaults", mock.Anything, mock.Anything).
+				Return(func(desired map[string]string, _ types.NvConfigQuery) map[string]string { return desired }).Maybe()
 			mockNV = nvconfigmocks.NewNVConfigUtils(GinkgoT())
 			manager = configurationManager{
 				configurationUtils: &mockHostUtils,

--- a/pkg/configuration/mocks/ConfigValidation.go
+++ b/pkg/configuration/mocks/ConfigValidation.go
@@ -61,9 +61,9 @@ func (_m *ConfigValidation) CalculateDesiredRuntimeConfig(device *v1alpha1.NicDe
 	return r0, r1
 }
 
-// ConstructNvParamMapFromTemplate provides a mock function with given fields: device, nvConfigQuery
-func (_m *ConfigValidation) ConstructNvParamMapFromTemplate(device *v1alpha1.NicDevice, nvConfigQuery types.NvConfigQuery) (map[string]string, error) {
-	ret := _m.Called(device, nvConfigQuery)
+// ConstructNvParamMapFromTemplate provides a mock function with given fields: device
+func (_m *ConfigValidation) ConstructNvParamMapFromTemplate(device *v1alpha1.NicDevice) (map[string]string, error) {
+	ret := _m.Called(device)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ConstructNvParamMapFromTemplate")
@@ -71,24 +71,44 @@ func (_m *ConfigValidation) ConstructNvParamMapFromTemplate(device *v1alpha1.Nic
 
 	var r0 map[string]string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*v1alpha1.NicDevice, types.NvConfigQuery) (map[string]string, error)); ok {
-		return rf(device, nvConfigQuery)
+	if rf, ok := ret.Get(0).(func(*v1alpha1.NicDevice) (map[string]string, error)); ok {
+		return rf(device)
 	}
-	if rf, ok := ret.Get(0).(func(*v1alpha1.NicDevice, types.NvConfigQuery) map[string]string); ok {
-		r0 = rf(device, nvConfigQuery)
+	if rf, ok := ret.Get(0).(func(*v1alpha1.NicDevice) map[string]string); ok {
+		r0 = rf(device)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string]string)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(*v1alpha1.NicDevice, types.NvConfigQuery) error); ok {
-		r1 = rf(device, nvConfigQuery)
+	if rf, ok := ret.Get(1).(func(*v1alpha1.NicDevice) error); ok {
+		r1 = rf(device)
 	} else {
 		r1 = ret.Error(1)
 	}
 
 	return r0, r1
+}
+
+// ResolveFactoryDefaults provides a mock function with given fields: desired, portConfig
+func (_m *ConfigValidation) ResolveFactoryDefaults(desired map[string]string, portConfig types.NvConfigQuery) map[string]string {
+	ret := _m.Called(desired, portConfig)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ResolveFactoryDefaults")
+	}
+
+	var r0 map[string]string
+	if rf, ok := ret.Get(0).(func(map[string]string, types.NvConfigQuery) map[string]string); ok {
+		r0 = rf(desired, portConfig)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]string)
+		}
+	}
+
+	return r0
 }
 
 // RuntimeConfigApplied provides a mock function with given fields: device

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -85,6 +85,14 @@ const (
 	NvParamBF3DpuMode         = "0"
 	NvParamBF3NicMode         = "1"
 
+	// NvParamFactoryDefault is a sentinel used in ConstructNvParamMapFromTemplate's
+	// output to mean "this parameter should match the firmware's factory default."
+	// The resolver ResolveFactoryDefaults replaces it with the DefaultConfig value
+	// from a scoped mlxconfig query before the compare/apply loop runs. The literal
+	// string is intentionally not a valid numeric value so it can't collide with
+	// anything returned by mlxconfig.
+	NvParamFactoryDefault = "<factory-default>"
+
 	SriovEnabledParam        = "SRIOV_EN"
 	SriovNumOfVfsParam       = "NUM_OF_VFS"
 	LinkTypeP1Param          = "LINK_TYPE_P1"

--- a/pkg/nvconfig/utils.go
+++ b/pkg/nvconfig/utils.go
@@ -157,9 +157,15 @@ func (h *nvConfigUtils) queryMLXConfig(ctx context.Context, query types.NvConfig
 	return nil
 }
 
-// QueryNvConfig queries nv config for a mellanox device and returns default, current and next boot configs
+// QueryNvConfig queries nv config for a mellanox device and returns default, current and next boot configs.
+//
+// When parameters is empty, runs a full chip walk (slow on BF3/BF4: hundreds of params).
+// When parameters is non-empty, runs one `mlxconfig query <name>` per name; a per-param
+// failure (e.g. FW doesn't expose that name) is logged at V(2) and skipped — the missing
+// name is simply absent from the returned maps, matching full-walk behavior for unsupported
+// params. This keeps a single bad name in the list from aborting the whole reconcile.
 func (h *nvConfigUtils) QueryNvConfig(ctx context.Context, pciAddr string, parameters []string) (types.NvConfigQuery, error) {
-	log.Log.Info("ConfigurationUtils.QueryNvConfig()", "pciAddr", pciAddr)
+	log.Log.Info("ConfigurationUtils.QueryNvConfig()", "pciAddr", pciAddr, "parameters", parameters)
 
 	query := types.NewNvConfigQuery()
 
@@ -169,13 +175,16 @@ func (h *nvConfigUtils) QueryNvConfig(ctx context.Context, pciAddr string, param
 			log.Log.Error(err, "Failed to parse mlxconfig query output", "device", pciAddr)
 			return query, err
 		}
-	} else {
-		for _, param := range parameters {
-			err := h.queryMLXConfig(ctx, query, pciAddr, param)
-			if err != nil {
-				log.Log.Error(err, "Failed to parse mlxconfig query output", "device", pciAddr, "parameter", param)
-				return query, err
-			}
+		return query, nil
+	}
+
+	for _, param := range parameters {
+		if err := h.queryMLXConfig(ctx, query, pciAddr, param); err != nil {
+			// Per-param error: treat as "param not supported by FW", skip it.
+			// The downstream comparison logic already handles missing names as
+			// "not supported" — see manager.go's NextBootConfig presence check.
+			log.Log.V(2).Info("mlxconfig query failed for parameter, skipping", "device", pciAddr, "parameter", param, "error", err.Error())
+			continue
 		}
 	}
 

--- a/pkg/nvconfig/utils_test.go
+++ b/pkg/nvconfig/utils_test.go
@@ -211,5 +211,127 @@ Configurations:                              Default         Current         Nex
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("mlxconfig error"))
 		})
+
+		It("issues one mlxconfig query per name in a scoped call and merges the results", func() {
+			cmdA := &execTesting.FakeCmd{}
+			cmdA.OutputScript = append(cmdA.OutputScript, func() ([]byte, []byte, error) {
+				return []byte(`
+Configurations:                              Default         Current         Next Boot
+         SRIOV_EN                            True(1)         True(1)         True(1)
+`), nil, nil
+			})
+			cmdB := &execTesting.FakeCmd{}
+			cmdB.OutputScript = append(cmdB.OutputScript, func() ([]byte, []byte, error) {
+				return []byte(`
+Configurations:                              Default         Current         Next Boot
+         NUM_OF_VFS                          0               0               0
+`), nil, nil
+			})
+
+			fakeExec.CommandScript = []execTesting.FakeCommandAction{
+				func(cmd string, args ...string) exec.Cmd {
+					Expect(cmd).To(Equal("mlxconfig"))
+					Expect(args).To(Equal([]string{"-d", pciAddress, "-e", "query", consts.SriovEnabledParam}))
+					return cmdA
+				},
+				func(cmd string, args ...string) exec.Cmd {
+					Expect(cmd).To(Equal("mlxconfig"))
+					Expect(args).To(Equal([]string{"-d", pciAddress, "-e", "query", consts.SriovNumOfVfsParam}))
+					return cmdB
+				},
+			}
+			h.execInterface = fakeExec
+
+			query, err := h.QueryNvConfig(context.TODO(), pciAddress,
+				[]string{consts.SriovEnabledParam, consts.SriovNumOfVfsParam})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(query.CurrentConfig).To(HaveKeyWithValue(consts.SriovEnabledParam, []string{"true", "1"}))
+			Expect(query.CurrentConfig).To(HaveKeyWithValue(consts.SriovNumOfVfsParam, []string{"0"}))
+		})
+
+		It("skips per-param errors and returns the successfully-queried names", func() {
+			// First param succeeds, second param errors (FW doesn't expose it),
+			// third param succeeds. QueryNvConfig should log+skip the middle one
+			// and still return a populated query for the other two.
+			cmdOK1 := &execTesting.FakeCmd{}
+			cmdOK1.OutputScript = append(cmdOK1.OutputScript, func() ([]byte, []byte, error) {
+				return []byte(`
+Configurations:                              Default         Current         Next Boot
+         SRIOV_EN                            True(1)         True(1)         True(1)
+`), nil, nil
+			})
+			cmdErr := &execTesting.FakeCmd{}
+			cmdErr.OutputScript = append(cmdErr.OutputScript, func() ([]byte, []byte, error) {
+				return []byte("mlxconfig: parameter UNSUPPORTED_PARAM is not supported"), nil,
+					fmt.Errorf("exit status 1")
+			})
+			cmdOK2 := &execTesting.FakeCmd{}
+			cmdOK2.OutputScript = append(cmdOK2.OutputScript, func() ([]byte, []byte, error) {
+				return []byte(`
+Configurations:                              Default         Current         Next Boot
+         NUM_OF_VFS                          0               0               0
+`), nil, nil
+			})
+
+			fakeExec.CommandScript = []execTesting.FakeCommandAction{
+				func(cmd string, args ...string) exec.Cmd {
+					Expect(args).To(ContainElement(consts.SriovEnabledParam))
+					return cmdOK1
+				},
+				func(cmd string, args ...string) exec.Cmd {
+					Expect(args).To(ContainElement("UNSUPPORTED_PARAM"))
+					return cmdErr
+				},
+				func(cmd string, args ...string) exec.Cmd {
+					Expect(args).To(ContainElement(consts.SriovNumOfVfsParam))
+					return cmdOK2
+				},
+			}
+			h.execInterface = fakeExec
+
+			query, err := h.QueryNvConfig(context.TODO(), pciAddress,
+				[]string{consts.SriovEnabledParam, "UNSUPPORTED_PARAM", consts.SriovNumOfVfsParam})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(query.CurrentConfig).To(HaveKey(consts.SriovEnabledParam))
+			Expect(query.CurrentConfig).NotTo(HaveKey("UNSUPPORTED_PARAM"))
+			Expect(query.CurrentConfig).To(HaveKey(consts.SriovNumOfVfsParam))
+		})
+
+		It("expands array values within a scoped query via recursion", func() {
+			// First: scoped call for ESWITCH_HAIRPIN_DESCRIPTORS returns an Array marker.
+			// Recursion then fires a follow-up query ESWITCH_HAIRPIN_DESCRIPTORS[0..7].
+			cmdArr := &execTesting.FakeCmd{}
+			cmdArr.OutputScript = append(cmdArr.OutputScript, func() ([]byte, []byte, error) {
+				return []byte(`
+Configurations:                              Default         Current         Next Boot
+         ESWITCH_HAIRPIN_DESCRIPTORS         Array[0..7]     Array[0..7]     Array[0..7]
+`), nil, nil
+			})
+			cmdExpand := &execTesting.FakeCmd{}
+			cmdExpand.OutputScript = append(cmdExpand.OutputScript, func() ([]byte, []byte, error) {
+				return []byte(`
+Configurations:                              Default         Current         Next Boot
+         ESWITCH_HAIRPIN_DESCRIPTORS[0]      128             128             128
+         ESWITCH_HAIRPIN_DESCRIPTORS[1]      128             128             128
+`), nil, nil
+			})
+
+			fakeExec.CommandScript = []execTesting.FakeCommandAction{
+				func(cmd string, args ...string) exec.Cmd {
+					Expect(args).To(Equal([]string{"-d", pciAddress, "-e", "query", "ESWITCH_HAIRPIN_DESCRIPTORS"}))
+					return cmdArr
+				},
+				func(cmd string, args ...string) exec.Cmd {
+					Expect(args).To(Equal([]string{"-d", pciAddress, "-e", "query", "ESWITCH_HAIRPIN_DESCRIPTORS[0..7]"}))
+					return cmdExpand
+				},
+			}
+			h.execInterface = fakeExec
+
+			query, err := h.QueryNvConfig(context.TODO(), pciAddress, []string{"ESWITCH_HAIRPIN_DESCRIPTORS"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(query.CurrentConfig).To(HaveKeyWithValue("ESWITCH_HAIRPIN_DESCRIPTORS[0]", []string{"128"}))
+			Expect(query.CurrentConfig).To(HaveKeyWithValue("ESWITCH_HAIRPIN_DESCRIPTORS[1]", []string{"128"}))
+		})
 	})
 })


### PR DESCRIPTION
Every NicDevice reconcile was running a full `mlxconfig query` twice per device — once in ValidateDeviceNvSpec, once in ApplyNVConfiguration — because ConstructNvParamMapFromTemplate needed query results to "resurrect" defaults for disabled optionals before it could compute the desired param set. On BF3/BF4 that full walk is seconds per call and dominates reconcile wall time.

Two reinforcing changes:

1. ConstructNvParamMapFromTemplate is now query-independent and returns only what the spec explicitly asks to set. No more default resurrection for RoCE/GpuDirect/MaxAccOutRead when those optionals are disabled. Apply uses `mlxconfig set --with_default`, which normalizes every non-spec param to factory default in the same batch. This collapses the two-phase ADVANCED_PCI_SETTINGS flow into a single set call.

2. queryNvConfigs is scoped to keys(desired) ∪ {ADVANCED_PCI_SETTINGS} — the names the reconcile path actually reads. QueryNvConfig's per-param loop now logs+skips on per-param error instead of aborting, so one unsupported name in the list doesn't break reconcile. The full-walk path remains only for ResetToDefault.

BF devices targeted by this operator get INTERNAL_CPU_OFFLOAD_ENGINE set to NIC mode unconditionally; applying a NicConfigurationTemplate implies NIC mode by definition. The BF3OperationModeParam special-case in ValidateResetToDefault is removed as a consequence.

Breaking: non-spec NV config params are now reset to factory default on every apply. Run `ResetToDefault: true` once post-upgrade for initial alignment, or use `rawNvConfig` for tuning that must persist across reconciles.