### PR TITLE
drop --with_default by default in SpectrumX flow

### DIFF
--- a/pkg/configuration/manager.go
+++ b/pkg/configuration/manager.go
@@ -181,7 +181,7 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 	if device.Spec.Configuration.Template != nil &&
 		device.Spec.Configuration.Template.SpectrumXOptimized != nil &&
 		device.Spec.Configuration.Template.SpectrumXOptimized.Enabled {
-		return h.applySpectrumXNVConfiguration(ctx, device)
+		return h.applySpectrumXNVConfiguration(ctx, device, options)
 	}
 
 	nvConfigsForPorts, err := h.queryNvConfigs(ctx, device)
@@ -308,7 +308,7 @@ func (h configurationManager) checkMlxConfigMismatch(ctx context.Context, pci st
 }
 
 // applySpectrumXNVConfiguration handles the Spectrum-X NV configuration path (breakout + postBreakout)
-func (h configurationManager) applySpectrumXNVConfiguration(ctx context.Context, device *v1alpha1.NicDevice) (*types.ConfigurationApplyResult, error) {
+func (h configurationManager) applySpectrumXNVConfiguration(ctx context.Context, device *v1alpha1.NicDevice, options *types.ConfigurationOptions) (*types.ConfigurationApplyResult, error) {
 	pci := device.Status.Ports[0].PCI
 
 	breakoutParams, err := h.spectrumXConfigManager.GetBreakoutMlxConfig(device)
@@ -330,7 +330,7 @@ func (h configurationManager) applySpectrumXNVConfiguration(ctx context.Context,
 			return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
 		} else if mismatch {
 			log.Log.Info("applying breakout config", "device", device.Name)
-			if err := h.nvConfigUtils.SetNvConfigParametersBatch(pci, breakoutParams, true); err != nil {
+			if err := h.nvConfigUtils.SetNvConfigParametersBatch(pci, breakoutParams, options.WithDefault); err != nil {
 				return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
 			}
 			log.Log.Info("breakout config applied, reboot required", "device", device.Name)
@@ -352,7 +352,7 @@ func (h configurationManager) applySpectrumXNVConfiguration(ctx context.Context,
 				merged[k] = v
 			}
 			log.Log.Info("applying postBreakout config", "device", device.Name)
-			if err := h.nvConfigUtils.SetNvConfigParametersBatch(pci, merged, true); err != nil {
+			if err := h.nvConfigUtils.SetNvConfigParametersBatch(pci, merged, options.WithDefault); err != nil {
 				return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
 			}
 			log.Log.Info("postBreakout config applied, reboot required", "device", device.Name)

--- a/pkg/configuration/manager_test.go
+++ b/pkg/configuration/manager_test.go
@@ -1291,9 +1291,23 @@ var _ = Describe("ConfigurationManager", func() {
 				mockSpcXMgr.On("GetPostBreakoutMlxConfig", device).Return(nil, nil)
 				mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, mock.Anything).Return(
 					types.NvConfigQuery{CurrentConfig: map[string][]string{"NUM_OF_PF": {"1"}}}, nil)
-				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, breakoutParams, true).Return(nil)
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, breakoutParams, false).Return(nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Status).To(Equal(types.ApplyStatusPartiallyApplied))
+				Expect(result.RebootRequired).To(BeTrue())
+			})
+
+			It("propagates WithDefault=true to mlxconfig in SpectrumX flow", func() {
+				breakoutParams := map[string]string{"NUM_OF_PF": "2"}
+				mockSpcXMgr.On("GetBreakoutMlxConfig", device).Return(breakoutParams, nil)
+				mockSpcXMgr.On("GetPostBreakoutMlxConfig", device).Return(nil, nil)
+				mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, mock.Anything).Return(
+					types.NvConfigQuery{CurrentConfig: map[string][]string{"NUM_OF_PF": {"1"}}}, nil)
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, breakoutParams, true).Return(nil)
+
+				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{WithDefault: true})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.Status).To(Equal(types.ApplyStatusPartiallyApplied))
 				Expect(result.RebootRequired).To(BeTrue())
@@ -1309,7 +1323,7 @@ var _ = Describe("ConfigurationManager", func() {
 				mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string{"LINK_TYPE_P1"}).Return(
 					types.NvConfigQuery{CurrentConfig: map[string][]string{"LINK_TYPE_P1": {"1"}}}, nil)
 				merged := map[string]string{"NUM_OF_PF": "2", "LINK_TYPE_P1": "2"}
-				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, merged, true).Return(nil)
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, merged, false).Return(nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 				Expect(err).NotTo(HaveOccurred())
@@ -1338,7 +1352,7 @@ var _ = Describe("ConfigurationManager", func() {
 				mockSpcXMgr.On("GetPostBreakoutMlxConfig", device).Return(nil, nil)
 				mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, mock.Anything).Return(
 					types.NvConfigQuery{CurrentConfig: map[string][]string{"NUM_OF_PF": {"1"}}}, nil)
-				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, breakoutParams, true).Return(errors.New("set failed"))
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, breakoutParams, false).Return(errors.New("set failed"))
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 				Expect(err).To(HaveOccurred())
@@ -1360,7 +1374,7 @@ var _ = Describe("ConfigurationManager", func() {
 				})).Return(
 					types.NvConfigQuery{CurrentConfig: map[string][]string{"LINK_TYPE_P1": {"2"}, "CUSTOM_PARAM_P1": {"0"}}}, nil)
 				merged := map[string]string{"NUM_OF_PF": "2", "LINK_TYPE_P1": "2", "CUSTOM_PARAM_P1": "42"}
-				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, merged, true).Return(nil)
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, merged, false).Return(nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 				Expect(err).NotTo(HaveOccurred())
@@ -1383,7 +1397,7 @@ var _ = Describe("ConfigurationManager", func() {
 					types.NvConfigQuery{CurrentConfig: map[string][]string{"LINK_TYPE_P1": {"2"}}}, nil)
 				// The merged set should have rawNvConfig's value "1" for LINK_TYPE_P1
 				merged := map[string]string{"NUM_OF_PF": "2", "LINK_TYPE_P1": "1"}
-				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, merged, true).Return(nil)
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, merged, false).Return(nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 				Expect(err).NotTo(HaveOccurred())
@@ -1403,7 +1417,7 @@ var _ = Describe("ConfigurationManager", func() {
 				mergedBreakout := map[string]string{"NUM_OF_PF": "4"}
 				mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string{"NUM_OF_PF"}).Return(
 					types.NvConfigQuery{CurrentConfig: map[string][]string{"NUM_OF_PF": {"2"}}}, nil)
-				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, mergedBreakout, true).Return(nil)
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, mergedBreakout, false).Return(nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 				Expect(err).NotTo(HaveOccurred())
@@ -1428,7 +1442,7 @@ var _ = Describe("ConfigurationManager", func() {
 				})).Return(
 					types.NvConfigQuery{CurrentConfig: map[string][]string{"LINK_TYPE_P1": {"2"}, "CUSTOM_PARAM_P1": {"0"}}}, nil)
 				merged := map[string]string{"NUM_OF_PF": "2", "LINK_TYPE_P1": "2", "CUSTOM_PARAM_P1": "42"}
-				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, merged, true).Return(nil)
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, merged, false).Return(nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
The SpectrumX breakout/postBreakout path hardcoded SetNvConfigParametersBatch(withDefault=true), forcing --with_default on every operator-driven apply. In practice --with_default behaves unexpectedly and leaves some parameters not applied, which causes the device to keep reporting a config mismatch after reboot and sends the node into a reconcile/reboot loop.

Honor options.WithDefault instead so the operator controller (which passes the zero-value ConfigurationOptions) no longer emits the flag, while library callers can still opt in with
ConfigurationOptions{WithDefault: true}.