### PR TITLE
ci: disable pulse scan-image component usage tracking

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,6 +27,7 @@ include:
       rules:
         - if: '$CI_COMMIT_TAG =~ /^network-operator-.*$/'
       allow_failure_exit_code: [11, 255]
+      track_usage: "false"
 
   - component: $CI_SERVER_FQDN/security/devops-tools/ci-cd-components/pulse-container-scanner/scan-image@~latest
     inputs:
@@ -40,6 +41,7 @@ include:
       rules:
         - if: '$CI_COMMIT_TAG =~ /^network-operator-.*$/'
       allow_failure_exit_code: [11, 255]
+      track_usage: "false"
 
   - component: $CI_SERVER_FQDN/security/devops-tools/ci-cd-components/pulse-container-scanner/scan-image@~latest
     inputs:
@@ -53,6 +55,7 @@ include:
       rules:
         - if: '$CI_COMMIT_TAG =~ /^network-operator-.*$/'
       allow_failure_exit_code: [11, 255]
+      track_usage: "false"
 
   - component: $CI_SERVER_FQDN/security/devops-tools/ci-cd-components/pulse-container-scanner/scan-image@~latest
     inputs:
@@ -66,6 +69,7 @@ include:
       rules:
         - if: '$CI_COMMIT_TAG =~ /^network-operator-.*$/'
       allow_failure_exit_code: [11, 255]
+      track_usage: "false"
 
 stages:
   - build


### PR DESCRIPTION
The scan-image component auto-generates a *-track-usage telemetry job that requires a 'generic' runner tag not available in this project, causing it to be stuck indefinitely. Set track_usage=false on all 4 component includes to suppress these jobs. No impact on scan behavior.