### PR TITLE
ci: suppress track-usage jobs blocking .pre stage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -329,6 +329,10 @@ update-component-version-in-network-operator:
 
 # Suppress component-generated track-usage jobs — they require a 'generic' runner
 # tag not available in this project and block the .pre stage indefinitely.
+track-template-usage:
+  rules:
+    - when: never
+
 pulse-scan-oss-operator-ubuntu-track-usage:
   rules:
     - when: never


### PR DESCRIPTION
The scan-image component generates tracking/telemetry jobs in the .pre stage that require a runner tag not available in this project. As perpetually pending jobs they block all subsequent stages. Override all 5 generated tracking jobs with 'when: never' to prevent them from appearing in the pipeline.