### PR TITLE
ci: remove enable_override from OSS scan jobs (no policy scan)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,8 +20,6 @@ include:
       job_prefix: pulse-scan-oss-operator-ubuntu
       nspect_id: $NSPECT_ID
       container_image: $DOCKER_REGISTRY/$OPERATOR_IMAGE_NAME:$DOCKER_TAG-ubuntu
-      enable_override: true
-      program_version: $NSPECT_RELEASE_VERSION
       stage: pulse-scan-oss
       tags: [os/linux, type/docker]
       rules:
@@ -34,8 +32,6 @@ include:
       job_prefix: pulse-scan-oss-daemon-ubuntu
       nspect_id: $NSPECT_ID
       container_image: $DOCKER_REGISTRY/$DAEMON_IMAGE_NAME:$DOCKER_TAG-ubuntu
-      enable_override: true
-      program_version: $NSPECT_RELEASE_VERSION
       stage: pulse-scan-oss
       tags: [os/linux, type/docker]
       rules:
@@ -48,8 +44,6 @@ include:
       job_prefix: pulse-scan-oss-operator-rhel
       nspect_id: $NSPECT_ID
       container_image: $DOCKER_REGISTRY/$OPERATOR_IMAGE_NAME:$DOCKER_TAG-rhel
-      enable_override: true
-      program_version: $NSPECT_RELEASE_VERSION
       stage: pulse-scan-oss
       tags: [os/linux, type/docker]
       rules:
@@ -62,8 +56,6 @@ include:
       job_prefix: pulse-scan-oss-daemon-rhel
       nspect_id: $NSPECT_ID
       container_image: $DOCKER_REGISTRY/$DAEMON_IMAGE_NAME:$DOCKER_TAG-rhel
-      enable_override: true
-      program_version: $NSPECT_RELEASE_VERSION
       stage: pulse-scan-oss
       tags: [os/linux, type/docker]
       rules:


### PR DESCRIPTION
The old .scan-image-no-policy template scanned without reporting to nSpect. The new component with enable_override=true requires a policy file, causing pulse-cli to fail. Remove enable_override and program_version to match the original no-policy scan behavior.