### PR TITLE
feat: add --discovery-only mode to the daemon

### DIFF
--- a/cmd/nic-configuration-daemon/main.go
+++ b/cmd/nic-configuration-daemon/main.go
@@ -17,10 +17,13 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"flag"
 	"maps"
 	"os"
 	"slices"
+	"time"
 
 	maintenanceoperator "github.com/Mellanox/maintenance-operator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -54,6 +57,8 @@ var (
 
 func main() {
 	ncolog.BindFlags(flag.CommandLine)
+	discoveryOnly := flag.Bool("discovery-only", false,
+		"Run device discovery once, write NicDevice CRs, and exit. Disables all reconciliation.")
 	flag.Parse()
 	ncolog.InitLog()
 
@@ -100,6 +105,11 @@ func main() {
 	nvConfigUtils := nvconfig.NewNVConfigUtils()
 
 	deviceDiscovery := devicediscovery.NewDeviceDiscovery(nodeName, nvConfigUtils)
+
+	if *discoveryOnly {
+		runDiscoveryOnce(mgr, deviceDiscovery, hostUtils, nodeName, namespace)
+		return
+	}
 
 	// Initialize DMS server
 	dmsServer := dms.NewDMSServer()
@@ -204,4 +214,65 @@ func initNicFwMap(namespace string) error {
 	}
 
 	return nil
+}
+
+// runDiscoveryOnce performs a single NIC discovery + NicDevice CR sync cycle and exits.
+// It uses the manager only for its cached client and field index; no reconcilers are
+// registered. On any error it exits with status 1; on success it returns and the
+// caller exits with status 0.
+func runDiscoveryOnce(mgr ctrl.Manager, dd devicediscovery.DeviceDiscovery,
+	hu host.HostUtils, nodeName, namespace string) {
+
+	ddCtrl := controller.NewDeviceDiscoveryController(mgr.GetClient(), dd, hu, nodeName, namespace)
+
+	ctx, cancel := context.WithCancel(ctrl.SetupSignalHandler())
+	defer cancel()
+
+	// Same index the normal path registers; lifted here so the discovery-only path is self-contained.
+	if err := mgr.GetCache().IndexField(ctx, &v1alpha1.NicDevice{}, "status.node", func(o client.Object) []string {
+		return []string{o.(*v1alpha1.NicDevice).Status.Node}
+	}); err != nil {
+		log.Log.Error(err, "failed to index field for cache")
+		os.Exit(1)
+	}
+
+	mgrErr := make(chan error, 1)
+	go func() { mgrErr <- mgr.Start(ctx) }()
+
+	if !mgr.GetCache().WaitForCacheSync(ctx) {
+		// WaitForCacheSync returns false on genuine sync failure and on ctx
+		// cancellation (e.g. SIGTERM). Check ctx.Err() before we call cancel()
+		// so we can tell them apart.
+		if ctx.Err() != nil {
+			<-mgrErr
+			log.Log.Info("interrupted before cache sync, exiting")
+			return
+		}
+		log.Log.Error(nil, "cache sync failed")
+		cancel()
+		<-mgrErr
+		os.Exit(1)
+	}
+
+	const (
+		discoveryMaxAttempts   = 10
+		discoveryRetryInterval = 5 * time.Second
+	)
+	if err := ddCtrl.RunUntilSuccess(ctx, discoveryMaxAttempts, discoveryRetryInterval); err != nil {
+		cancel()
+		<-mgrErr
+		if errors.Is(err, context.Canceled) {
+			log.Log.Info("interrupted during device discovery, exiting")
+			return
+		}
+		log.Log.Error(err, "device discovery failed")
+		os.Exit(1)
+	}
+
+	cancel()
+	if err := <-mgrErr; err != nil && !errors.Is(err, context.Canceled) {
+		log.Log.Error(err, "manager exited with error")
+		os.Exit(1)
+	}
+	log.Log.Info("device discovery complete, exiting")
 }

--- a/internal/controller/devicediscovery_controller.go
+++ b/internal/controller/devicediscovery_controller.go
@@ -17,6 +17,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -115,7 +116,20 @@ func setFwConfigConditionsForDevice(device *v1alpha1.NicDevice, recommendedFirmw
 // reconcile reconciles the devices on the host by comparing the observed devices with the existing NicDevice custom resources (CRs).
 // It deletes CRs that do not represent observed devices, updates the CRs if the status of the device changes,
 // and creates new CRs for devices that do not have a CR representation.
-func (d *DeviceDiscoveryController) reconcile(ctx context.Context) error {
+//
+// Per-device errors (Create/Update/Delete/SetOwnerReference on individual CRs) are always logged.
+// If perDeviceErrs is non-nil, they are also appended to it so callers can surface them — used by
+// --discovery-only mode where a single best-effort pass must report incomplete CR state. When nil,
+// per-device errors are swallowed (preserves the periodic reconcile loop's tolerance for transient
+// failures between ticks).
+func (d *DeviceDiscoveryController) reconcile(ctx context.Context, perDeviceErrs *[]error) error {
+	trackErr := func(err error, what string, name string) {
+		log.Log.Error(err, what, "device", name)
+		if perDeviceErrs != nil {
+			*perDeviceErrs = append(*perDeviceErrs, fmt.Errorf("%s %s: %w", what, name, err))
+		}
+	}
+
 	observedDevices, err := d.deviceDiscovery.DiscoverNicDevices()
 	if err != nil {
 		return err
@@ -151,9 +165,8 @@ func (d *DeviceDiscoveryController) reconcile(ctx context.Context) error {
 		if !exists {
 			log.Log.V(2).Info("device doesn't exist on the node anymore, deleting", "device", nicDeviceCR.Name)
 			// Need to delete this CR, it doesn't represent the observedDevice on host anymore
-			err = d.Delete(ctx, &nicDeviceCR)
-			if err != nil {
-				log.Log.Error(err, "failed  to delete NicDevice CR", "device", nicDeviceCR.Name)
+			if err := d.Delete(ctx, &nicDeviceCR); err != nil {
+				trackErr(err, "failed to delete NicDevice CR", nicDeviceCR.Name)
 			}
 
 			continue
@@ -163,9 +176,8 @@ func (d *DeviceDiscoveryController) reconcile(ctx context.Context) error {
 
 		if changed := d.updateFwCondition(&nicDeviceCR); changed {
 			log.Log.V(2).Info("FirmwareConfigMatch condition changed, updating device", "nicDeviceCR", nicDeviceCR)
-			err = d.Client.Status().Update(ctx, &nicDeviceCR)
-			if err != nil {
-				log.Log.Error(err, "failed to update FirmwareConfigMatchCondition", "device", nicDeviceCR.Name)
+			if err := d.Client.Status().Update(ctx, &nicDeviceCR); err != nil {
+				trackErr(err, "failed to update FirmwareConfigMatchCondition", nicDeviceCR.Name)
 				continue
 			}
 		}
@@ -178,9 +190,8 @@ func (d *DeviceDiscoveryController) reconcile(ctx context.Context) error {
 			// Status of the device changes, need to update the CR
 			nicDeviceCR.Status = observedDeviceStatus
 
-			err := d.Client.Status().Update(ctx, &nicDeviceCR)
-			if err != nil {
-				log.Log.Error(err, "failed to update NicDevice CR status", "device", nicDeviceCR.Name)
+			if err := d.Client.Status().Update(ctx, &nicDeviceCR); err != nil {
+				trackErr(err, "failed to update NicDevice CR status", nicDeviceCR.Name)
 			}
 		}
 
@@ -199,22 +210,20 @@ func (d *DeviceDiscoveryController) reconcile(ctx context.Context) error {
 			},
 		}
 
-		err := controllerutil.SetOwnerReference(node, device, d.Scheme())
-		if err != nil {
-			log.Log.Error(err, "failed to set owner reference for device", "device", device)
+		if err := controllerutil.SetOwnerReference(node, device, d.Scheme()); err != nil {
+			trackErr(err, "failed to set owner reference for device", device.Name)
 			continue
 		}
-		err = d.Create(ctx, device)
+		err := d.Create(ctx, device)
 		if apierrors.IsAlreadyExists(err) {
 			// Device already exists but was not matched by PCI address, which means the status was not applied properly
 			// on a previous reconcile. Re-fetch so the status update below runs against the live object.
-			err = d.Get(ctx, types.NamespacedName{Name: device.Name, Namespace: device.Namespace}, device)
-			if err != nil {
-				log.Log.Error(err, "failed to get existing NicDevice obj", "device", device)
+			if err := d.Get(ctx, types.NamespacedName{Name: device.Name, Namespace: device.Namespace}, device); err != nil {
+				trackErr(err, "failed to get existing NicDevice obj", device.Name)
 				continue
 			}
 		} else if err != nil {
-			log.Log.Error(err, "failed to create NicDevice obj", "device", device)
+			trackErr(err, "failed to create NicDevice obj", device.Name)
 			continue
 		}
 
@@ -224,9 +233,8 @@ func (d *DeviceDiscoveryController) reconcile(ctx context.Context) error {
 
 		d.updateFwCondition(device)
 		log.Log.V(2).Info("updated device", "device", device)
-		err = d.Client.Status().Update(ctx, device)
-		if err != nil {
-			log.Log.Error(err, "failed to update FirmwareConfigMatchCondition", "device", device.Name)
+		if err := d.Client.Status().Update(ctx, device); err != nil {
+			trackErr(err, "failed to update NicDevice CR status", device.Name)
 			continue
 		}
 	}
@@ -254,7 +262,8 @@ func (d *DeviceDiscoveryController) Start(ctx context.Context) error {
 	retryChan := make(chan struct{}, 1) // Channel to trigger immediate retries
 
 	runReconcile := func() {
-		err := d.reconcile(ctx)
+		// Periodic mode tolerates per-device errors between ticks; pass nil so they're only logged.
+		err := d.reconcile(ctx, nil)
 		if err != nil {
 			log.Log.Error(err, "failed to run reconcile, requeueing")
 			// Retry the request if there's an error
@@ -277,6 +286,32 @@ OUTER:
 	}
 
 	return nil
+}
+
+// RunOnce performs a single device discovery + NicDevice CR sync cycle and returns.
+// Used by the daemon's --discovery-only mode (full sync semantics: creates new CRs,
+// updates changed status, deletes CRs for devices no longer present on the node).
+//
+// Unlike the periodic reconcile loop, RunOnce surfaces per-device errors via the returned
+// error (joined with errors.Join) so the caller's retry can re-attempt incomplete CRs.
+// Returns nil only if every observed device's CR sync succeeded.
+func (d *DeviceDiscoveryController) RunOnce(ctx context.Context) error {
+	var perDeviceErrs []error
+	if err := d.reconcile(ctx, &perDeviceErrs); err != nil {
+		return err
+	}
+	if len(perDeviceErrs) > 0 {
+		return fmt.Errorf("%d per-device error(s) during reconcile: %w", len(perDeviceErrs), errors.Join(perDeviceErrs...))
+	}
+	return nil
+}
+
+// RunUntilSuccess calls RunOnce until it succeeds or maxAttempts is exhausted,
+// waiting interval between attempts. Returns nil on success, or the last error
+// wrapped with the attempt count after maxAttempts failures. Returns ctx.Err()
+// if the context is cancelled during a wait between attempts.
+func (d *DeviceDiscoveryController) RunUntilSuccess(ctx context.Context, maxAttempts int, interval time.Duration) error {
+	return retryUntilSuccess(ctx, maxAttempts, interval, d.RunOnce)
 }
 
 // NewDeviceDiscoveryController creates a new instance of DeviceDiscoveryController with the specified parameters.

--- a/internal/controller/retry.go
+++ b/internal/controller/retry.go
@@ -1,0 +1,49 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// retryUntilSuccess calls fn up to maxAttempts times. It returns nil on the first
+// successful call. If all attempts fail, it returns the last error wrapped with the
+// attempt count. Between attempts it waits the given interval; if the context is
+// cancelled during a wait, it returns ctx.Err() immediately without further attempts.
+func retryUntilSuccess(ctx context.Context, maxAttempts int, interval time.Duration, fn func(context.Context) error) error {
+	var lastErr error
+	for i := 0; i < maxAttempts; i++ {
+		lastErr = fn(ctx)
+		if lastErr == nil {
+			return nil
+		}
+		log.Log.Error(lastErr, "attempt failed", "attempt", i+1, "of", maxAttempts)
+		if i == maxAttempts-1 {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(interval):
+		}
+	}
+	return fmt.Errorf("failed after %d attempts: %w", maxAttempts, lastErr)
+}

--- a/internal/controller/retry_test.go
+++ b/internal/controller/retry_test.go
@@ -1,0 +1,117 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestRetryUntilSuccess_FirstAttemptSucceeds(t *testing.T) {
+	var calls atomic.Int32
+	err := retryUntilSuccess(context.Background(), 5, time.Millisecond, func(_ context.Context) error {
+		calls.Add(1)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("expected 1 call, got %d", got)
+	}
+}
+
+func TestRetryUntilSuccess_SucceedsAfterRetries(t *testing.T) {
+	var calls atomic.Int32
+	err := retryUntilSuccess(context.Background(), 5, time.Millisecond, func(_ context.Context) error {
+		if calls.Add(1) < 3 {
+			return errors.New("transient")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected nil error after retries, got %v", err)
+	}
+	if got := calls.Load(); got != 3 {
+		t.Fatalf("expected 3 calls (2 failures + 1 success), got %d", got)
+	}
+}
+
+func TestRetryUntilSuccess_FailsAfterMaxAttempts(t *testing.T) {
+	var calls atomic.Int32
+	sentinel := errors.New("persistent")
+	err := retryUntilSuccess(context.Background(), 10, time.Microsecond, func(_ context.Context) error {
+		calls.Add(1)
+		return sentinel
+	})
+	if err == nil {
+		t.Fatal("expected error after exhausting attempts, got nil")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected wrapped sentinel error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "10 attempts") {
+		t.Fatalf("expected error message to reference attempt count, got %q", err.Error())
+	}
+	if got := calls.Load(); got != 10 {
+		t.Fatalf("expected exactly 10 calls, got %d", got)
+	}
+}
+
+func TestRetryUntilSuccess_ContextCancelledDuringWait(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var calls atomic.Int32
+	sentinel := errors.New("transient")
+
+	// Cancel the context synchronously inside the first attempt; the wait that
+	// follows must observe the cancellation and bail out without further calls.
+	err := retryUntilSuccess(ctx, 10, time.Hour, func(_ context.Context) error {
+		calls.Add(1)
+		cancel()
+		return sentinel
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 call before cancellation, got %d", got)
+	}
+}
+
+func TestRetryUntilSuccess_NoWaitAfterFinalAttempt(t *testing.T) {
+	// With a single attempt, the function must not wait — the test would hang on
+	// the sleep otherwise. We give it a long interval and expect immediate return.
+	start := time.Now()
+	var calls atomic.Int32
+	err := retryUntilSuccess(context.Background(), 1, time.Hour, func(_ context.Context) error {
+		calls.Add(1)
+		return errors.New("boom")
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("expected 1 call, got %d", got)
+	}
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Fatalf("expected immediate return after final attempt, took %v", elapsed)
+	}
+}

--- a/internal/controller/runonce_test.go
+++ b/internal/controller/runonce_test.go
@@ -1,0 +1,233 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/Mellanox/nic-configuration-operator/api/v1alpha1"
+	deviceDiscoveryMocks "github.com/Mellanox/nic-configuration-operator/pkg/devicediscovery/mocks"
+	hostMocks "github.com/Mellanox/nic-configuration-operator/pkg/host/mocks"
+)
+
+const (
+	runOnceTestNode      = "test-node"
+	runOnceTestNamespace = "test-ns"
+	runOnceTestPCI       = "0000:3b:00.0"
+)
+
+// buildRunOnceFixture returns a *DeviceDiscoveryController wired to a fake k8s client and mocks.
+// existing seeds NicDevice CRs into the fake client. observed is what DiscoverNicDevices will
+// return. interceptorFuncs lets the caller force errors on specific client operations.
+func buildRunOnceFixture(
+	t *testing.T,
+	existing []*v1alpha1.NicDevice,
+	observed map[string]v1alpha1.NicDevice,
+	interceptorFuncs interceptor.Funcs,
+) *DeviceDiscoveryController {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 scheme: %v", err)
+	}
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add v1alpha1 scheme: %v", err)
+	}
+
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: runOnceTestNode}}
+
+	objs := make([]client.Object, 0, 1+len(existing))
+	objs = append(objs, node)
+	for _, d := range existing {
+		objs = append(objs, d)
+	}
+
+	builder := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithIndex(&v1alpha1.NicDevice{}, "status.node", func(o client.Object) []string {
+			return []string{o.(*v1alpha1.NicDevice).Status.Node}
+		}).
+		WithObjects(objs...).
+		WithStatusSubresource(&v1alpha1.NicDevice{}).
+		WithInterceptorFuncs(interceptorFuncs)
+
+	k8sClient := builder.Build()
+
+	dd := &deviceDiscoveryMocks.DeviceDiscovery{}
+	dd.On("DiscoverNicDevices").Return(observed, nil)
+
+	hu := &hostMocks.HostUtils{}
+	hu.On("DiscoverOfedVersion").Return("")
+
+	return NewDeviceDiscoveryController(k8sClient, dd, hu, runOnceTestNode, runOnceTestNamespace)
+}
+
+func newObservedDevice(pci string, deviceType string) v1alpha1.NicDevice {
+	return v1alpha1.NicDevice{
+		Status: v1alpha1.NicDeviceStatus{
+			Type:  deviceType,
+			Ports: []v1alpha1.NicDevicePortSpec{{PCI: pci}},
+		},
+	}
+}
+
+func newExistingCR(name, pci, node string) *v1alpha1.NicDevice {
+	return &v1alpha1.NicDevice{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: runOnceTestNamespace},
+		Status: v1alpha1.NicDeviceStatus{
+			Node:  node,
+			Type:  "nic",
+			Ports: []v1alpha1.NicDevicePortSpec{{PCI: pci}},
+		},
+	}
+}
+
+func TestRunOnce_AllSucceed_ReturnsNil(t *testing.T) {
+	observed := map[string]v1alpha1.NicDevice{
+		"0000:3b:00": newObservedDevice(runOnceTestPCI, "nic"),
+	}
+
+	ctrl := buildRunOnceFixture(t, nil, observed, interceptor.Funcs{})
+
+	if err := ctrl.RunOnce(context.Background()); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+
+	// Verify the CR was created with populated status.
+	list := &v1alpha1.NicDeviceList{}
+	if err := ctrl.List(context.Background(), list); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list.Items) != 1 {
+		t.Fatalf("expected 1 CR, got %d", len(list.Items))
+	}
+	if list.Items[0].Status.Type != "nic" {
+		t.Fatalf("expected populated status, got %+v", list.Items[0].Status)
+	}
+}
+
+func TestRunOnce_StatusUpdateFails_ReturnsPerDeviceError(t *testing.T) {
+	observed := map[string]v1alpha1.NicDevice{
+		"0000:3b:00": newObservedDevice(runOnceTestPCI, "nic"),
+	}
+
+	funcs := interceptor.Funcs{
+		SubResourceUpdate: func(_ context.Context, _ client.Client, _ string, _ client.Object, _ ...client.SubResourceUpdateOption) error {
+			return errors.New("simulated status update failure")
+		},
+	}
+	ctrl := buildRunOnceFixture(t, nil, observed, funcs)
+
+	err := ctrl.RunOnce(context.Background())
+	if err == nil {
+		t.Fatal("expected per-device error, got nil")
+	}
+	if !strings.Contains(err.Error(), "per-device error") {
+		t.Fatalf("expected error to mention 'per-device error', got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "simulated status update failure") {
+		t.Fatalf("expected error to wrap the underlying failure, got %q", err.Error())
+	}
+}
+
+func TestRunOnce_DeleteFails_ReturnsPerDeviceError(t *testing.T) {
+	// A CR exists for a device that's no longer observed → reconcile tries to delete it.
+	existing := []*v1alpha1.NicDevice{
+		newExistingCR("stale-cr", "0000:aa:00.0", runOnceTestNode),
+	}
+	// observed map doesn't contain 0000:aa:00, so reconcile will attempt to delete the stale CR.
+	observed := map[string]v1alpha1.NicDevice{}
+
+	funcs := interceptor.Funcs{
+		Delete: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.DeleteOption) error {
+			return errors.New("simulated delete failure")
+		},
+	}
+	ctrl := buildRunOnceFixture(t, existing, observed, funcs)
+
+	err := ctrl.RunOnce(context.Background())
+	if err == nil {
+		t.Fatal("expected per-device error, got nil")
+	}
+	if !strings.Contains(err.Error(), "per-device error") {
+		t.Fatalf("expected error to mention 'per-device error', got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "simulated delete failure") {
+		t.Fatalf("expected error to wrap the underlying failure, got %q", err.Error())
+	}
+}
+
+func TestReconcile_PeriodicMode_SwallowsPerDeviceErrors(t *testing.T) {
+	// Regression check: passing nil for perDeviceErrs (operator's periodic loop path) must
+	// preserve the existing best-effort behavior — Delete failures are logged but reconcile
+	// still returns nil so the 5-minute tick keeps the loop alive.
+	existing := []*v1alpha1.NicDevice{
+		newExistingCR("stale-cr", "0000:aa:00.0", runOnceTestNode),
+	}
+	observed := map[string]v1alpha1.NicDevice{}
+
+	funcs := interceptor.Funcs{
+		Delete: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.DeleteOption) error {
+			return errors.New("simulated delete failure")
+		},
+	}
+	ctrl := buildRunOnceFixture(t, existing, observed, funcs)
+
+	if err := ctrl.reconcile(context.Background(), nil); err != nil {
+		t.Fatalf("periodic-mode reconcile should swallow per-device errors, got %v", err)
+	}
+}
+
+func TestRunUntilSuccess_RetriesPerDeviceErrorsThenSucceeds(t *testing.T) {
+	// First call: Status().Update fails → RunOnce surfaces an error → retry triggers.
+	// Second call: interceptor lets the update through → RunOnce returns nil → retry exits.
+	observed := map[string]v1alpha1.NicDevice{
+		"0000:3b:00": newObservedDevice(runOnceTestPCI, "nic"),
+	}
+
+	var statusUpdateCalls atomic.Int32
+	funcs := interceptor.Funcs{
+		SubResourceUpdate: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+			if statusUpdateCalls.Add(1) == 1 {
+				return errors.New("transient status update failure")
+			}
+			return c.Status().Update(ctx, obj, opts...)
+		},
+	}
+	ctrl := buildRunOnceFixture(t, nil, observed, funcs)
+
+	// Use a microsecond interval to keep the test fast.
+	if err := ctrl.RunUntilSuccess(context.Background(), 5, 0); err != nil {
+		t.Fatalf("expected retry to recover, got %v", err)
+	}
+	if got := statusUpdateCalls.Load(); got != 2 {
+		t.Fatalf("expected 2 Status().Update attempts (1 fail + 1 success), got %d", got)
+	}
+}


### PR DESCRIPTION
Run a single device-discovery + NicDevice CR sync cycle and exit, retrying up to 10 times on failure. Lets k8s-launch-kit (and similar tools) consume the daemon as a one-shot Job instead of bootstrapping a long-running DaemonSet just to read NicDevice CRs.