### PR TITLE
Load Spectrum-X profiles from cluster ConfigMaps

### DIFF
--- a/cmd/nic-configuration-daemon/main.go
+++ b/cmd/nic-configuration-daemon/main.go
@@ -23,11 +23,15 @@ import (
 	"slices"
 
 	maintenanceoperator "github.com/Mellanox/maintenance-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/selection"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -61,11 +65,28 @@ func main() {
 	utilruntime.Must(maintenanceoperator.AddToScheme(scheme))
 	utilruntime.Must(v1alpha1.AddToScheme(scheme))
 
+	// Restrict the cached ConfigMap informer to objects carrying the Spectrum-X profile label
+	// (any value), so the daemon doesn't watch/cache every ConfigMap in the cluster. The
+	// firmware-map ConfigMap is read via a raw client (helper.InitNicFwMapFromConfigMap), not
+	// the cached client, so this narrowing is safe.
+	spectrumXProfileReq, err := labels.NewRequirement(consts.SpectrumXProfileLabel, selection.Exists, nil)
+	if err != nil {
+		log.Log.Error(err, "unable to build spectrum-x profile label selector")
+		os.Exit(1)
+	}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,
 		// Setting bind address to 0 disables the health probe / metrics server
 		HealthProbeBindAddress: "0",
 		Metrics:                metricsserver.Options{BindAddress: "0"},
+		Cache: cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				&corev1.ConfigMap{}: {
+					Label: labels.NewSelector().Add(*spectrumXProfileReq),
+				},
+			},
+		},
 	})
 	if err != nil {
 		log.Log.Error(err, "unable to create manager")
@@ -171,6 +192,16 @@ func main() {
 	}
 	if err = nicInterfaceNameTemplateReconciler.SetupWithManager(mgr); err != nil {
 		log.Log.Error(err, "unable to create controller", "controller", "NicInterfaceNameTemplateReconciler")
+		os.Exit(1)
+	}
+
+	spectrumXProfileReconciler := &controller.SpectrumXProfileReconciler{
+		Client:           mgr.GetClient(),
+		Scheme:           mgr.GetScheme(),
+		SpectrumXManager: spectrumXConfigManager,
+	}
+	if err = spectrumXProfileReconciler.SetupWithManager(mgr); err != nil {
+		log.Log.Error(err, "unable to create controller", "controller", "SpectrumXProfileReconciler")
 		os.Exit(1)
 	}
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -10,6 +10,8 @@ rules:
   - configmaps
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/deployment/nic-configuration-operator-chart/templates/role.yaml
+++ b/deployment/nic-configuration-operator-chart/templates/role.yaml
@@ -11,6 +11,8 @@ rules:
     - configmaps
   verbs:
     - get
+    - list
+    - watch
 - apiGroups:
     - ""
   resources:

--- a/internal/controller/nicconfigurationtemplate_controller.go
+++ b/internal/controller/nicconfigurationtemplate_controller.go
@@ -63,7 +63,7 @@ type nicConfigurationTemplate struct {
 //+kubebuilder:rbac:groups=configuration.net.nvidia.com,resources=nicinterfacenametemplates,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=configuration.net.nvidia.com,resources=nicinterfacenametemplates/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch;update;patch
-//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=pods,verbs=list
 //+kubebuilder:rbac:groups="",resources=pods/eviction,verbs=create;delete;get;list;patch;update;watch
 //+kubebuilder:rbac:groups=maintenance.nvidia.com,resources=nodemaintenances,verbs=get;list;watch;create;update;patch;delete

--- a/internal/controller/spectrumxprofile_controller.go
+++ b/internal/controller/spectrumxprofile_controller.go
@@ -1,0 +1,146 @@
+/*
+2026 NVIDIA CORPORATION & AFFILIATES
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/Mellanox/nic-configuration-operator/pkg/consts"
+	"github.com/Mellanox/nic-configuration-operator/pkg/spectrumx"
+	"github.com/Mellanox/nic-configuration-operator/pkg/types"
+)
+
+// SpectrumXProfileReconciler reconciles Spectrum-X profile ConfigMaps (selected by
+// consts.SpectrumXProfileLabel, in any namespace) and pushes the parsed profile into the
+// SpectrumXManager. The ConfigMap name is used as the Spectrum-X version key referenced by
+// template.spectrumXOptimized.version.
+type SpectrumXProfileReconciler struct {
+	client.Client
+	Scheme           *runtime.Scheme
+	SpectrumXManager spectrumx.SpectrumXManager
+
+	// owners records which ConfigMap currently provides each Spectrum-X version. Since the
+	// version key is the ConfigMap name and ConfigMaps are watched cluster-wide, two same-named
+	// ConfigMaps in different namespaces map to the same version. owners makes that conflict
+	// visible and ensures that deleting a non-owning duplicate does not wipe the active profile.
+	ownersMu sync.Mutex
+	owners   map[string]client.ObjectKey
+}
+
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
+
+// Reconcile loads (or removes) the Spectrum-X profile carried by the reconciled ConfigMap.
+func (r *SpectrumXProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	reqLog := log.FromContext(ctx)
+
+	cm := &corev1.ConfigMap{}
+	err := r.Get(ctx, req.NamespacedName, cm)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// ConfigMap was deleted - drop the corresponding profile from the manager.
+			r.removeProfile(ctx, req.NamespacedName)
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	// Defensive: if the selector label is gone (e.g. it was removed), treat as removal. The
+	// cache informer is filtered by the label, so a label removal surfaces as a delete event,
+	// but a stale object could still reach us here.
+	if _, ok := cm.Labels[consts.SpectrumXProfileLabel]; !ok {
+		reqLog.Info("Spectrum-X profile label removed from ConfigMap, removing profile", "version", req.Name)
+		r.removeProfile(ctx, req.NamespacedName)
+		return ctrl.Result{}, nil
+	}
+
+	data, ok := cm.Data[consts.SpectrumXProfileConfigMapDataKey]
+	if !ok || strings.TrimSpace(data) == "" {
+		// Missing or blank profile payload - return an error to requeue until it is fixed.
+		return ctrl.Result{}, fmt.Errorf(
+			"spectrum-x profile ConfigMap %s/%s is missing or has an empty %q data key",
+			req.Namespace, req.Name, consts.SpectrumXProfileConfigMapDataKey)
+	}
+
+	config, err := types.ParseSpectrumXConfig([]byte(data))
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf(
+			"failed to parse spectrum-x profile from ConfigMap %s/%s: %w", req.Namespace, req.Name, err)
+	}
+
+	r.ownersMu.Lock()
+	defer r.ownersMu.Unlock()
+	if r.owners == nil {
+		r.owners = map[string]client.ObjectKey{}
+	}
+	if owner, exists := r.owners[req.Name]; exists && owner != req.NamespacedName {
+		reqLog.Info("Multiple ConfigMaps define the same Spectrum-X version; the latest reconcile wins",
+			"version", req.Name, "previousOwner", owner.String(), "newOwner", req.String())
+	}
+	r.owners[req.Name] = req.NamespacedName
+
+	reqLog.Info("Loaded Spectrum-X profile", "version", req.Name, "configMap", req.String())
+	r.SpectrumXManager.SetConfig(req.Name, config)
+
+	return ctrl.Result{}, nil
+}
+
+// removeProfile drops the profile for a version, but only when the reconciled ConfigMap is the
+// current owner (or no owner is recorded). This prevents a duplicate same-named ConfigMap in a
+// different namespace from wiping the profile that another ConfigMap is actively providing.
+func (r *SpectrumXProfileReconciler) removeProfile(ctx context.Context, key client.ObjectKey) {
+	reqLog := log.FromContext(ctx)
+	r.ownersMu.Lock()
+	defer r.ownersMu.Unlock()
+	if owner, exists := r.owners[key.Name]; exists && owner != key {
+		reqLog.Info("Ignoring removal of non-owning Spectrum-X profile ConfigMap",
+			"version", key.Name, "removed", key.String(), "owner", owner.String())
+		return
+	}
+	delete(r.owners, key.Name)
+	reqLog.Info("Removing Spectrum-X profile", "version", key.Name, "configMap", key.String())
+	r.SpectrumXManager.RemoveConfig(key.Name)
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *SpectrumXProfileReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if r.owners == nil {
+		r.owners = map[string]client.ObjectKey{}
+	}
+
+	// Only reconcile ConfigMaps carrying the Spectrum-X profile label. This predicate complements
+	// the manager's cache selector (see cmd/nic-configuration-daemon/main.go), which already
+	// restricts the cached ConfigMap informer to labeled objects.
+	hasProfileLabel := predicate.NewPredicateFuncs(func(o client.Object) bool {
+		_, ok := o.GetLabels()[consts.SpectrumXProfileLabel]
+		return ok
+	})
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.ConfigMap{}, builder.WithPredicates(hasProfileLabel)).
+		Complete(r)
+}

--- a/internal/controller/spectrumxprofile_controller_test.go
+++ b/internal/controller/spectrumxprofile_controller_test.go
@@ -1,0 +1,181 @@
+/*
+2026 NVIDIA CORPORATION & AFFILIATES
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/Mellanox/nic-configuration-operator/pkg/consts"
+	spectrumxmocks "github.com/Mellanox/nic-configuration-operator/pkg/spectrumx/mocks"
+)
+
+const validSpectrumXProfile = `
+useSoftwareCCAlgorithm: true
+docaCCVersion: "1.0"
+mlxConfig:
+  swplb:
+    "1023":
+      postBreakout:
+        SRIOV_EN: "1"
+runtimeConfig:
+  roce: []
+`
+
+func newProfileReconciler(t *testing.T, objs ...*corev1.ConfigMap) (*SpectrumXProfileReconciler, *spectrumxmocks.SpectrumXManager) {
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add scheme: %v", err)
+	}
+
+	builder := fake.NewClientBuilder().WithScheme(scheme)
+	for _, o := range objs {
+		builder = builder.WithObjects(o)
+	}
+
+	mgr := spectrumxmocks.NewSpectrumXManager(t)
+	return &SpectrumXProfileReconciler{
+		Client:           builder.Build(),
+		Scheme:           scheme,
+		SpectrumXManager: mgr,
+	}, mgr
+}
+
+// All tests use a single (version, namespace) pair; the controller keys the manager map on the
+// ConfigMap name, and namespace is irrelevant since profile ConfigMaps may live in any namespace.
+const (
+	testProfileVersion = "RA2.0"
+	testProfileNS      = "any-ns"
+)
+
+func profileConfigMap(withLabel bool, data map[string]string) *corev1.ConfigMap {
+	labels := map[string]string{}
+	if withLabel {
+		labels[consts.SpectrumXProfileLabel] = ""
+	}
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: testProfileVersion, Namespace: testProfileNS, Labels: labels},
+		Data:       data,
+	}
+}
+
+func reconcileProfile(r *SpectrumXProfileReconciler) (ctrl.Result, error) {
+	return r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: testProfileVersion, Namespace: testProfileNS},
+	})
+}
+
+func TestSpectrumXProfile_SetConfigOnValidConfigMap(t *testing.T) {
+	cm := profileConfigMap(true, map[string]string{
+		consts.SpectrumXProfileConfigMapDataKey: validSpectrumXProfile,
+	})
+	r, mgr := newProfileReconciler(t, cm)
+	mgr.On("SetConfig", testProfileVersion, mock.AnythingOfType("*types.SpectrumXConfig")).Once()
+
+	if _, err := reconcileProfile(r); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSpectrumXProfile_RemoveConfigOnDeletedConfigMap(t *testing.T) {
+	// No ConfigMap in the fake client => Get returns NotFound => RemoveConfig.
+	r, mgr := newProfileReconciler(t)
+	mgr.On("RemoveConfig", testProfileVersion).Once()
+
+	if _, err := reconcileProfile(r); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSpectrumXProfile_RemoveConfigWhenLabelMissing(t *testing.T) {
+	cm := profileConfigMap(false, map[string]string{
+		consts.SpectrumXProfileConfigMapDataKey: validSpectrumXProfile,
+	})
+	r, mgr := newProfileReconciler(t, cm)
+	mgr.On("RemoveConfig", testProfileVersion).Once()
+
+	if _, err := reconcileProfile(r); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSpectrumXProfile_ErrorWhenDataKeyMissing(t *testing.T) {
+	cm := profileConfigMap(true, map[string]string{"other": "x"})
+	r, _ := newProfileReconciler(t, cm)
+
+	if _, err := reconcileProfile(r); err == nil {
+		t.Fatal("expected error for missing profile data key, got nil")
+	}
+}
+
+func TestSpectrumXProfile_ErrorWhenYAMLMalformed(t *testing.T) {
+	cm := profileConfigMap(true, map[string]string{
+		consts.SpectrumXProfileConfigMapDataKey: "mlxConfig: [bad: yaml",
+	})
+	r, _ := newProfileReconciler(t, cm)
+
+	if _, err := reconcileProfile(r); err == nil {
+		t.Fatal("expected error for malformed YAML, got nil")
+	}
+}
+
+func TestSpectrumXProfile_ErrorWhenDataKeyWhitespaceOnly(t *testing.T) {
+	cm := profileConfigMap(true, map[string]string{
+		consts.SpectrumXProfileConfigMapDataKey: "   \n\t ",
+	})
+	r, _ := newProfileReconciler(t, cm)
+
+	if _, err := reconcileProfile(r); err == nil {
+		t.Fatal("expected error for whitespace-only profile data, got nil")
+	}
+}
+
+func TestSpectrumXProfile_DeleteOfNonOwnerKeepsActiveProfile(t *testing.T) {
+	// ConfigMap "RA2.0" in ns-a is the active owner of the version.
+	cmA := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testProfileVersion, Namespace: "ns-a",
+			Labels: map[string]string{consts.SpectrumXProfileLabel: ""},
+		},
+		Data: map[string]string{consts.SpectrumXProfileConfigMapDataKey: validSpectrumXProfile},
+	}
+	r, mgr := newProfileReconciler(t, cmA)
+	// Establish ownership; SetConfig is expected exactly once. RemoveConfig must NOT be called.
+	mgr.On("SetConfig", testProfileVersion, mock.AnythingOfType("*types.SpectrumXConfig")).Once()
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: testProfileVersion, Namespace: "ns-a"},
+	}); err != nil {
+		t.Fatalf("unexpected error establishing ownership: %v", err)
+	}
+
+	// A same-named ConfigMap in ns-b is deleted (not present in the client => NotFound). Because
+	// ns-a owns the version, the active profile must be preserved (no RemoveConfig call). The
+	// mock cleanup would fail if RemoveConfig were called without an expectation.
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: testProfileVersion, Namespace: "ns-b"},
+	}); err != nil {
+		t.Fatalf("unexpected error on non-owner delete: %v", err)
+	}
+}

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -120,10 +120,17 @@ const (
 	HostPath = "/host"
 
 	SupportedNicFirmwareConfigmap = "nic-configuration-operator-supported-nic-firmware"
-	Mlx5ModuleVersionPath         = "/sys/bus/pci/drivers/mlx5_core/module/version"
-	Mlx5CoreDriverName            = "mlx5_core"
-	PCIDevicesSysfsPath           = "/sys/bus/pci/devices"
-	Mlx5CoreDriverBindPath        = "/sys/bus/pci/drivers/mlx5_core/bind"
+
+	// SpectrumXProfileLabel selects ConfigMaps that carry a Spectrum-X profile.
+	// Presence of the key selects the ConfigMap; its value is ignored.
+	SpectrumXProfileLabel = "network.nvidia.com/operator.nic-configuration.spectrum-x-profile"
+	// SpectrumXProfileConfigMapDataKey is the ConfigMap Data key holding the SpectrumXConfig YAML.
+	// The ConfigMap name is used as the Spectrum-X version key (template.spectrumXOptimized.version).
+	SpectrumXProfileConfigMapDataKey = "profile"
+	Mlx5ModuleVersionPath            = "/sys/bus/pci/drivers/mlx5_core/module/version"
+	Mlx5CoreDriverName               = "mlx5_core"
+	PCIDevicesSysfsPath              = "/sys/bus/pci/devices"
+	Mlx5CoreDriverBindPath           = "/sys/bus/pci/drivers/mlx5_core/bind"
 
 	FwConfigNotAppliedAfterRebootErrorMsg = "firmware configuration failed to apply after reboot"
 

--- a/pkg/spectrumx/mocks/SpectrumXManager.go
+++ b/pkg/spectrumx/mocks/SpectrumXManager.go
@@ -199,6 +199,16 @@ func (_m *SpectrumXManager) RuntimeConfigApplied(device *v1alpha1.NicDevice) (bo
 	return r0, r1
 }
 
+// SetConfig provides a mock function with given fields: version, config
+func (_m *SpectrumXManager) SetConfig(version string, config *types.SpectrumXConfig) {
+	_m.Called(version, config)
+}
+
+// RemoveConfig provides a mock function with given fields: version
+func (_m *SpectrumXManager) RemoveConfig(version string) {
+	_m.Called(version)
+}
+
 // NewSpectrumXManager creates a new instance of SpectrumXManager. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewSpectrumXManager(t interface {

--- a/pkg/spectrumx/spectrumx.go
+++ b/pkg/spectrumx/spectrumx.go
@@ -67,9 +67,18 @@ type SpectrumXManager interface {
 	// GetCCTerminationChannel returns a read-only channel that receives the RDMA interface name
 	// when a DOCA SPC-X CC process terminates unexpectedly after startup
 	GetCCTerminationChannel() <-chan string
+	// SetConfig upserts the Spectrum-X profile for the given version (e.g. "RA2.0").
+	// Called by the SpectrumXProfileReconciler when a profile ConfigMap is created/updated.
+	SetConfig(version string, config *types.SpectrumXConfig)
+	// RemoveConfig removes the Spectrum-X profile for the given version.
+	// Called by the SpectrumXProfileReconciler when a profile ConfigMap is deleted.
+	RemoveConfig(version string)
 }
 
 type spectrumXConfigManager struct {
+	// configMutex guards spectrumXConfigs, which is mutated at runtime by the
+	// SpectrumXProfileReconciler while being read from reconcile goroutines.
+	configMutex      sync.RWMutex
 	spectrumXConfigs map[string]*types.SpectrumXConfig
 	dmsManager       dms.DMSManager
 	execInterface    execUtils.Interface
@@ -112,10 +121,32 @@ func filterParameters(params []types.ConfigurationParameter, deviceType string, 
 	return filtered
 }
 
+// getConfig returns the SpectrumXConfig for a version under a read lock.
+func (m *spectrumXConfigManager) getConfig(version string) (*types.SpectrumXConfig, bool) {
+	m.configMutex.RLock()
+	defer m.configMutex.RUnlock()
+	config, ok := m.spectrumXConfigs[version]
+	return config, ok
+}
+
+// SetConfig upserts the Spectrum-X profile for the given version.
+func (m *spectrumXConfigManager) SetConfig(version string, config *types.SpectrumXConfig) {
+	m.configMutex.Lock()
+	defer m.configMutex.Unlock()
+	m.spectrumXConfigs[version] = config
+}
+
+// RemoveConfig removes the Spectrum-X profile for the given version.
+func (m *spectrumXConfigManager) RemoveConfig(version string) {
+	m.configMutex.Lock()
+	defer m.configMutex.Unlock()
+	delete(m.spectrumXConfigs, version)
+}
+
 // getDesiredConfig looks up the SpectrumXConfig for the device's version
 func (m *spectrumXConfigManager) getDesiredConfig(device *v1alpha1.NicDevice) (*types.SpectrumXConfig, error) {
 	version := device.Spec.Configuration.Template.SpectrumXOptimized.Version
-	config, ok := m.spectrumXConfigs[version]
+	config, ok := m.getConfig(version)
 	if !ok {
 		return nil, fmt.Errorf("spectrum-x config version %s not found", version)
 	}
@@ -318,7 +349,7 @@ func (m *spectrumXConfigManager) RuntimeConfigApplied(device *v1alpha1.NicDevice
 	log.Log.Info("SpectrumXConfigManager.RuntimeConfigApplied()", "device", device.Name)
 
 	spcXSpec := device.Spec.Configuration.Template.SpectrumXOptimized
-	desiredConfig, found := m.spectrumXConfigs[spcXSpec.Version]
+	desiredConfig, found := m.getConfig(spcXSpec.Version)
 	if !found {
 		return false, fmt.Errorf("spectrumx config not found for version %s", spcXSpec.Version)
 	}
@@ -472,7 +503,7 @@ func (m *spectrumXConfigManager) RuntimeConfigApplied(device *v1alpha1.NicDevice
 // ApplyRuntimeConfig applies the desired Spectrum-X runtime spec to the device
 func (m *spectrumXConfigManager) ApplyRuntimeConfig(device *v1alpha1.NicDevice) (*types.RuntimeConfigurationApplyResult, error) {
 	spcXSpec := device.Spec.Configuration.Template.SpectrumXOptimized
-	desiredConfig, found := m.spectrumXConfigs[spcXSpec.Version]
+	desiredConfig, found := m.getConfig(spcXSpec.Version)
 	if !found {
 		return &types.RuntimeConfigurationApplyResult{Status: types.ApplyStatusFailed}, fmt.Errorf("spectrumx config not found for version %s", spcXSpec.Version)
 	}
@@ -634,7 +665,7 @@ func (m *spectrumXConfigManager) GetDocaCCTargetVersion(device *v1alpha1.NicDevi
 	}
 
 	spcXVersion := device.Spec.Configuration.Template.SpectrumXOptimized.Version
-	config, found := m.spectrumXConfigs[spcXVersion]
+	config, found := m.getConfig(spcXVersion)
 	if !found {
 		return "", fmt.Errorf("spectrumx config not found for version %s", spcXVersion)
 	}
@@ -730,6 +761,11 @@ func (m *spectrumXConfigManager) GetCCTerminationChannel() <-chan string {
 }
 
 func NewSpectrumXConfigManager(dmsManager dms.DMSManager, spectrumXConfigs map[string]*types.SpectrumXConfig) SpectrumXManager {
+	// Ensure the map is always usable so SetConfig is safe even when started with no configs
+	// (the operator daemon loads profiles at runtime from ConfigMaps via SetConfig).
+	if spectrumXConfigs == nil {
+		spectrumXConfigs = map[string]*types.SpectrumXConfig{}
+	}
 	return &spectrumXConfigManager{
 		dmsManager:        dmsManager,
 		spectrumXConfigs:  spectrumXConfigs,

--- a/pkg/types/spectrumx.go
+++ b/pkg/types/spectrumx.go
@@ -64,19 +64,25 @@ type ConfigurationParameter struct {
 	HwplbFirstPortOnly bool   `yaml:"hwplbFirstPortOnly,omitempty"`
 }
 
-func LoadSpectrumXConfig(configPath string) (*SpectrumXConfig, error) {
+// ParseSpectrumXConfig unmarshals a SpectrumXConfig from raw YAML bytes.
+// Used to load profiles delivered via in-cluster ConfigMaps.
+func ParseSpectrumXConfig(data []byte) (*SpectrumXConfig, error) {
 	spectrumXConfig := &SpectrumXConfig{}
-
-	data, err := os.ReadFile(configPath)
-	if err != nil {
-		return nil, err
-	}
 
 	if err := yaml.Unmarshal(data, spectrumXConfig); err != nil {
 		return nil, err
 	}
 
 	return spectrumXConfig, nil
+}
+
+func LoadSpectrumXConfig(configPath string) (*SpectrumXConfig, error) {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return ParseSpectrumXConfig(data)
 }
 
 const ValuesDoNotMatchErrorPrefix = "values do not match"

--- a/pkg/types/spectrumx_test.go
+++ b/pkg/types/spectrumx_test.go
@@ -92,3 +92,23 @@ var _ = Describe("LoadSpectrumXConfig", func() {
 		Expect(err).To(HaveOccurred())
 	})
 })
+
+var _ = Describe("ParseSpectrumXConfig", func() {
+	It("parses raw YAML bytes and populates fields", func() {
+		cfg, err := ParseSpectrumXConfig([]byte(spectrumXTestYAML))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cfg).ToNot(BeNil())
+
+		Expect(cfg.MlxConfig).To(HaveKey("swplb"))
+		swplb := cfg.MlxConfig["swplb"]["1023"]
+		Expect(swplb.Breakout).To(HaveKey(2))
+		Expect(swplb.PostBreakout).To(HaveKeyWithValue("SRIOV_EN", "1"))
+		Expect(cfg.UseSoftwareCCAlgorithm).To(BeTrue())
+		Expect(cfg.DocaCCVersion).To(Equal("1.0"))
+	})
+
+	It("returns an error on malformed YAML", func() {
+		_, err := ParseSpectrumXConfig([]byte("mlxConfig: [this is: not valid"))
+		Expect(err).To(HaveOccurred())
+	})
+})


### PR DESCRIPTION
Spectrum-X profile YAMLs are no longer embedded in the daemon image. They are now delivered as in-cluster ConfigMaps and loaded at runtime by a new SpectrumXProfileReconciler running inside every nic-configuration-daemon.

- Selection: ConfigMaps carrying the label network.nvidia.com/operator.nic-configuration.spectrum-x-profile (presence-only), in any namespace.
- Layout: one ConfigMap per version; the ConfigMap name is the version key referenced by template.spectrumXOptimized.version. Profile YAML lives under the fixed Data key "profile", parsed by types.ParseSpectrumXConfig.
- Flow: create/update -> SpectrumXManager.SetConfig; delete or label removal -> RemoveConfig. Unknown version errors in getDesiredConfig and requeues until the profile CM appears (eventually consistent).
- SpectrumXManager gains thread-safe SetConfig/RemoveConfig (configMutex RWMutex); all config reads go through getConfig.
- main.go restricts the cached ConfigMap informer to labeled objects so the daemon does not watch every ConfigMap cluster-wide.
- RBAC: configmaps get;list;watch cluster-wide (kubebuilder marker + generated role.yaml + Helm role.yaml).