### PR TITLE
fix: allow custom names for SPC-X profiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ COPY ./ ./
 #RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/maintenance-manager/main.go
 RUN --mount=type=cache,target=/go/pkg/mod/ GO_GCFLAGS=${GCFLAGS} make build-manager
 
-FROM ${BASE_IMAGE_DOCA_FULL_RT_HOST:-nvcr.io/nvidia/doca/doca:3.3.0-full-rt-host}
+FROM ${BASE_IMAGE_DOCA_FULL_RT_HOST:-nvcr.io/nvstaging/doca/doca:full-rt-3.5.0-host-dev}
 
 ARG TARGETARCH
 

--- a/Dockerfile.nic-configuration-daemon
+++ b/Dockerfile.nic-configuration-daemon
@@ -26,7 +26,7 @@ COPY ./ ./
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN --mount=type=cache,target=/go/pkg/mod/ GO_GCFLAGS=${GCFLAGS} make build-daemon
 
-FROM ${BASE_IMAGE_DOCA_FULL_RT_HOST:-nvcr.io/nvidia/doca/doca:3.3.0-full-rt-host}
+FROM ${BASE_IMAGE_DOCA_FULL_RT_HOST:-nvcr.io/nvstaging/doca/doca:full-rt-3.5.0-host-dev}
 
 ARG TARGETARCH
 

--- a/api/v1alpha1/nicconfigurationtemplate_types.go
+++ b/api/v1alpha1/nicconfigurationtemplate_types.go
@@ -123,12 +123,10 @@ type GpuDirectOptimizedSpec struct {
 // SpectrumXOptimizedSpec enables Spectrum-X specific optimizations
 // +kubebuilder:validation:XValidation:rule="!has(self.multiplaneMode) || !has(self.numberOfPlanes) || self.multiplaneMode != 'none' || self.numberOfPlanes == 1",message="when MultiplaneMode is none, numberOfPlanes must be 1"
 // +kubebuilder:validation:XValidation:rule="!has(self.multiplaneMode) || !has(self.numberOfPlanes) || self.multiplaneMode == 'none' || self.numberOfPlanes != 1",message="when MultiplaneMode is not none, numberOfPlanes must not be 1"
-// +kubebuilder:validation:XValidation:rule="!has(self.version) || !has(self.multiplaneMode) || !has(self.numberOfPlanes) || !(self.version == 'RA1.3' || self.version == 'RA2.0') || (self.multiplaneMode == 'none' && self.numberOfPlanes == 1)",message="when Version is RA1.3 or RA2.0, MultiplaneMode must be none and numberOfPlanes must be 1"
 type SpectrumXOptimizedSpec struct {
 	// Optimize Spectrum X
 	Enabled bool `json:"enabled"`
-	// Version of the Spectrum-X architecture to optimize for
-	// +kubebuilder:validation:Enum=RA1.3;RA2.0;RA2.1;RA2.2
+	// Version of the Spectrum-X architecture to optimize for. Should match the name of the config map with Spectrum-X profile 
 	// +required
 	Version string `json:"version"`
 	// Overlay mode to be configured

--- a/config/crd/bases/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
+++ b/config/crd/bases/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
@@ -307,12 +307,8 @@ spec:
                         type: string
                       version:
                         description: Version of the Spectrum-X architecture to optimize
-                          for
-                        enum:
-                        - RA1.3
-                        - RA2.0
-                        - RA2.1
-                        - RA2.2
+                          for. Should match the name of the config map with Spectrum-X
+                          profile
                         type: string
                     required:
                     - enabled
@@ -329,12 +325,6 @@ spec:
                       rule: '!has(self.multiplaneMode) || !has(self.numberOfPlanes)
                         || self.multiplaneMode == ''none'' || self.numberOfPlanes
                         != 1'
-                    - message: when Version is RA1.3 or RA2.0, MultiplaneMode must
-                        be none and numberOfPlanes must be 1
-                      rule: '!has(self.version) || !has(self.multiplaneMode) || !has(self.numberOfPlanes)
-                        || !(self.version == ''RA1.3'' || self.version == ''RA2.0'')
-                        || (self.multiplaneMode == ''none'' && self.numberOfPlanes
-                        == 1)'
                 required:
                 - numVfs
                 type: object

--- a/config/crd/bases/configuration.net.nvidia.com_nicdevices.yaml
+++ b/config/crd/bases/configuration.net.nvidia.com_nicdevices.yaml
@@ -276,12 +276,8 @@ spec:
                             type: string
                           version:
                             description: Version of the Spectrum-X architecture to
-                              optimize for
-                            enum:
-                            - RA1.3
-                            - RA2.0
-                            - RA2.1
-                            - RA2.2
+                              optimize for. Should match the name of the config map
+                              with Spectrum-X profile
                             type: string
                         required:
                         - enabled
@@ -298,12 +294,6 @@ spec:
                           rule: '!has(self.multiplaneMode) || !has(self.numberOfPlanes)
                             || self.multiplaneMode == ''none'' || self.numberOfPlanes
                             != 1'
-                        - message: when Version is RA1.3 or RA2.0, MultiplaneMode
-                            must be none and numberOfPlanes must be 1
-                          rule: '!has(self.version) || !has(self.multiplaneMode) ||
-                            !has(self.numberOfPlanes) || !(self.version == ''RA1.3''
-                            || self.version == ''RA2.0'') || (self.multiplaneMode
-                            == ''none'' && self.numberOfPlanes == 1)'
                     required:
                     - numVfs
                     type: object

--- a/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
+++ b/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
@@ -307,12 +307,8 @@ spec:
                         type: string
                       version:
                         description: Version of the Spectrum-X architecture to optimize
-                          for
-                        enum:
-                        - RA1.3
-                        - RA2.0
-                        - RA2.1
-                        - RA2.2
+                          for. Should match the name of the config map with Spectrum-X
+                          profile
                         type: string
                     required:
                     - enabled
@@ -329,12 +325,6 @@ spec:
                       rule: '!has(self.multiplaneMode) || !has(self.numberOfPlanes)
                         || self.multiplaneMode == ''none'' || self.numberOfPlanes
                         != 1'
-                    - message: when Version is RA1.3 or RA2.0, MultiplaneMode must
-                        be none and numberOfPlanes must be 1
-                      rule: '!has(self.version) || !has(self.multiplaneMode) || !has(self.numberOfPlanes)
-                        || !(self.version == ''RA1.3'' || self.version == ''RA2.0'')
-                        || (self.multiplaneMode == ''none'' && self.numberOfPlanes
-                        == 1)'
                 required:
                 - numVfs
                 type: object

--- a/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicdevices.yaml
+++ b/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicdevices.yaml
@@ -276,12 +276,8 @@ spec:
                             type: string
                           version:
                             description: Version of the Spectrum-X architecture to
-                              optimize for
-                            enum:
-                            - RA1.3
-                            - RA2.0
-                            - RA2.1
-                            - RA2.2
+                              optimize for. Should match the name of the config map
+                              with Spectrum-X profile
                             type: string
                         required:
                         - enabled
@@ -298,12 +294,6 @@ spec:
                           rule: '!has(self.multiplaneMode) || !has(self.numberOfPlanes)
                             || self.multiplaneMode == ''none'' || self.numberOfPlanes
                             != 1'
-                        - message: when Version is RA1.3 or RA2.0, MultiplaneMode
-                            must be none and numberOfPlanes must be 1
-                          rule: '!has(self.version) || !has(self.multiplaneMode) ||
-                            !has(self.numberOfPlanes) || !(self.version == ''RA1.3''
-                            || self.version == ''RA2.0'') || (self.multiplaneMode
-                            == ''none'' && self.numberOfPlanes == 1)'
                     required:
                     - numVfs
                     type: object


### PR DESCRIPTION
Since now the profiles come from CFG maps, we don't need to restrict their names