### PR TITLE
configuration: stop managing ADVANCED_PCI_SETTINGS

### DIFF
--- a/api/v1alpha1/nicconfigurationtemplate_types.go
+++ b/api/v1alpha1/nicconfigurationtemplate_types.go
@@ -126,7 +126,7 @@ type GpuDirectOptimizedSpec struct {
 type SpectrumXOptimizedSpec struct {
 	// Optimize Spectrum X
 	Enabled bool `json:"enabled"`
-	// Version of the Spectrum-X architecture to optimize for. Should match the name of the config map with Spectrum-X profile 
+	// Version of the Spectrum-X architecture to optimize for. Should match the name of the config map with Spectrum-X profile
 	// +required
 	Version string `json:"version"`
 	// Overlay mode to be configured

--- a/internal/controller/nicdevice_controller.go
+++ b/internal/controller/nicdevice_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -87,6 +88,9 @@ type nicDeviceConfigurationStatus struct {
 	requestedFirmwareVersion     string
 	nvConfigUpdateRequired       bool
 	rebootRequired               bool
+	// unsupportedNvParams lists desired nv params that are hidden on this device (absent from
+	// NextBootConfig). Surfaces as PartiallyApplied in the ConfigUpdateInProgress condition.
+	unsupportedNvParams []string
 }
 
 // Reconcile reconciles the NicConfigurationTemplate object
@@ -558,7 +562,13 @@ func (r *NicDeviceReconciler) applyRuntimeConfig(ctx context.Context, status *ni
 		return err
 	}
 
-	err = r.updateConfigInProgressStatusCondition(ctx, status.device, consts.UpdateSuccessfulReason, metav1.ConditionFalse, "")
+	reason := consts.UpdateSuccessfulReason
+	message := ""
+	if len(status.unsupportedNvParams) > 0 {
+		reason = consts.PartiallyAppliedReason
+		message = fmt.Sprintf(consts.PartiallyAppliedMessageFmt, strings.Join(status.unsupportedNvParams, ", "))
+	}
+	err = r.updateConfigInProgressStatusCondition(ctx, status.device, reason, metav1.ConditionFalse, message)
 	if err != nil {
 		return err
 	}
@@ -669,8 +679,8 @@ func (r *NicDeviceReconciler) handleConfigurationSpecValidation(ctx context.Cont
 		return nil
 	}
 
-	nvConfigUpdateRequired, rebootRequired, err := r.ConfigurationManager.ValidateDeviceNvSpec(ctx, status.device)
-	log.Log.V(2).Info("nv spec validation complete for device", "device", status.device.Name, "nvConfigUpdateRequired", nvConfigUpdateRequired, "rebootRequired", rebootRequired)
+	nvConfigUpdateRequired, rebootRequired, unsupportedNvParams, err := r.ConfigurationManager.ValidateDeviceNvSpec(ctx, status.device)
+	log.Log.V(2).Info("nv spec validation complete for device", "device", status.device.Name, "nvConfigUpdateRequired", nvConfigUpdateRequired, "rebootRequired", rebootRequired, "unsupportedNvParams", unsupportedNvParams)
 	if err != nil {
 		log.Log.Error(err, "failed to validate spec for device", "device", status.device.Name)
 		if types.IsIncorrectSpecError(err) {
@@ -690,6 +700,7 @@ func (r *NicDeviceReconciler) handleConfigurationSpecValidation(ctx context.Cont
 
 	status.nvConfigUpdateRequired = nvConfigUpdateRequired
 	status.rebootRequired = rebootRequired
+	status.unsupportedNvParams = unsupportedNvParams
 
 	if nvConfigUpdateRequired {
 		log.Log.V(2).Info("update started for device", "device", status.device.Name)

--- a/internal/controller/nicdevice_controller_test.go
+++ b/internal/controller/nicdevice_controller_test.go
@@ -379,7 +379,7 @@ var _ = Describe("NicDeviceReconciler", func() {
 			}).Should(BeNil())
 		})
 		It("Should result in SpecValidationFailed status if spec validation failed", func() {
-			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(false, false, errors.New(specValidationFailed))
+			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(false, false, nil, errors.New(specValidationFailed))
 
 			createDevice(false, nil)
 
@@ -393,7 +393,7 @@ var _ = Describe("NicDeviceReconciler", func() {
 		It("Should result in IncorrectSpec status if spec is incorrect", func() {
 			err := types.IncorrectSpecError("spec error")
 			errorText := err.Error()
-			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(false, false, err)
+			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(false, false, nil, err)
 
 			createDevice(false, nil)
 
@@ -405,7 +405,7 @@ var _ = Describe("NicDeviceReconciler", func() {
 			}))
 		})
 		It("Should result in UpdateSuccessful status if nv config updates or reboot are not required", func() {
-			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(false, false, nil)
+			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(false, false, nil, nil)
 			configurationManager.On("ApplyRuntimeConfiguration", mock.Anything, mock.Anything).Return(&types.RuntimeConfigurationApplyResult{Status: types.ApplyStatusSuccess}, nil)
 			maintenanceManager.On("ReleaseMaintenance", mock.Anything).Return(nil)
 
@@ -433,7 +433,7 @@ var _ = Describe("NicDeviceReconciler", func() {
 			os.Setenv(consts.FEATURE_GATE_FW_RESET_AFTER_CONFIG_UPDATE, consts.LabelValueTrue)
 			defer os.Unsetenv(consts.FEATURE_GATE_FW_RESET_AFTER_CONFIG_UPDATE)
 
-			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(true, true, nil)
+			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(true, true, nil, nil)
 			configurationManager.On("ApplyNVConfiguration", mock.Anything, mock.Anything, mock.Anything).Return(&types.ConfigurationApplyResult{Status: types.ApplyStatusSuccess, RebootRequired: true}, nil)
 			configurationManager.On("ResetNicFirmware", mock.Anything, mock.Anything).Return(nil)
 			maintenanceManager.On("ScheduleMaintenance", mock.Anything).Return(nil)
@@ -457,7 +457,7 @@ var _ = Describe("NicDeviceReconciler", func() {
 			configurationManager.AssertCalled(GinkgoT(), "ResetNicFirmware", mock.Anything, mock.Anything)
 		})
 		It("Should NOT reset FW after nv config update if feature gate FW_RESET_AFTER_CONFIG_UPDATE is NOT enabled", func() {
-			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(true, true, nil)
+			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(true, true, nil, nil)
 			configurationManager.On("ApplyNVConfiguration", mock.Anything, mock.Anything, mock.Anything).Return(&types.ConfigurationApplyResult{Status: types.ApplyStatusSuccess, RebootRequired: true}, nil)
 			configurationManager.On("ResetNicFirmware", mock.Anything, mock.Anything).Return(nil)
 			maintenanceManager.On("ScheduleMaintenance", mock.Anything).Return(nil)
@@ -482,7 +482,7 @@ var _ = Describe("NicDeviceReconciler", func() {
 		})
 		It("Should keep in UpdateStarted status if maintenance fails to schedule", func() {
 			errorText := "maintenance request failed"
-			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(true, false, nil)
+			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(true, false, nil, nil)
 			maintenanceManager.On("ScheduleMaintenance", mock.Anything).Return(errors.New(errorText))
 
 			createDevice(true, nil)
@@ -503,7 +503,7 @@ var _ = Describe("NicDeviceReconciler", func() {
 			Consistently(lastAppliedStateAnnotationExists).Should(BeTrue())
 		})
 		It("Should keep in UpdateStarted status if maintenance is not allowed", func() {
-			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(true, false, nil)
+			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(true, false, nil, nil)
 			maintenanceManager.On("ScheduleMaintenance", mock.Anything).Return(nil)
 			maintenanceManager.On("MaintenanceAllowed", mock.Anything).Return(false, nil)
 
@@ -525,7 +525,7 @@ var _ = Describe("NicDeviceReconciler", func() {
 		})
 		It("Should result in NonVolatileConfigUpdateFailed status if nv config fails to apply", func() {
 			errorText := "maintenance request failed"
-			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(true, false, nil)
+			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(true, false, nil, nil)
 			maintenanceManager.On("ScheduleMaintenance", mock.Anything).Return(nil)
 			maintenanceManager.On("MaintenanceAllowed", mock.Anything).Return(true, nil)
 			configurationManager.On("ApplyNVConfiguration", mock.Anything, mock.Anything, mock.Anything).Return((*types.ConfigurationApplyResult)(nil), errors.New(errorText))
@@ -541,7 +541,7 @@ var _ = Describe("NicDeviceReconciler", func() {
 		})
 		It("Should result in Pending status and not apply runtime spec if failed to reboot", func() {
 			errorText := "reboot request failed"
-			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(true, true, nil)
+			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(true, true, nil, nil)
 			maintenanceManager.On("ScheduleMaintenance", mock.Anything).Return(nil)
 			maintenanceManager.On("MaintenanceAllowed", mock.Anything).Return(true, nil)
 			configurationManager.On("ApplyNVConfiguration", mock.Anything, mock.Anything, mock.Anything).Return(&types.ConfigurationApplyResult{Status: types.ApplyStatusSuccess, RebootRequired: true}, nil)
@@ -564,7 +564,7 @@ var _ = Describe("NicDeviceReconciler", func() {
 		})
 		It("Should not release maintenance if runtime config failed to apply", func() {
 			errorText := "runtime config update failed"
-			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(false, false, nil)
+			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(false, false, nil, nil)
 			configurationManager.On("ApplyRuntimeConfiguration", mock.Anything, mock.Anything).Return((*types.RuntimeConfigurationApplyResult)(nil), errors.New(errorText))
 
 			createDevice(false, nil)
@@ -585,7 +585,7 @@ var _ = Describe("NicDeviceReconciler", func() {
 			maintenanceManager.AssertExpectations(GinkgoT())
 		})
 		It("Should request maintenance if runtime config needs to be reset", func() {
-			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(false, false, nil)
+			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(false, false, nil, nil)
 			maintenanceManager.On("ScheduleMaintenance", mock.Anything).Return(nil)
 			maintenanceManager.On("MaintenanceAllowed", mock.Anything).Return(false, nil)
 
@@ -603,7 +603,7 @@ var _ = Describe("NicDeviceReconciler", func() {
 			maintenanceManager.AssertExpectations(GinkgoT())
 		})
 		It("Should not request another reboot if nv config failed to apply after the first one", func() {
-			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(false, true, nil)
+			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(false, true, nil, nil)
 			hostUtils.On("GetHostUptimeSeconds").Return(time.Second*0, nil)
 
 			_ = createDevice(false, &metav1.Condition{
@@ -631,7 +631,7 @@ var _ = Describe("NicDeviceReconciler", func() {
 		})
 
 		It("Should not fail on an not applied nv config when reboot hasn't happened yet", func() {
-			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(false, true, nil)
+			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(false, true, nil, nil)
 			hostUtils.On("GetHostUptimeSeconds").Return(time.Second*1000, nil)
 
 			_ = createDevice(false, &metav1.Condition{
@@ -691,8 +691,8 @@ var _ = Describe("NicDeviceReconciler", func() {
 		)
 
 		It("Should not begin maintenance and apply spec for device if spec validation failed for other device", func() {
-			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, matchSecondDevice).Return(true, true, nil)
-			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, matchFirstDevice).Return(false, false, errors.New(specValidationFailed))
+			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, matchSecondDevice).Return(true, true, nil, nil)
+			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, matchFirstDevice).Return(false, false, nil, errors.New(specValidationFailed))
 
 			createDevices()
 
@@ -718,8 +718,8 @@ var _ = Describe("NicDeviceReconciler", func() {
 		})
 
 		It("Should not apply runtime spec for device if spec validation failed for other device", func() {
-			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, matchSecondDevice).Return(false, false, nil)
-			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, matchFirstDevice).Return(false, false, errors.New(specValidationFailed))
+			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, matchSecondDevice).Return(false, false, nil, nil)
+			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, matchFirstDevice).Return(false, false, nil, errors.New(specValidationFailed))
 
 			createDevices()
 
@@ -741,8 +741,8 @@ var _ = Describe("NicDeviceReconciler", func() {
 		})
 
 		It("Should not apply runtime spec for device if nv spec apply needed for other device", func() {
-			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, matchSecondDevice).Return(false, false, nil)
-			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, matchFirstDevice).Return(true, true, nil)
+			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, matchSecondDevice).Return(false, false, nil, nil)
+			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, matchFirstDevice).Return(true, true, nil, nil)
 			maintenanceManager.On("ScheduleMaintenance", mock.Anything).Return(nil)
 			maintenanceManager.On("MaintenanceAllowed", mock.Anything).Return(true, nil)
 			configurationManager.On("ApplyNVConfiguration", mock.Anything, matchFirstDevice, mock.Anything).Return(&types.ConfigurationApplyResult{Status: types.ApplyStatusSuccess, RebootRequired: true}, nil)
@@ -845,7 +845,7 @@ var _ = Describe("NicDeviceReconciler", func() {
 			firmwareManager.On("GetFirmwareVersionsFromDevice", mock.Anything).Return(newFwVersion, newFwVersion, nil)
 			maintenanceManager.AssertNotCalled(GinkgoT(), "ScheduleMaintenance", mock.Anything)
 			maintenanceManager.On("ReleaseMaintenance", mock.Anything).Return(nil)
-			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(false, false, nil)
+			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(false, false, nil, nil)
 			configurationManager.On("ApplyRuntimeConfiguration", mock.Anything, mock.Anything).Return(&types.RuntimeConfigurationApplyResult{Status: types.ApplyStatusSuccess}, nil)
 
 			createDevice(newFwVersion, consts.FirmwareUpdatePolicyUpdate)
@@ -867,7 +867,7 @@ var _ = Describe("NicDeviceReconciler", func() {
 			firmwareManager.On("GetFirmwareVersionsFromDevice", mock.Anything).Return(newFwVersion, newFwVersion, nil)
 			maintenanceManager.AssertNotCalled(GinkgoT(), "ScheduleMaintenance", mock.Anything)
 			maintenanceManager.On("ReleaseMaintenance", mock.Anything).Return(nil)
-			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(false, false, nil)
+			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(false, false, nil, nil)
 			configurationManager.On("ApplyRuntimeConfiguration", mock.Anything, mock.Anything).Return(&types.RuntimeConfigurationApplyResult{Status: types.ApplyStatusSuccess}, nil)
 
 			createDevice(oldFwVersion, consts.FirmwareUpdatePolicyUpdate)
@@ -981,7 +981,7 @@ var _ = Describe("NicDeviceReconciler", func() {
 			maintenanceManager.On("MaintenanceAllowed", mock.Anything).Return(true, nil)
 			maintenanceManager.On("ReleaseMaintenance", mock.Anything)
 			firmwareManager.On("InstallFirmware", mock.Anything, mock.Anything, mock.Anything).Return(false, nil)
-			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(false, false, nil)
+			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(false, false, nil, nil)
 			configurationManager.On("ApplyRuntimeConfiguration", mock.Anything, mock.Anything).Return(&types.RuntimeConfigurationApplyResult{Status: types.ApplyStatusSuccess}, nil)
 			configurationManager.On("ResetNicFirmware", mock.Anything, mock.Anything).Return(nil)
 
@@ -1242,7 +1242,7 @@ var _ = Describe("NicDeviceReconciler", func() {
 			maintenanceManager.On("ReleaseMaintenance", mock.Anything).Return(nil)
 			firmwareManager.On("InstallFirmware", mock.Anything, mock.Anything, mock.Anything).Return(false, nil)
 			configurationManager.On("ResetNicFirmware", mock.Anything, mock.Anything).Return(nil)
-			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(false, false, nil)
+			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(false, false, nil, nil)
 			configurationManager.On("ApplyRuntimeConfiguration", mock.Anything, mock.Anything).Return(&types.RuntimeConfigurationApplyResult{Status: types.ApplyStatusSuccess}, nil)
 
 			createDevices(consts.FirmwareUpdatePolicyUpdate)
@@ -1546,7 +1546,7 @@ var _ = Describe("NicDeviceReconciler", func() {
 			deviceDiscoveryUtils.On("GetRDMADeviceName", secondPCI).Return("new_mlx5_0")
 
 			// Mock configuration validation for the second device
-			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(false, false, nil)
+			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(false, false, nil, nil)
 			configurationManager.On("ApplyRuntimeConfiguration", mock.Anything, mock.Anything).Return(&types.RuntimeConfigurationApplyResult{Status: types.ApplyStatusSuccess}, nil)
 
 			// Verify the second device's port names are refreshed
@@ -1581,7 +1581,7 @@ var _ = Describe("NicDeviceReconciler", func() {
 			Expect(k8sClient.Status().Update(ctx, device)).To(Succeed())
 
 			// Mock configuration validation
-			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(false, false, nil)
+			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(false, false, nil, nil)
 			configurationManager.On("ApplyRuntimeConfiguration", mock.Anything, mock.Anything).Return(&types.RuntimeConfigurationApplyResult{Status: types.ApplyStatusSuccess}, nil)
 
 			// The InterfaceNameCondition should never be set
@@ -1595,7 +1595,7 @@ var _ = Describe("NicDeviceReconciler", func() {
 
 	Describe("reconcile triggered by CC process termination", func() {
 		It("Should re-reconcile when CC termination channel fires", func() {
-			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(false, false, nil)
+			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(false, false, nil, nil)
 			configurationManager.On("ApplyRuntimeConfiguration", mock.Anything, mock.Anything).Return(&types.RuntimeConfigurationApplyResult{Status: types.ApplyStatusSuccess}, nil)
 			maintenanceManager.On("ReleaseMaintenance", mock.Anything).Return(nil)
 

--- a/pkg/configuration/configvalidation.go
+++ b/pkg/configuration/configvalidation.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"slices"
 	"strconv"
 
 	v1 "k8s.io/api/core/v1"
@@ -41,8 +40,6 @@ type configValidation interface {
 	// returns bool - reboot required
 	// returns error - if an error occurred during validation
 	ValidateResetToDefault(nvConfig types.NvConfigQuery) (bool, bool, error)
-	// AdvancedPCISettingsEnabled returns true if ADVANCED_PCI_SETTINGS param is enabled for current config
-	AdvancedPCISettingsEnabled(nvConfig types.NvConfigQuery) bool
 	// RuntimeConfigApplied checks if desired runtime config is applied
 	RuntimeConfigApplied(device *v1alpha1.NicDevice) (bool, error)
 	// CalculateDesiredRuntimeConfig returns desired values for runtime config
@@ -68,7 +65,7 @@ func nvParamLinkTypeFromName(linkType string) string {
 func applyDefaultNvConfigValueIfExists(
 	paramName string, desiredParameters map[string]string, query types.NvConfigQuery) {
 	defaultValues, found := query.DefaultConfig[paramName]
-	// Default values might not yet be available if ENABLE_PCI_OPTIMIZATIONS is disabled
+	// The param's default may be absent if it is hidden on this device (e.g. ADVANCED_PCI_SETTINGS off).
 	if found {
 		// Take the default numeric value
 		desiredParameters[paramName] = defaultValues[len(defaultValues)-1]
@@ -127,32 +124,24 @@ func (v *configValidationImpl) ConstructNvParamMapFromTemplate(
 	if template.PciPerformanceOptimized != nil && template.PciPerformanceOptimized.Enabled {
 		if template.PciPerformanceOptimized.MaxAccOutRead != 0 {
 			desiredParameters[consts.MaxAccOutReadParam] = strconv.Itoa(template.PciPerformanceOptimized.MaxAccOutRead)
-		} else {
-			// MAX_ACC_OUT_READ parameter is hidden if ADVANCED_PCI_SETTINGS is disabled
-			if v.AdvancedPCISettingsEnabled(query) {
-				values, found := query.DefaultConfig[consts.MaxAccOutReadParam]
-				if !found {
-					err := types.IncorrectSpecError(
-						"Device does not support pci performance nv config parameters")
-					log.Log.Error(err, "incorrect spec", "device", device.Name, "parameter", consts.MaxAccOutReadParam)
-					return desiredParameters, err
-				}
+		} else if values, found := query.DefaultConfig[consts.MaxAccOutReadParam]; found {
+			// MAX_ACC_OUT_READ is hidden when ADVANCED_PCI_SETTINGS is off. If the default is not
+			// in DefaultConfig the param is unsupported on this device — skip it silently and let
+			// the apply path report ApplyStatusPartiallyApplied if any other params still need work.
+			maxAccOutReadParamDefaultValue := values[len(values)-1]
 
-				maxAccOutReadParamDefaultValue := values[len(values)-1]
-
-				// According to the PRM, setting MAX_ACC_OUT_READ to zero enables the auto mode,
-				// which applies the best suitable optimizations.
-				// However, there is a bug in certain FW versions, where the zero value is not available.
-				// In this case, until the fix is available, skipping this parameter and emitting a warning
-				if maxAccOutReadParamDefaultValue == consts.NvParamZero {
-					applyDefaultNvConfigValueIfExists(consts.MaxAccOutReadParam, desiredParameters, query)
-				} else {
-					warning := fmt.Sprintf("%s nv config parameter does not work properly on this version of FW, skipping it", consts.MaxAccOutReadParam)
-					if v.eventRecorder != nil {
-						v.eventRecorder.Event(device, v1.EventTypeWarning, "FirmwareError", warning)
-					}
-					log.Log.Error(errors.New(warning), "skipping parameter", "device", device.Name, "fw version", device.Status.FirmwareVersion)
+			// According to the PRM, setting MAX_ACC_OUT_READ to zero enables the auto mode,
+			// which applies the best suitable optimizations.
+			// However, there is a bug in certain FW versions, where the zero value is not available.
+			// In this case, until the fix is available, skipping this parameter and emitting a warning
+			if maxAccOutReadParamDefaultValue == consts.NvParamZero {
+				applyDefaultNvConfigValueIfExists(consts.MaxAccOutReadParam, desiredParameters, query)
+			} else {
+				warning := fmt.Sprintf("%s nv config parameter does not work properly on this version of FW, skipping it", consts.MaxAccOutReadParam)
+				if v.eventRecorder != nil {
+					v.eventRecorder.Event(device, v1.EventTypeWarning, "FirmwareError", warning)
 				}
+				log.Log.Error(errors.New(warning), "skipping parameter", "device", device.Name, "fw version", device.Status.FirmwareVersion)
 			}
 		}
 
@@ -218,38 +207,13 @@ func (v *configValidationImpl) ConstructNvParamMapFromTemplate(
 // returns bool - reboot required
 // returns error - if an error occurred during validation
 func (v *configValidationImpl) ValidateResetToDefault(nvConfig types.NvConfigQuery) (bool, bool, error) {
-	// ResetToDefault requires us to set ADVANCED_PCI_SETTINGS=true, which is not a default value
-	// Deleting this key from maps so that it doesn't interfere with comparisons
-	delete(nvConfig.DefaultConfig, consts.AdvancedPCISettingsParam)
 	// We want to retain the BF3 operation mode after reset, so not taking it into consideration
 	delete(nvConfig.DefaultConfig, consts.BF3OperationModeParam)
 	delete(nvConfig.CurrentConfig, consts.BF3OperationModeParam)
 	delete(nvConfig.NextBootConfig, consts.BF3OperationModeParam)
 
-	alreadyResetInCurrent := false
-	willResetInNextBoot := false
-
-	advancedPciSettingsEnabledInCurrentConfig := false
-	if values, found := nvConfig.CurrentConfig[consts.AdvancedPCISettingsParam]; found && slices.Contains(values, consts.NvParamTrue) {
-		advancedPciSettingsEnabledInCurrentConfig = true
-	}
-	if advancedPciSettingsEnabledInCurrentConfig {
-		delete(nvConfig.CurrentConfig, consts.AdvancedPCISettingsParam)
-		if reflect.DeepEqual(nvConfig.CurrentConfig, nvConfig.DefaultConfig) {
-			alreadyResetInCurrent = true
-		}
-	}
-
-	advancedPciSettingsEnabledInNextBootConfig := false
-	if values, found := nvConfig.NextBootConfig[consts.AdvancedPCISettingsParam]; found && slices.Contains(values, consts.NvParamTrue) {
-		advancedPciSettingsEnabledInNextBootConfig = true
-	}
-	if advancedPciSettingsEnabledInNextBootConfig {
-		delete(nvConfig.NextBootConfig, consts.AdvancedPCISettingsParam)
-		if reflect.DeepEqual(nvConfig.NextBootConfig, nvConfig.DefaultConfig) {
-			willResetInNextBoot = true
-		}
-	}
+	alreadyResetInCurrent := reflect.DeepEqual(nvConfig.CurrentConfig, nvConfig.DefaultConfig)
+	willResetInNextBoot := reflect.DeepEqual(nvConfig.NextBootConfig, nvConfig.DefaultConfig)
 
 	// Reset complete, nothing to do for now
 	if alreadyResetInCurrent && willResetInNextBoot {
@@ -261,14 +225,6 @@ func (v *configValidationImpl) ValidateResetToDefault(nvConfig types.NvConfigQue
 	}
 	// Reset required
 	return true, true, nil
-}
-
-// AdvancedPCISettingsEnabled returns true if ADVANCED_PCI_SETTINGS param is enabled for current config
-func (v *configValidationImpl) AdvancedPCISettingsEnabled(nvConfig types.NvConfigQuery) bool {
-	if values, found := nvConfig.CurrentConfig[consts.AdvancedPCISettingsParam]; found && slices.Contains(values, consts.NvParamTrue) {
-		return true
-	}
-	return false
 }
 
 // validatePortExtendedQoS validates per-port extended QoS settings (CableLen, ECN, PauseFrames)

--- a/pkg/configuration/configvalidation_test.go
+++ b/pkg/configuration/configvalidation_test.go
@@ -294,12 +294,8 @@ var _ = Describe("ConfigValidationImpl", func() {
 			defaultValues := map[string][]string{
 				consts.MaxAccOutReadParam: {consts.NvParamZero},
 			}
-			currentValues := map[string][]string{
-				consts.AdvancedPCISettingsParam: {consts.NvParamTrue},
-			}
 			query := types.NewNvConfigQuery()
 			query.DefaultConfig = defaultValues
-			query.CurrentConfig = currentValues
 
 			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, query)
 			Expect(err).NotTo(HaveOccurred())
@@ -699,12 +695,8 @@ var _ = Describe("ConfigValidationImpl", func() {
 			defaultValues := map[string][]string{
 				consts.MaxAccOutReadParam: {"testMaxAccOutRead", "0"},
 			}
-			currentValues := map[string][]string{
-				consts.AdvancedPCISettingsParam: {"testAdvancedPCISettings", "1"},
-			}
 			query := types.NewNvConfigQuery()
 			query.DefaultConfig = defaultValues
-			query.CurrentConfig = currentValues
 
 			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, query)
 			Expect(err).NotTo(HaveOccurred())
@@ -717,9 +709,6 @@ var _ = Describe("ConfigValidationImpl", func() {
 	Describe("ValidateResetToDefault", func() {
 		It("should return false, false if device is already reset in current and next boot", func() {
 			nvConfigQuery := types.NewNvConfigQuery()
-			nvConfigQuery.CurrentConfig[consts.AdvancedPCISettingsParam] = []string{consts.NvParamTrue}
-			nvConfigQuery.NextBootConfig[consts.AdvancedPCISettingsParam] = []string{consts.NvParamTrue}
-
 			nvConfigQuery.DefaultConfig["RandomParam"] = []string{testVal}
 			nvConfigQuery.CurrentConfig["RandomParam"] = []string{testVal}
 			nvConfigQuery.NextBootConfig["RandomParam"] = []string{testVal}
@@ -732,9 +721,6 @@ var _ = Describe("ConfigValidationImpl", func() {
 
 		It("should return false, true if reset will complete after reboot", func() {
 			nvConfigQuery := types.NewNvConfigQuery()
-			nvConfigQuery.CurrentConfig[consts.AdvancedPCISettingsParam] = []string{consts.NvParamTrue}
-			nvConfigQuery.NextBootConfig[consts.AdvancedPCISettingsParam] = []string{consts.NvParamTrue}
-
 			nvConfigQuery.DefaultConfig["RandomParam"] = []string{testVal}
 			nvConfigQuery.CurrentConfig["RandomParam"] = []string{anotherTestVal}
 			nvConfigQuery.NextBootConfig["RandomParam"] = []string{testVal}
@@ -747,9 +733,6 @@ var _ = Describe("ConfigValidationImpl", func() {
 
 		It("should return true, true if reset is required", func() {
 			nvConfigQuery := types.NewNvConfigQuery()
-			nvConfigQuery.CurrentConfig[consts.AdvancedPCISettingsParam] = []string{consts.NvParamTrue}
-			nvConfigQuery.NextBootConfig[consts.AdvancedPCISettingsParam] = []string{consts.NvParamTrue}
-
 			nvConfigQuery.DefaultConfig["RandomParam"] = []string{testVal}
 			nvConfigQuery.CurrentConfig["RandomParam"] = []string{anotherTestVal}
 			nvConfigQuery.NextBootConfig["RandomParam"] = []string{anotherTestVal}

--- a/pkg/configuration/manager.go
+++ b/pkg/configuration/manager.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"sort"
 	"strings"
 
 	"k8s.io/client-go/tools/record"
@@ -37,8 +38,11 @@ type ConfigurationManager interface {
 	// ValidateDeviceNvSpec will validate device's non-volatile spec against already applied configuration on the host
 	// returns bool - nv config update required
 	// returns bool - reboot required
+	// returns []string - sorted, deduped param names that are part of the desired spec but hidden on
+	//   the device (absent from NextBootConfig). These cannot be applied and surface as PartiallyApplied
+	//   in the final ConfigUpdateInProgress condition.
 	// returns error - there are errors in device's spec
-	ValidateDeviceNvSpec(ctx context.Context, device *v1alpha1.NicDevice) (bool, bool, error)
+	ValidateDeviceNvSpec(ctx context.Context, device *v1alpha1.NicDevice) (bool, bool, []string, error)
 	// ApplyNVConfiguration calculates device's missing nv spec configuration and applies it to the device on the host
 	// returns *ConfigurationApplyResult - result of the apply operation
 	// returns error - there were errors while applying nv configuration
@@ -64,21 +68,23 @@ type configurationManager struct {
 // ValidateDeviceNvSpec will validate device's non-volatile spec against already applied configuration on the host
 // returns bool - nv config update required
 // returns bool - reboot required
+// returns []string - desired params that are hidden on the device (absent from NextBootConfig); sorted, deduped
 // returns error - there are errors in device's spec
 // if fully matches in current and next config, returns false, false
 // if fully matched next but not current, returns false, true
 // if not fully matched next boot, returns true, true
-func (h configurationManager) ValidateDeviceNvSpec(ctx context.Context, device *v1alpha1.NicDevice) (bool, bool, error) {
+func (h configurationManager) ValidateDeviceNvSpec(ctx context.Context, device *v1alpha1.NicDevice) (bool, bool, []string, error) {
 	log.Log.Info("configurationManager.ValidateDeviceNvSpec", "device", device.Name)
 
 	if device.Spec.Configuration.Template != nil && device.Spec.Configuration.Template.SpectrumXOptimized != nil && device.Spec.Configuration.Template.SpectrumXOptimized.Enabled {
-		return h.validateSpectrumXNvSpec(ctx, device)
+		configUpdate, reboot, err := h.validateSpectrumXNvSpec(ctx, device)
+		return configUpdate, reboot, nil, err
 	}
 
 	nvConfigsForPorts, err := h.queryNvConfigs(ctx, device)
 	if err != nil {
 		log.Log.Error(err, "failed to query nv configs", "device", device.Name)
-		return false, false, err
+		return false, false, nil, err
 	}
 	firstPortPCIAddr := device.Status.Ports[0].PCI
 	firstPortConfig := nvConfigsForPorts[firstPortPCIAddr]
@@ -90,44 +96,45 @@ func (h configurationManager) ValidateDeviceNvSpec(ctx context.Context, device *
 			resetNeededForPort, rebootNeededForPort, err := h.configValidation.ValidateResetToDefault(nvConfig)
 			if err != nil {
 				log.Log.Error(err, "failed to validate reset to default", "device", device.Name)
-				return false, false, err
+				return false, false, nil, err
 			}
 			resetNeeded = resetNeeded || resetNeededForPort
 			rebootNeeded = rebootNeeded || rebootNeededForPort
 		}
-		return resetNeeded, rebootNeeded, nil
+		return resetNeeded, rebootNeeded, nil, nil
 	}
 
 	// ConstructNvParamMapFromTemplate only uses the given nvConfig for a few default values, so we can use any port's nvConfig
 	desiredConfig, err := h.configValidation.ConstructNvParamMapFromTemplate(device, firstPortConfig)
 	if err != nil {
 		log.Log.Error(err, "failed to calculate desired nvconfig parameters", "device", device.Name)
-		return false, false, err
+		return false, false, nil, err
 	}
 
 	configUpdateNeeded := false
 	rebootNeeded := false
-
-	// If ADVANCED_PCI_SETTINGS are enabled in current config, unknown parameters are treated as spec error
-	// ADVANCED_PCI_SETTINGS param value is shared across all ports, so we can use any port's nvConfig for validation
-	advancedPciSettingsEnabled := h.configValidation.AdvancedPCISettingsEnabled(firstPortConfig)
+	unsupportedSet := map[string]struct{}{}
 
 	for _, nvConfig := range nvConfigsForPorts {
 		for parameter, desiredValue := range desiredConfig {
-			currentValues, foundInCurrent := nvConfig.CurrentConfig[parameter]
 			nextValues, foundInNextBoot := nvConfig.NextBootConfig[parameter]
-			if advancedPciSettingsEnabled && !foundInCurrent {
-				err = types.IncorrectSpecError(fmt.Sprintf("Parameter %s unsupported for device %s", parameter, device.Name))
-				log.Log.Error(err, "can't set nv config parameter for device")
-				return false, false, err
+			if !foundInNextBoot {
+				// Param unsupported on this device (e.g. hidden because ADVANCED_PCI_SETTINGS is off,
+				// or the variant simply doesn't expose it). Apply skips the same param and reports
+				// ApplyStatusPartiallyApplied; record it here so the controller can surface
+				// PartiallyApplied even when nothing else needs to change.
+				log.Log.V(2).Info("Parameter not in NextBootConfig, treating as unsupported",
+					"device", device.Name, "param", parameter)
+				unsupportedSet[parameter] = struct{}{}
+				continue
 			}
-
-			if foundInNextBoot && slices.Contains(nextValues, strings.ToLower(desiredValue)) {
-				if !foundInCurrent || !slices.Contains(currentValues, strings.ToLower(desiredValue)) {
-					rebootNeeded = true
-				}
-			} else {
+			if !slices.Contains(nextValues, strings.ToLower(desiredValue)) {
 				configUpdateNeeded = true
+				rebootNeeded = true
+				continue
+			}
+			currentValues, foundInCurrent := nvConfig.CurrentConfig[parameter]
+			if !foundInCurrent || !slices.Contains(currentValues, strings.ToLower(desiredValue)) {
 				rebootNeeded = true
 			}
 		}
@@ -136,14 +143,23 @@ func (h configurationManager) ValidateDeviceNvSpec(ctx context.Context, device *
 	// Layer Network Bay system_conf validation on top of the regular nv config validation.
 	systemConfMismatch, err := h.systemConfMismatch(ctx, device)
 	if err != nil {
-		return false, false, err
+		return false, false, nil, err
 	}
 	if systemConfMismatch {
 		configUpdateNeeded = true
 		rebootNeeded = true
 	}
 
-	return configUpdateNeeded, rebootNeeded, nil
+	var unsupportedParams []string
+	if len(unsupportedSet) > 0 {
+		unsupportedParams = make([]string, 0, len(unsupportedSet))
+		for name := range unsupportedSet {
+			unsupportedParams = append(unsupportedParams, name)
+		}
+		sort.Strings(unsupportedParams)
+	}
+
+	return configUpdateNeeded, rebootNeeded, unsupportedParams, nil
 }
 
 // ApplyNVConfiguration calculates device's missing nv spec configuration and applies it to the device on the host
@@ -182,38 +198,6 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 
 	if device.Spec.Configuration.Template == nil {
 		return &types.ConfigurationApplyResult{Status: types.ApplyStatusNothingToDo}, nil
-	}
-
-	// if ADVANCED_PCI_SETTINGS == 0, not all nv config parameters are available for configuration
-	// we enable this parameter first to unlock them
-	if !h.configValidation.AdvancedPCISettingsEnabled(firstPortConfig) {
-		log.Log.V(2).Info("AdvancedPciSettings not enabled, fw reset required", "device", device.Name)
-		err := h.nvConfigUtils.SetNvConfigParameter(firstPortPCIAddr, consts.AdvancedPCISettingsParam, consts.NvParamTrue)
-		if err != nil {
-			log.Log.Error(err, "Failed to apply nv config parameter", "device", device.Name, "param", consts.AdvancedPCISettingsParam, "value", consts.NvParamTrue)
-			return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
-		}
-
-		if !options.SkipReset {
-			err = h.ResetNicFirmware(ctx, device)
-			if err != nil {
-				log.Log.Error(err, "Failed to reset NIC firmware, reboot required to apply ADVANCED_PCI_SETTINGS", "device", device.Name)
-				// We try to perform FW reset after setting the ADVANCED_PCI_SETTINGS to save us a reboot
-				// However, if the soft FW reset fails for some reason, we need to perform a reboot to unlock
-				// all the nv config parameters
-				return &types.ConfigurationApplyResult{Status: types.ApplyStatusSuccess, RebootRequired: true}, nil
-			}
-		} else {
-			return &types.ConfigurationApplyResult{Status: types.ApplyStatusSuccess, RebootRequired: true}, nil
-		}
-
-		// Query nv config again, additional options could become available
-		nvConfigsForPorts, err = h.queryNvConfigs(ctx, device)
-		if err != nil {
-			log.Log.Error(err, "failed to query nv configs", "device", device.Name)
-			return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
-		}
-		firstPortConfig = nvConfigsForPorts[firstPortPCIAddr]
 	}
 
 	desiredConfig, err := h.configValidation.ConstructNvParamMapFromTemplate(device, firstPortConfig)
@@ -383,12 +367,6 @@ func (h configurationManager) applyResetToDefault(device *v1alpha1.NicDevice, pc
 			log.Log.Error(err, "Failed to restore the BlueField device mode of operation", "device", device.Name, "mode", mode, "param", consts.BF3OperationModeParam, "value", val)
 			return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
 		}
-	}
-
-	err = h.nvConfigUtils.SetNvConfigParameter(pciAddr, consts.AdvancedPCISettingsParam, consts.NvParamTrue)
-	if err != nil {
-		log.Log.Error(err, "Failed to apply nv config parameter", "device", device.Name, "param", consts.AdvancedPCISettingsParam, "value", consts.NvParamTrue)
-		return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
 	}
 
 	return &types.ConfigurationApplyResult{Status: types.ApplyStatusSuccess, RebootRequired: true}, nil

--- a/pkg/configuration/manager_test.go
+++ b/pkg/configuration/manager_test.go
@@ -18,7 +18,6 @@ package configuration
 import (
 	"context"
 	"errors"
-	"fmt"
 	"slices"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -80,7 +79,7 @@ var _ = Describe("ConfigurationManager", func() {
 					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
 						Return(types.NewNvConfigQuery(), queryErr)
 
-					configUpdate, reboot, err := manager.ValidateDeviceNvSpec(ctx, device)
+					configUpdate, reboot, _, err := manager.ValidateDeviceNvSpec(ctx, device)
 					Expect(configUpdate).To(BeFalse())
 					Expect(reboot).To(BeFalse())
 					Expect(err).To(MatchError(queryErr))
@@ -106,7 +105,7 @@ var _ = Describe("ConfigurationManager", func() {
 					mockConfigValidation.On("ValidateResetToDefault", nvConfig).
 						Return(true, false, nil)
 
-					configUpdate, reboot, err := manager.ValidateDeviceNvSpec(ctx, device)
+					configUpdate, reboot, _, err := manager.ValidateDeviceNvSpec(ctx, device)
 					Expect(configUpdate).To(BeTrue())
 					Expect(reboot).To(BeFalse())
 					Expect(err).To(BeNil())
@@ -128,7 +127,7 @@ var _ = Describe("ConfigurationManager", func() {
 					mockConfigValidation.On("ValidateResetToDefault", nvConfig).
 						Return(false, false, validationErr)
 
-					configUpdate, reboot, err := manager.ValidateDeviceNvSpec(ctx, device)
+					configUpdate, reboot, _, err := manager.ValidateDeviceNvSpec(ctx, device)
 					Expect(configUpdate).To(BeFalse())
 					Expect(reboot).To(BeFalse())
 					Expect(err).To(MatchError(validationErr))
@@ -152,7 +151,7 @@ var _ = Describe("ConfigurationManager", func() {
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 						Return(nil, constructErr)
 
-					configUpdate, reboot, err := manager.ValidateDeviceNvSpec(ctx, device)
+					configUpdate, reboot, _, err := manager.ValidateDeviceNvSpec(ctx, device)
 					Expect(configUpdate).To(BeFalse())
 					Expect(reboot).To(BeFalse())
 					Expect(err).To(MatchError(constructErr))
@@ -176,10 +175,8 @@ var _ = Describe("ConfigurationManager", func() {
 						Return(nvConfig, nil)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 						Return(desiredConfig, nil)
-					mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-						Return(false)
 
-					configUpdate, reboot, err := manager.ValidateDeviceNvSpec(ctx, device)
+					configUpdate, reboot, _, err := manager.ValidateDeviceNvSpec(ctx, device)
 					Expect(configUpdate).To(BeFalse())
 					Expect(reboot).To(BeFalse())
 					Expect(err).To(BeNil())
@@ -203,10 +200,8 @@ var _ = Describe("ConfigurationManager", func() {
 						Return(nvConfig, nil)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 						Return(desiredConfig, nil)
-					mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-						Return(false)
 
-					configUpdate, reboot, err := manager.ValidateDeviceNvSpec(ctx, device)
+					configUpdate, reboot, _, err := manager.ValidateDeviceNvSpec(ctx, device)
 					Expect(configUpdate).To(BeFalse())
 					Expect(reboot).To(BeTrue())
 					Expect(err).To(BeNil())
@@ -230,10 +225,8 @@ var _ = Describe("ConfigurationManager", func() {
 						Return(nvConfig, nil)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 						Return(desiredConfig, nil)
-					mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-						Return(false)
 
-					configUpdate, reboot, err := manager.ValidateDeviceNvSpec(ctx, device)
+					configUpdate, reboot, _, err := manager.ValidateDeviceNvSpec(ctx, device)
 					Expect(configUpdate).To(BeTrue())
 					Expect(reboot).To(BeTrue())
 					Expect(err).To(BeNil())
@@ -243,8 +236,8 @@ var _ = Describe("ConfigurationManager", func() {
 				})
 			})
 
-			Context("when AdvancedPCISettingsEnabled is true and a parameter is missing in CurrentConfig", func() {
-				It("should return an IncorrectSpecError", func() {
+			Context("when a desired param is missing from CurrentConfig but present in NextBootConfig", func() {
+				It("should return false, true, nil (reboot only)", func() {
 					nvConfig := types.NvConfigQuery{
 						CurrentConfig:  map[string][]string{"param2": {"value2"}},
 						NextBootConfig: map[string][]string{"param1": {"value1"}, "param2": {"value2"}},
@@ -256,16 +249,61 @@ var _ = Describe("ConfigurationManager", func() {
 						Return(nvConfig, nil)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 						Return(desiredConfig, nil)
-					mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-						Return(true)
 
-					expectedErr := types.IncorrectSpecError(
-						fmt.Sprintf("Parameter %s unsupported for device %s", "param1", device.Name))
+					configUpdate, reboot, _, err := manager.ValidateDeviceNvSpec(ctx, device)
+					Expect(configUpdate).To(BeFalse())
+					Expect(reboot).To(BeTrue())
+					Expect(err).To(BeNil())
 
-					configUpdate, reboot, err := manager.ValidateDeviceNvSpec(ctx, device)
+					mockNVConfigUtils.AssertExpectations(GinkgoT())
+					mockConfigValidation.AssertExpectations(GinkgoT())
+				})
+			})
+
+			Context("when a desired param is missing from NextBootConfig (unsupported)", func() {
+				It("should treat it as unsupported, skip it, and surface the param name", func() {
+					nvConfig := types.NvConfigQuery{
+						CurrentConfig:  map[string][]string{"param2": {"value2"}},
+						NextBootConfig: map[string][]string{"param2": {"value2"}},
+						DefaultConfig:  map[string][]string{"param2": {"default2"}},
+					}
+					// param1 is hidden on this device (e.g. ADVANCED_PCI_SETTINGS off)
+					desiredConfig := map[string]string{"param1": "value1", "param2": "value2"}
+
+					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+						Return(nvConfig, nil)
+					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+						Return(desiredConfig, nil)
+
+					configUpdate, reboot, unsupported, err := manager.ValidateDeviceNvSpec(ctx, device)
 					Expect(configUpdate).To(BeFalse())
 					Expect(reboot).To(BeFalse())
-					Expect(err).To(MatchError(expectedErr))
+					Expect(unsupported).To(Equal([]string{"param1"}))
+					Expect(err).To(BeNil())
+
+					mockNVConfigUtils.AssertExpectations(GinkgoT())
+					mockConfigValidation.AssertExpectations(GinkgoT())
+				})
+
+				It("still flags mismatched supported params as configUpdateNeeded and reports unsupported ones", func() {
+					nvConfig := types.NvConfigQuery{
+						CurrentConfig:  map[string][]string{"param2": {"oldValue2"}},
+						NextBootConfig: map[string][]string{"param2": {"oldValue2"}},
+						DefaultConfig:  map[string][]string{"param2": {"default2"}},
+					}
+					// param1 is unsupported; param2 needs to change
+					desiredConfig := map[string]string{"param1": "value1", "param2": "value2"}
+
+					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+						Return(nvConfig, nil)
+					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+						Return(desiredConfig, nil)
+
+					configUpdate, reboot, unsupported, err := manager.ValidateDeviceNvSpec(ctx, device)
+					Expect(configUpdate).To(BeTrue())
+					Expect(reboot).To(BeTrue())
+					Expect(unsupported).To(Equal([]string{"param1"}))
+					Expect(err).To(BeNil())
 
 					mockNVConfigUtils.AssertExpectations(GinkgoT())
 					mockConfigValidation.AssertExpectations(GinkgoT())
@@ -285,10 +323,8 @@ var _ = Describe("ConfigurationManager", func() {
 						Return(nvConfig, nil)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 						Return(desiredConfig, nil)
-					mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-						Return(true)
 
-					configUpdate, reboot, err := manager.ValidateDeviceNvSpec(ctx, device)
+					configUpdate, reboot, _, err := manager.ValidateDeviceNvSpec(ctx, device)
 					Expect(configUpdate).To(BeFalse())
 					Expect(reboot).To(BeFalse())
 					Expect(err).To(BeNil())
@@ -308,10 +344,8 @@ var _ = Describe("ConfigurationManager", func() {
 						Return(nvConfig, nil)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 						Return(desiredConfig, nil)
-					mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-						Return(true)
 
-					configUpdate, reboot, err := manager.ValidateDeviceNvSpec(ctx, device)
+					configUpdate, reboot, _, err := manager.ValidateDeviceNvSpec(ctx, device)
 					Expect(configUpdate).To(BeFalse())
 					Expect(reboot).To(BeFalse())
 					Expect(err).To(BeNil())
@@ -331,10 +365,8 @@ var _ = Describe("ConfigurationManager", func() {
 						Return(nvConfig, nil)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 						Return(desiredConfig, nil)
-					mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-						Return(true)
 
-					configUpdate, reboot, err := manager.ValidateDeviceNvSpec(ctx, device)
+					configUpdate, reboot, _, err := manager.ValidateDeviceNvSpec(ctx, device)
 					Expect(configUpdate).To(BeTrue())
 					Expect(reboot).To(BeTrue())
 					Expect(err).To(BeNil())
@@ -349,7 +381,7 @@ var _ = Describe("ConfigurationManager", func() {
 					// two ports
 					device.Status.Ports = []v1alpha1.NicDevicePortSpec{{PCI: pciAddress}, {PCI: pciAddress2}}
 
-					// First port config (used for ConstructNvParamMapFromTemplate and AdvancedPCISettingsEnabled)
+					// First port config (used for ConstructNvParamMapFromTemplate)
 					nvConfig0 := types.NvConfigQuery{
 						CurrentConfig:  map[string][]string{"TRACER_ENABLED": {"1"}},
 						NextBootConfig: map[string][]string{"TRACER_ENABLED": {"1"}},
@@ -365,9 +397,8 @@ var _ = Describe("ConfigurationManager", func() {
 					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig0, nil)
 					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress2, []string(nil)).Return(nvConfig1, nil)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig0).Return(map[string]string{"TRACER_ENABLED": "1"}, nil)
-					mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig0).Return(false)
 
-					configUpdate, reboot, err := manager.ValidateDeviceNvSpec(ctx, device)
+					configUpdate, reboot, _, err := manager.ValidateDeviceNvSpec(ctx, device)
 					Expect(err).To(BeNil())
 					Expect(configUpdate).To(BeFalse())
 					Expect(reboot).To(BeTrue())
@@ -393,9 +424,8 @@ var _ = Describe("ConfigurationManager", func() {
 					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig0, nil)
 					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress2, []string(nil)).Return(nvConfig1, nil)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig0).Return(map[string]string{"TRACER_ENABLED": "1"}, nil)
-					mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig0).Return(false)
 
-					configUpdate, reboot, err := manager.ValidateDeviceNvSpec(ctx, device)
+					configUpdate, reboot, _, err := manager.ValidateDeviceNvSpec(ctx, device)
 					Expect(err).To(BeNil())
 					Expect(configUpdate).To(BeTrue())
 					Expect(reboot).To(BeTrue())
@@ -404,7 +434,7 @@ var _ = Describe("ConfigurationManager", func() {
 					mockConfigValidation.AssertExpectations(GinkgoT())
 				})
 
-				It("returns IncorrectSpecError when advanced enabled and a port misses param in current", func() {
+				It("requires reboot when a port misses param in current but matches next boot", func() {
 					device.Status.Ports = []v1alpha1.NicDevicePortSpec{{PCI: pciAddress}, {PCI: pciAddress2}}
 
 					nvConfig0 := types.NvConfigQuery{
@@ -421,12 +451,11 @@ var _ = Describe("ConfigurationManager", func() {
 					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig0, nil)
 					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress2, []string(nil)).Return(nvConfig1, nil)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig0).Return(map[string]string{"TRACER_ENABLED": "1"}, nil)
-					mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig0).Return(true)
 
-					configUpdate, reboot, err := manager.ValidateDeviceNvSpec(ctx, device)
+					configUpdate, reboot, _, err := manager.ValidateDeviceNvSpec(ctx, device)
+					Expect(err).To(BeNil())
 					Expect(configUpdate).To(BeFalse())
-					Expect(reboot).To(BeFalse())
-					Expect(types.IsIncorrectSpecError(err)).To(BeTrue())
+					Expect(reboot).To(BeTrue())
 
 					mockNVConfigUtils.AssertExpectations(GinkgoT())
 					mockConfigValidation.AssertExpectations(GinkgoT())
@@ -476,7 +505,7 @@ var _ = Describe("ConfigurationManager", func() {
 					device.Spec.Configuration.ResetToDefault = true
 				})
 
-				It("should reset NV config and set AdvancedPCISettings parameter successfully", func() {
+				It("should reset NV config successfully on a non-BF3 device", func() {
 					nvConfig := types.NvConfigQuery{
 						CurrentConfig:  map[string][]string{"param1": {"value1"}},
 						NextBootConfig: map[string][]string{"param1": {"value1"}},
@@ -486,10 +515,8 @@ var _ = Describe("ConfigurationManager", func() {
 						Return(nvConfig, nil)
 
 					mockNV.On("ResetNvConfig", pciAddress).Return(nil)
-					mockNV.
-						On("SetNvConfigParameter", pciAddress, consts.AdvancedPCISettingsParam, consts.NvParamTrue).
-						Return(nil)
 					mockNV.AssertNotCalled(GinkgoT(), "SetNvConfigParameter", pciAddress, consts.BF3OperationModeParam, mock.Anything)
+					mockNV.AssertNotCalled(GinkgoT(), "SetNvConfigParameter", pciAddress, consts.AdvancedPCISettingsParam, mock.Anything)
 
 					result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 					Expect(result.RebootRequired).To(BeTrue())
@@ -509,12 +536,10 @@ var _ = Describe("ConfigurationManager", func() {
 
 					mockNV.On("ResetNvConfig", pciAddress).Return(nil)
 					mockNV.
-						On("SetNvConfigParameter", pciAddress, consts.AdvancedPCISettingsParam, consts.NvParamTrue).
-						Return(nil)
-					mockNV.
 						On("SetNvConfigParameter", pciAddress, consts.BF3OperationModeParam, consts.NvParamBF3NicMode).
 						Return(nil)
 					mockNV.AssertNotCalled(GinkgoT(), "SetNvConfigParameter", pciAddress, consts.BF3OperationModeParam, consts.NvParamBF3DpuMode)
+					mockNV.AssertNotCalled(GinkgoT(), "SetNvConfigParameter", pciAddress, consts.AdvancedPCISettingsParam, mock.Anything)
 
 					result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 					Expect(result.RebootRequired).To(BeTrue())
@@ -542,11 +567,11 @@ var _ = Describe("ConfigurationManager", func() {
 					mockNV.AssertExpectations(GinkgoT())
 				})
 
-				It("should return error if SetNvConfigParameter fails", func() {
+				It("should return error if BF3 mode restore fails", func() {
 					nvConfig := types.NvConfigQuery{
-						CurrentConfig:  map[string][]string{"param1": {"value1"}},
-						NextBootConfig: map[string][]string{"param1": {"value1"}},
-						DefaultConfig:  map[string][]string{"param1": {"default1"}},
+						CurrentConfig:  map[string][]string{consts.BF3OperationModeParam: {consts.NvParamBF3NicMode}},
+						NextBootConfig: map[string][]string{consts.BF3OperationModeParam: {consts.NvParamBF3DpuMode}},
+						DefaultConfig:  map[string][]string{consts.BF3OperationModeParam: {consts.NvParamBF3DpuMode}},
 					}
 					mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
 						Return(nvConfig, nil)
@@ -554,7 +579,7 @@ var _ = Describe("ConfigurationManager", func() {
 					mockNV.On("ResetNvConfig", pciAddress).Return(nil)
 					setParamErr := errors.New("failed to set nv config parameter")
 					mockNV.
-						On("SetNvConfigParameter", pciAddress, consts.AdvancedPCISettingsParam, consts.NvParamTrue).
+						On("SetNvConfigParameter", pciAddress, consts.BF3OperationModeParam, consts.NvParamBF3NicMode).
 						Return(setParamErr)
 
 					result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
@@ -579,110 +604,7 @@ var _ = Describe("ConfigurationManager", func() {
 					})
 				})
 
-				Context("when AdvancedPCISettingsEnabled is false", func() {
-					It("should set AdvancedPCISettingsParam and reset NIC firmware successfully", func() {
-						nvConfig := types.NvConfigQuery{
-							CurrentConfig:  map[string][]string{"param1": {"value1"}},
-							NextBootConfig: map[string][]string{"param1": {"value1"}},
-							DefaultConfig:  map[string][]string{"param1": {"default1"}},
-						}
-						desiredConfig := map[string]string{"param1": "value1"}
-
-						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
-							Return(nvConfig, nil)
-						mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-							Return(false)
-						mockNV.
-							On("SetNvConfigParameter", pciAddress, consts.AdvancedPCISettingsParam, consts.NvParamTrue).
-							Return(nil)
-						mockHostUtils.On("ResetNicFirmware", mock.Anything, pciAddress).
-							Return(nil)
-						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
-							Return(nvConfig, nil)
-						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
-							Return(desiredConfig, nil)
-
-						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
-						Expect(result.RebootRequired).To(BeFalse())
-						Expect(err).To(BeNil())
-
-						mockNV.AssertExpectations(GinkgoT())
-						mockConfigValidation.AssertExpectations(GinkgoT())
-					})
-
-					It("should return error if SetNvConfigParameter fails", func() {
-						nvConfig := types.NvConfigQuery{
-							CurrentConfig:  map[string][]string{"param1": {"value1"}},
-							NextBootConfig: map[string][]string{"param1": {"value1"}},
-							DefaultConfig:  map[string][]string{"param1": {"default1"}},
-						}
-						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig, nil)
-						mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-							Return(false)
-						setParamErr := errors.New("failed to set nv config parameter")
-						mockNV.
-							On("SetNvConfigParameter", pciAddress, consts.AdvancedPCISettingsParam, consts.NvParamTrue).
-							Return(setParamErr)
-
-						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
-						Expect(result.RebootRequired).To(BeFalse())
-						Expect(err).To(MatchError(setParamErr))
-
-						mockNV.AssertExpectations(GinkgoT())
-						mockConfigValidation.AssertExpectations(GinkgoT())
-					})
-
-					It("should request reboot if ResetNicFirmware fails", func() {
-						nvConfig := types.NvConfigQuery{
-							CurrentConfig:  map[string][]string{"param1": {"value1"}},
-							NextBootConfig: map[string][]string{"param1": {"value1"}},
-							DefaultConfig:  map[string][]string{"param1": {"default1"}},
-						}
-						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig, nil)
-						mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-							Return(false)
-						mockNV.On("SetNvConfigParameter", pciAddress, consts.AdvancedPCISettingsParam, consts.NvParamTrue).
-							Return(nil)
-						resetFirmwareErr := errors.New("failed to reset NIC firmware")
-						mockHostUtils.On("ResetNicFirmware", mock.Anything, pciAddress).Return(resetFirmwareErr)
-
-						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
-						Expect(result.RebootRequired).To(BeTrue())
-						Expect(err).To(BeNil())
-
-						mockNV.AssertExpectations(GinkgoT())
-						mockConfigValidation.AssertExpectations(GinkgoT())
-					})
-
-					It("should return error if second QueryNvConfig fails", func() {
-						nvConfig := types.NvConfigQuery{
-							CurrentConfig:  map[string][]string{"param1": {"value1"}},
-							NextBootConfig: map[string][]string{"param1": {"value1"}},
-							DefaultConfig:  map[string][]string{"param1": {"default1"}},
-						}
-
-						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
-							Return(nvConfig, nil).Times(1)
-						mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-							Return(false)
-						mockNV.On("SetNvConfigParameter", pciAddress, consts.AdvancedPCISettingsParam, consts.NvParamTrue).
-							Return(nil)
-						mockHostUtils.On("ResetNicFirmware", mock.Anything, pciAddress).
-							Return(nil)
-						secondQueryErr := errors.New("failed to query nv config again")
-						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
-							Return(types.NewNvConfigQuery(), secondQueryErr)
-
-						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
-						Expect(result.RebootRequired).To(BeFalse())
-						Expect(err).To(MatchError(secondQueryErr))
-
-						mockNV.AssertExpectations(GinkgoT())
-						mockConfigValidation.AssertExpectations(GinkgoT())
-					})
-				})
-
-				Context("when AdvancedPCISettingsEnabled is true", func() {
+				Context("when applying the desired template config", func() {
 					It("should construct desiredConfig and apply no changes if desiredConfig matches NextBootConfig", func() {
 						nvConfig := types.NvConfigQuery{
 							CurrentConfig:  map[string][]string{"param1": {"value1"}},
@@ -693,8 +615,6 @@ var _ = Describe("ConfigurationManager", func() {
 
 						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
 							Return(nvConfig, nil)
-						mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-							Return(true)
 						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 							Return(desiredConfig, nil)
 
@@ -716,8 +636,6 @@ var _ = Describe("ConfigurationManager", func() {
 
 						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
 							Return(nvConfig, nil)
-						mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-							Return(true)
 						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 							Return(desiredConfig, nil)
 						mockNV.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"param1": "value2"}, false, false).
@@ -741,8 +659,6 @@ var _ = Describe("ConfigurationManager", func() {
 
 						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
 							Return(nvConfig, nil)
-						mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-							Return(true)
 						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 							Return(nil, constructErr)
 
@@ -764,8 +680,6 @@ var _ = Describe("ConfigurationManager", func() {
 
 						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
 							Return(nvConfig, nil)
-						mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-							Return(true)
 						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 							Return(desiredConfig, nil)
 
@@ -788,8 +702,6 @@ var _ = Describe("ConfigurationManager", func() {
 
 						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
 							Return(nvConfig, nil)
-						mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-							Return(true)
 						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 							Return(desiredConfig, nil)
 						setParamErr := errors.New("failed to set param1")
@@ -823,7 +735,6 @@ var _ = Describe("ConfigurationManager", func() {
 
 						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig0, nil)
 						mockNV.On("QueryNvConfig", ctx, pciAddress2, []string(nil)).Return(nvConfig1, nil)
-						mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig0).Return(true)
 						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig0).Return(map[string]string{"TRACER_ENABLED": "1"}, nil)
 						// Only port2 should be updated
 						mockNV.On("SetNvConfigParametersBatch", pciAddress2, map[string]string{"TRACER_ENABLED": "1"}, false, false).Return(nil)
@@ -852,7 +763,6 @@ var _ = Describe("ConfigurationManager", func() {
 
 						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig0, nil)
 						mockNV.On("QueryNvConfig", ctx, pciAddress2, []string(nil)).Return(nvConfig1, nil)
-						mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig0).Return(true)
 						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig0).Return(map[string]string{"TRACER_ENABLED": "1"}, nil)
 
 						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
@@ -877,8 +787,6 @@ var _ = Describe("ConfigurationManager", func() {
 
 					mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
 						Return(nvConfig, nil)
-					mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-						Return(true)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 						Return(desiredConfig, nil)
 					mockNV.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"param1": "newValue3", "param2": "newValue3"}, false, false).
@@ -904,8 +812,6 @@ var _ = Describe("ConfigurationManager", func() {
 
 					mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
 						Return(nvConfig, nil)
-					mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).
-						Return(true)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 						Return(desiredConfig, nil)
 
@@ -1308,7 +1214,7 @@ var _ = Describe("ConfigurationManager", func() {
 				mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, mock.Anything).Return(
 					types.NvConfigQuery{CurrentConfig: map[string][]string{"NUM_OF_PF": {"1"}, "NUM_OF_PLANES_P1": {"0"}}}, nil)
 
-				updateNeeded, rebootNeeded, err := manager.ValidateDeviceNvSpec(ctx, device)
+				updateNeeded, rebootNeeded, _, err := manager.ValidateDeviceNvSpec(ctx, device)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(updateNeeded).To(BeTrue())
 				Expect(rebootNeeded).To(BeTrue())
@@ -1324,7 +1230,7 @@ var _ = Describe("ConfigurationManager", func() {
 				mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string{"LINK_TYPE_P1"}).Return(
 					types.NvConfigQuery{CurrentConfig: map[string][]string{"LINK_TYPE_P1": {"1"}}}, nil)
 
-				updateNeeded, rebootNeeded, err := manager.ValidateDeviceNvSpec(ctx, device)
+				updateNeeded, rebootNeeded, _, err := manager.ValidateDeviceNvSpec(ctx, device)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(updateNeeded).To(BeTrue())
 				Expect(rebootNeeded).To(BeTrue())
@@ -1340,7 +1246,7 @@ var _ = Describe("ConfigurationManager", func() {
 				mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string{"LINK_TYPE_P1"}).Return(
 					types.NvConfigQuery{CurrentConfig: map[string][]string{"LINK_TYPE_P1": {"2"}}}, nil)
 
-				updateNeeded, rebootNeeded, err := manager.ValidateDeviceNvSpec(ctx, device)
+				updateNeeded, rebootNeeded, _, err := manager.ValidateDeviceNvSpec(ctx, device)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(updateNeeded).To(BeFalse())
 				Expect(rebootNeeded).To(BeFalse())
@@ -1349,7 +1255,7 @@ var _ = Describe("ConfigurationManager", func() {
 			It("returns error when GetBreakoutMlxConfig fails", func() {
 				mockSpcXMgr.On("GetBreakoutMlxConfig", device).Return(nil, errors.New("config not found"))
 
-				_, _, err := manager.ValidateDeviceNvSpec(ctx, device)
+				_, _, _, err := manager.ValidateDeviceNvSpec(ctx, device)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("config not found"))
 			})
@@ -1361,7 +1267,7 @@ var _ = Describe("ConfigurationManager", func() {
 				mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, mock.Anything).Return(
 					types.NvConfigQuery{}, errors.New("query failed"))
 
-				_, _, err := manager.ValidateDeviceNvSpec(ctx, device)
+				_, _, _, err := manager.ValidateDeviceNvSpec(ctx, device)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("query failed"))
 			})
@@ -1373,7 +1279,7 @@ var _ = Describe("ConfigurationManager", func() {
 				mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string{"LINK_TYPE_P1"}).Return(
 					types.NvConfigQuery{CurrentConfig: map[string][]string{"LINK_TYPE_P1": {"1"}}}, nil)
 
-				updateNeeded, rebootNeeded, err := manager.ValidateDeviceNvSpec(ctx, device)
+				updateNeeded, rebootNeeded, _, err := manager.ValidateDeviceNvSpec(ctx, device)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(updateNeeded).To(BeTrue())
 				Expect(rebootNeeded).To(BeTrue())
@@ -1394,7 +1300,7 @@ var _ = Describe("ConfigurationManager", func() {
 				})).Return(
 					types.NvConfigQuery{CurrentConfig: map[string][]string{"LINK_TYPE_P1": {"2"}, "CUSTOM_PARAM_P1": {"0"}}}, nil)
 
-				updateNeeded, rebootNeeded, err := manager.ValidateDeviceNvSpec(ctx, device)
+				updateNeeded, rebootNeeded, _, err := manager.ValidateDeviceNvSpec(ctx, device)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(updateNeeded).To(BeTrue())
 				Expect(rebootNeeded).To(BeTrue())
@@ -1415,7 +1321,7 @@ var _ = Describe("ConfigurationManager", func() {
 				})).Return(
 					types.NvConfigQuery{CurrentConfig: map[string][]string{"LINK_TYPE_P1": {"2"}, "CUSTOM_PARAM_P1": {"42"}}}, nil)
 
-				updateNeeded, rebootNeeded, err := manager.ValidateDeviceNvSpec(ctx, device)
+				updateNeeded, rebootNeeded, _, err := manager.ValidateDeviceNvSpec(ctx, device)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(updateNeeded).To(BeFalse())
 				Expect(rebootNeeded).To(BeFalse())
@@ -1436,7 +1342,7 @@ var _ = Describe("ConfigurationManager", func() {
 				mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string{"LINK_TYPE_P1"}).Return(
 					types.NvConfigQuery{CurrentConfig: map[string][]string{"LINK_TYPE_P1": {"1"}}}, nil)
 
-				updateNeeded, rebootNeeded, err := manager.ValidateDeviceNvSpec(ctx, device)
+				updateNeeded, rebootNeeded, _, err := manager.ValidateDeviceNvSpec(ctx, device)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(updateNeeded).To(BeFalse())
 				Expect(rebootNeeded).To(BeFalse())
@@ -1456,7 +1362,7 @@ var _ = Describe("ConfigurationManager", func() {
 				mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string{"NUM_OF_PF"}).Return(
 					types.NvConfigQuery{CurrentConfig: map[string][]string{"NUM_OF_PF": {"2"}}}, nil)
 
-				updateNeeded, rebootNeeded, err := manager.ValidateDeviceNvSpec(ctx, device)
+				updateNeeded, rebootNeeded, _, err := manager.ValidateDeviceNvSpec(ctx, device)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(updateNeeded).To(BeTrue())
 				Expect(rebootNeeded).To(BeTrue())
@@ -1677,12 +1583,11 @@ var _ = Describe("ConfigurationManager", func() {
 		Describe("ValidateDeviceNvSpec", func() {
 			It("requires update+reboot when system_conf does not match", func() {
 				mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig, nil)
-				mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).Return(true)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 					Return(map[string]string{}, nil)
 				mockNV.On("ValidateSystemConf", ctx, pciAddress, "conf3", 0).Return(false, nil)
 
-				configUpdate, reboot, err := manager.ValidateDeviceNvSpec(ctx, device)
+				configUpdate, reboot, _, err := manager.ValidateDeviceNvSpec(ctx, device)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(configUpdate).To(BeTrue())
 				Expect(reboot).To(BeTrue())
@@ -1690,12 +1595,11 @@ var _ = Describe("ConfigurationManager", func() {
 
 			It("requires nothing when both regular config and system_conf match", func() {
 				mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig, nil)
-				mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).Return(true)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 					Return(map[string]string{}, nil)
 				mockNV.On("ValidateSystemConf", ctx, pciAddress, "conf3", 0).Return(true, nil)
 
-				configUpdate, reboot, err := manager.ValidateDeviceNvSpec(ctx, device)
+				configUpdate, reboot, _, err := manager.ValidateDeviceNvSpec(ctx, device)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(configUpdate).To(BeFalse())
 				Expect(reboot).To(BeFalse())
@@ -1705,7 +1609,6 @@ var _ = Describe("ConfigurationManager", func() {
 		Describe("ApplyNVConfiguration", func() {
 			It("applies set_system_conf and requires reboot when it does not match", func() {
 				mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig, nil)
-				mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).Return(true)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 					Return(map[string]string{}, nil)
 				mockNV.On("ValidateSystemConf", ctx, pciAddress, "conf3", 0).Return(false, nil)
@@ -1719,7 +1622,6 @@ var _ = Describe("ConfigurationManager", func() {
 
 			It("passes --force to set_system_conf when Force is set", func() {
 				mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig, nil)
-				mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).Return(true)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 					Return(map[string]string{}, nil)
 				mockNV.On("ValidateSystemConf", ctx, pciAddress, "conf3", 0).Return(false, nil)
@@ -1732,7 +1634,6 @@ var _ = Describe("ConfigurationManager", func() {
 
 			It("does nothing when system_conf already matches and no regular params change", func() {
 				mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig, nil)
-				mockConfigValidation.On("AdvancedPCISettingsEnabled", nvConfig).Return(true)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 					Return(map[string]string{}, nil)
 				mockNV.On("ValidateSystemConf", ctx, pciAddress, "conf3", 0).Return(true, nil)

--- a/pkg/configuration/mocks/ConfigValidation.go
+++ b/pkg/configuration/mocks/ConfigValidation.go
@@ -13,24 +13,6 @@ type ConfigValidation struct {
 	mock.Mock
 }
 
-// AdvancedPCISettingsEnabled provides a mock function with given fields: nvConfig
-func (_m *ConfigValidation) AdvancedPCISettingsEnabled(nvConfig types.NvConfigQuery) bool {
-	ret := _m.Called(nvConfig)
-
-	if len(ret) == 0 {
-		panic("no return value specified for AdvancedPCISettingsEnabled")
-	}
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func(types.NvConfigQuery) bool); ok {
-		r0 = rf(nvConfig)
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	return r0
-}
-
 // CalculateDesiredRuntimeConfig provides a mock function with given fields: device
 func (_m *ConfigValidation) CalculateDesiredRuntimeConfig(device *v1alpha1.NicDevice) types.DesiredRuntimeConfig {
 	ret := _m.Called(device)

--- a/pkg/configuration/mocks/ConfigurationManager.go
+++ b/pkg/configuration/mocks/ConfigurationManager.go
@@ -95,7 +95,7 @@ func (_m *ConfigurationManager) ResetNicFirmware(ctx context.Context, device *v1
 }
 
 // ValidateDeviceNvSpec provides a mock function with given fields: ctx, device
-func (_m *ConfigurationManager) ValidateDeviceNvSpec(ctx context.Context, device *v1alpha1.NicDevice) (bool, bool, error) {
+func (_m *ConfigurationManager) ValidateDeviceNvSpec(ctx context.Context, device *v1alpha1.NicDevice) (bool, bool, []string, error) {
 	ret := _m.Called(ctx, device)
 
 	if len(ret) == 0 {
@@ -104,8 +104,9 @@ func (_m *ConfigurationManager) ValidateDeviceNvSpec(ctx context.Context, device
 
 	var r0 bool
 	var r1 bool
-	var r2 error
-	if rf, ok := ret.Get(0).(func(context.Context, *v1alpha1.NicDevice) (bool, bool, error)); ok {
+	var r2 []string
+	var r3 error
+	if rf, ok := ret.Get(0).(func(context.Context, *v1alpha1.NicDevice) (bool, bool, []string, error)); ok {
 		return rf(ctx, device)
 	}
 	if rf, ok := ret.Get(0).(func(context.Context, *v1alpha1.NicDevice) bool); ok {
@@ -120,13 +121,21 @@ func (_m *ConfigurationManager) ValidateDeviceNvSpec(ctx context.Context, device
 		r1 = ret.Get(1).(bool)
 	}
 
-	if rf, ok := ret.Get(2).(func(context.Context, *v1alpha1.NicDevice) error); ok {
+	if rf, ok := ret.Get(2).(func(context.Context, *v1alpha1.NicDevice) []string); ok {
 		r2 = rf(ctx, device)
 	} else {
-		r2 = ret.Error(2)
+		if ret.Get(2) != nil {
+			r2 = ret.Get(2).([]string)
+		}
 	}
 
-	return r0, r1, r2
+	if rf, ok := ret.Get(3).(func(context.Context, *v1alpha1.NicDevice) error); ok {
+		r3 = rf(ctx, device)
+	} else {
+		r3 = ret.Error(3)
+	}
+
+	return r0, r1, r2, r3
 }
 
 // NewConfigurationManager creates a new instance of ConfigurationManager. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -41,6 +41,8 @@ const (
 	NonVolatileConfigUpdateFailedReason = "NonVolatileConfigUpdateFailed"
 	RuntimeConfigUpdateFailedReason     = "RuntimeConfigUpdateFailed"
 	UpdateSuccessfulReason              = "UpdateSuccessful"
+	PartiallyAppliedReason              = "PartiallyApplied"
+	PartiallyAppliedMessageFmt          = "configuration partially applied; the following spec params are not supported on this device and were skipped: %s"
 	SpecValidationFailed                = "SpecValidationFailed"
 	FirmwareError                       = "FirmwareError"
 	PendingFirmwareUpdateReason         = "PendingFirmwareUpdate"


### PR DESCRIPTION
## Summary

The configuration manager currently auto-enables `ADVANCED_PCI_SETTINGS` when it's off, runs `mlxfwreset` to avoid a reboot, and re-queries nvconfig to pick up newly visible params. The validation path also rejects any spec referencing a param hidden because ADVANCED is off, returning `IncorrectSpecError`.

That entangles the operator with a platform-policy knob better owned by the deployer (or by the device template via `rawNvConfig`). This PR drops the auto-enable entirely. Hidden params are now treated as unsupported and skipped — matching the existing `hasUnsupportedParams` branch in apply (`ApplyStatusPartiallyApplied`).

`consts.AdvancedPCISettingsParam` is kept so users can still drive the param explicitly via `template.rawNvConfig`.

## Changes

* `ApplyNVConfiguration`: drop the auto-enable + `mlxfwreset` + re-query block.
* `ValidateDeviceNvSpec`: drop the `advancedPciSettingsEnabled` guard and the `IncorrectSpecError` branch; treat missing-from-`NextBootConfig` as a skip (no `configUpdateNeeded`).
* `applyResetToDefault`: drop the post-reset `ADVANCED_PCI_SETTINGS=true` re-set.
* `configValidation.ConstructNvParamMapFromTemplate`: drop the ADVANCED gate around the MaxAccOutRead default-derivation; skip silently when the param is hidden instead of returning `IncorrectSpecError`.
* `configValidation.ValidateResetToDefault`: collapse to BF3-mode preservation plus plain `reflect.DeepEqual` between Current/NextBoot and Default.
* Remove `AdvancedPCISettingsEnabled` from the `configValidation` interface, impl, and mock; rework Ginkgo specs accordingly.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/configuration/... -count=1` — pass
- [x] `go test ./... -count=1` — all unit/integration suites pass (the one flake in `internal/controller` cleared on rerun; `test/e2e` failure is a sandboxed `kubectl create -f https://github.com/...`, unrelated)
- [x] `golangci-lint run ./pkg/configuration/...` — 0 issues
- [ ] E2E on a NIC where `ADVANCED_PCI_SETTINGS` is off and the template references a hidden param: reconcile should complete and report `ApplyStatusPartiallyApplied`, without auto-enabling ADVANCED.