### PR TITLE
docs: add Spectrum-X profile ConfigMap example

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,9 @@ To create a Spectrum-X profile ConfigMap:
 3. Add the label `network.nvidia.com/operator.nic-configuration.spectrum-x-profile`. The label value is ignored; only the label key must be present.
 4. Put the complete Spectrum-X profile YAML under `data.profile`.
 
-The profile ConfigMap can be created in any namespace watched by the operator. If two labeled ConfigMaps in different namespaces use the same name, they define the same Spectrum-X version key and the latest reconciled ConfigMap wins.
+The profile ConfigMap can be created in any namespace watched by the operator.
+
+> **Warning:** If two labeled ConfigMaps in different namespaces share the same name, they define the same Spectrum-X version key and the latest-reconciled ConfigMap silently wins with no error. To avoid unpredictable behavior, use unique ConfigMap names across all watched namespaces.
 
 ##### [Example Spectrum-X profile ConfigMap](docs/examples/spectrum-x/example-spectrum-x-profile-configmap.yaml):
 

--- a/README.md
+++ b/README.md
@@ -109,22 +109,69 @@ spec:
   * Cannot be combined with `roceOptimized` (RoCE settings are included automatically)
   * Can be combined with `rawNvConfig` — raw params are merged as overrides on top of Spectrum-X calculated params
   * Only supported on ConnectX-8 (`nicType: 1023`), ConnectX-9 (`nicType: 1025`) and BlueField-3 SuperNIC (`nicType: a2dc`)
-  * `version`: Required. Reference Architecture version (`RA1.3`, `RA2.0`, `RA2.1`, or `RA2.2`)
+  * `version`: Required. Must match the name of a Spectrum-X profile ConfigMap
   * `overlay`: Optional, default `none`. Set to `l3` for L3 EVPN overlay
-  * `multiplaneMode`: Optional, default `none`. Only available with RA2.1. Options: `none`, `swplb`, `hwplb`, `uniplane`
-  * `numberOfPlanes`: Optional, default `1`. Only available with RA2.1. Options: `1`, `2`, or `4`
+  * `multiplaneMode`: Optional, default `none`. Options: `none`, `swplb`, `hwplb`, `uniplane`
+  * `numberOfPlanes`: Optional, default `1`. Options: `1`, `2`, or `4`
 * If a configuration is not set in spec, its non-volatile configuration parameters (if any) should be set to device default.
 
 #### Spectrum-X Configuration
 
-The NIC Configuration Operator supports Spectrum-X-specific NIC configuration for different versions of the NVIDIA Spectrum-X Reference Architecture (RA1.3, RA2.0, and RA2.1).
+The NIC Configuration Operator supports Spectrum-X-specific NIC configuration through Spectrum-X profile ConfigMaps. A profile ConfigMap contains the Spectrum-X YAML profile consumed by the daemon at runtime.
+
+To create a Spectrum-X profile ConfigMap:
+
+1. Create one ConfigMap per profile.
+2. Set the ConfigMap name to the value that will be used in `template.spectrumXOptimized.version`.
+3. Add the label `network.nvidia.com/operator.nic-configuration.spectrum-x-profile`. The label value is ignored; only the label key must be present.
+4. Put the complete Spectrum-X profile YAML under `data.profile`.
+
+The profile ConfigMap can be created in any namespace watched by the operator. If two labeled ConfigMaps in different namespaces use the same name, they define the same Spectrum-X version key and the latest reconciled ConfigMap wins.
+
+##### [Example Spectrum-X profile ConfigMap](docs/examples/spectrum-x/example-spectrum-x-profile-configmap.yaml):
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-spectrum-x-profile
+  namespace: nvidia-network-operator
+  labels:
+    network.nvidia.com/operator.nic-configuration.spectrum-x-profile: ""
+data:
+  profile: |
+    useSoftwareCCAlgorithm: true
+    docaCCVersion: "example-version"
+    mlxConfig:
+      none:
+        "1023":
+          postBreakout:
+            EXAMPLE_NVCONFIG_PARAMETER: "example-value"
+    runtimeConfig:
+      roce:
+        - name: Example RoCE runtime parameter
+          value: "example-value"
+          valueType: string
+          dmsPath: "<dms-path-for-runtime-parameter>"
+```
+
+Reference the profile from a `NicConfigurationTemplate` by using the ConfigMap name as the Spectrum-X version:
+
+```yaml
+spectrumXOptimized:
+  enabled: true
+  version: "example-spectrum-x-profile"
+  overlay: "none"
+  multiplaneMode: "none"
+  numberOfPlanes: 1
+```
 
 Supported NIC types for Spectrum-X:
 * ConnectX-8 (device ID `1023`) -- supports all multiplane modes
 * ConnectX-9 (device ID `1025`) -- supports all multiplane modes (same configuration as ConnectX-8)
 * BlueField-3 SuperNIC (device ID `a2dc`) -- supports all multiplane modes except `hwplb`
 
-RA2.1 introduces multiplane mode support, allowing NICs to be configured with multiple data planes. Available modes:
+Spectrum-X profiles can configure NICs with multiple data planes. Available modes:
 
 | Mode | Description | Supported NICs | Planes |
 |------|-------------|----------------|--------|
@@ -132,8 +179,6 @@ RA2.1 introduces multiplane mode support, allowing NICs to be configured with mu
 | `swplb` | Software Packet Load Balancing | ConnectX-8, ConnectX-9, BF3 SuperNIC | 2, 4 |
 | `hwplb` | Hardware Packet Load Balancing | ConnectX-8, ConnectX-9 only | 2, 4 |
 | `uniplane` | Uniplane mode | ConnectX-8, ConnectX-9, BF3 SuperNIC | 2 |
-
-> **Note:** Multiplane modes are only available with RA2.1. For RA1.3 and RA2.0, `multiplaneMode` must be `none` and `numberOfPlanes` must be `1`.
 
 ##### [Example Spectrum-X NicConfigurationTemplate with multiplane](docs/examples/spectrum-x/example-nicconfigurationtemplate-spectrum-x-multiplane.yaml):
 

--- a/docs/examples/spectrum-x/example-spectrum-x-profile-configmap.yaml
+++ b/docs/examples/spectrum-x/example-spectrum-x-profile-configmap.yaml
@@ -1,0 +1,74 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Example only. Replace the placeholder parameter names, values, and DMS paths
+# with values from a validated Spectrum-X profile.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-spectrum-x-profile
+  namespace: nvidia-network-operator
+  labels:
+    network.nvidia.com/operator.nic-configuration.spectrum-x-profile: ""
+data:
+  profile: |
+    useSoftwareCCAlgorithm: true
+    docaCCVersion: "example-version"
+    mlxConfig:
+      none:
+        "1023":
+          postBreakout:
+            EXAMPLE_NVCONFIG_PARAMETER: "example-value"
+        "1025":
+          postBreakout:
+            EXAMPLE_NVCONFIG_PARAMETER: "example-value"
+        "a2dc":
+          postBreakout:
+            EXAMPLE_NVCONFIG_PARAMETER: "example-value"
+      swplb:
+        "1023":
+          breakout:
+            2:
+              EXAMPLE_BREAKOUT_PARAMETER: "example-value"
+          postBreakout:
+            EXAMPLE_POST_BREAKOUT_PARAMETER: "example-value"
+    runtimeConfig:
+      roce:
+        - name: Example RoCE runtime parameter
+          value: "example-value"
+          valueType: string
+          dmsPath: "<dms-path-for-runtime-parameter>"
+      adaptiveRouting:
+        - name: Example adaptive routing parameter
+          value: true
+          valueType: bool
+          dmsPath: "<dms-path-for-runtime-parameter>"
+      congestionControl:
+        - name: Example congestion control parameter
+          value: 1
+          valueType: int
+          dmsPath: "<dms-path-for-runtime-parameter>"
+      interPacketGap:
+        pureL3:
+          - name: Example inter-packet gap parameter
+            value: 1
+            valueType: int
+            dmsPath: "<dms-path-for-runtime-parameter>"
+        l3EVPN:
+          - name: Example overlay inter-packet gap parameter
+            value: 1
+            valueType: int
+            dmsPath: "<dms-path-for-runtime-parameter>"


### PR DESCRIPTION
## Summary
- Document that `spectrumXOptimized.version` must match the Spectrum-X profile ConfigMap name.
- Add the required profile ConfigMap layout: label selector and `data.profile` payload.
- Add a generic example profile ConfigMap with placeholder NVConfig names and placeholder DMS paths only.

## Validation
- `ruby -e 'require "yaml"; YAML.safe_load(File.read("docs/examples/spectrum-x/example-spectrum-x-profile-configmap.yaml")); puts "yaml ok"'`\n- `git diff --check -- README.md docs/examples/spectrum-x/example-spectrum-x-profile-configmap.yaml`