### PR TITLE
fix: optimize NV configuration apply flow

### DIFF
--- a/docs/nic-configuration-library.md
+++ b/docs/nic-configuration-library.md
@@ -163,11 +163,11 @@ func NewConfigurationManager(
 
 #### NV Configuration Flow
 
-1. **Query** current NV config via `nvConfigUtils.QueryNvConfig()`
-2. **Network Bay `set_system_conf` (baseline, applied first)** — for ConnectX-9 Network Bay devices (`template.networkBay` set and `status.networkBay` detected), the per-ASIC `set_system_conf <conf>[<asic>]` is applied **before** the regular / Spectrum-X params so those layer on top of it (override priority: `rawNvConfig` > Spectrum-X > system_conf). Drift is detected per-param via `nvconfig.ValidateSystemConf()`, which returns the overall match bit plus the names of the mismatched params; the manager ignores MISMATCH rows for params owned by a higher-priority layer (matched by exact per-index key — `rawNvConfig` index-range syntax like `MODULE_SPLIT_M0[0..3]` is rejected by CRD validation, so keys are always concrete); a change requires a reboot. Skipped for devices with `ResetToDefault`
-3. **Diff** desired vs current parameters. Params not present in the device's next-boot config are unsupported on this device (e.g. hidden because `ADVANCED_PCI_SETTINGS` is off) and are skipped — the operator does **not** auto-manage `ADVANCED_PCI_SETTINGS`; drive it explicitly via `template.rawNvConfig` if needed
-4. **Batch set** via `nvConfigUtils.SetNvConfigParametersBatch()` — single `mlxconfig set` call (`--force` added when `ConfigurationOptions.Force=true`). Apply reports `ApplyStatusPartiallyApplied` when any desired param was skipped as unsupported
-5. **Optional reset** — `mlxfwreset` unless `ConfigurationOptions.SkipReset=true`
+1. **Reset branch** — when `ResetToDefault` is set, query the first PF, run `mlxconfig reset`, restore BF3 operation mode when needed, then finish.
+2. **Link type capability check** — when `template.linkType` is set, query only `LINK_TYPE_P1` to determine whether link type changes are supported.
+3. **Network Bay `set_system_conf` (baseline, applied before overrides)** — for ConnectX-9 Network Bay devices (`template.networkBay` set and `status.networkBay` detected), the per-ASIC `set_system_conf <conf>[<asic>]` is applied **before** the regular / Spectrum-X params so those layer on top of it (override priority: `rawNvConfig` > Spectrum-X > system_conf). Drift is detected per-param via `nvconfig.ValidateSystemConf()`, which returns the overall match bit plus the names of the mismatched params; the manager ignores MISMATCH rows for params owned by a higher-priority layer (matched by exact per-index key — `rawNvConfig` index-range syntax like `MODULE_SPLIT_M0[0..3]` is rejected by CRD validation, so keys are always concrete); a change requires a reboot. Skipped for devices with `ResetToDefault`.
+4. **Diff** desired vs next-boot parameters when needed. Params not present in the device's next-boot config are unsupported or not visible yet and are skipped — the operator does **not** auto-manage `ADVANCED_PCI_SETTINGS`; drive it explicitly via `template.rawNvConfig` if needed.
+5. **Batch set** via `nvConfigUtils.SetNvConfigParametersBatch()` — single `mlxconfig set` call (`--force` added when `ConfigurationOptions.Force=true`, `--with_default` when `WithDefault=true`). The setter returns `ApplyStatusNothingToDo` when a successful `--with_default` command reports no `Configurations:` section, so the apply result only requires reboot when something was actually changed. Apply reports `ApplyStatusPartiallyApplied` when any desired param was skipped as unsupported.
 
 **`ConfigurationOptions`:**
 - `SkipReset` — skip `mlxfwreset` after applying NV config
@@ -360,7 +360,7 @@ type NVConfigUtils interface {
     // params: map of paramName → paramValue
     // withDefault: add --with_default flag
     // force: add --force flag
-    SetNvConfigParametersBatch(pciAddr string, params map[string]string, withDefault bool, force bool) error
+    SetNvConfigParametersBatch(pciAddr string, params map[string]string, withDefault bool, force bool) (types.ApplyStatus, error)
 
     // ResetNvConfig resets NIC's NV config to defaults
     ResetNvConfig(pciAddr string) error
@@ -383,7 +383,8 @@ func NewNVConfigUtils() NVConfigUtils
 
 **Batch command format:**
 ```
-mlxconfig -d <pci> --yes [--with_default] [--force] set PARAM1=VAL1 PARAM2=VAL2 ...
+mlxconfig -d <pci> --yes [--force] set PARAM1=VAL1 PARAM2=VAL2 ...
+mlxconfig -d <pci> -e --with_default -y [--force] set PARAM1=VAL1 PARAM2=VAL2 ...
 ```
 Parameter names are sorted for deterministic command generation.
 

--- a/pkg/configuration/configvalidation.go
+++ b/pkg/configuration/configvalidation.go
@@ -16,12 +16,10 @@ limitations under the License.
 package configuration
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
 
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -38,7 +36,7 @@ type configValidation interface {
 	// devices these params override the set_system_conf baseline. Operates under the assumption that spec
 	// validation was already carried out.
 	ConstructNvParamMapFromTemplate(
-		device *v1alpha1.NicDevice, nvConfigQuery types.NvConfigQuery) (map[string]string, error)
+		device *v1alpha1.NicDevice, linkTypeChangeSupported bool) (map[string]string, error)
 	// ValidateResetToDefault checks if device's nv config has been reset to default in current and next boots
 	// returns bool - need to perform reset
 	// returns bool - reboot required
@@ -67,22 +65,12 @@ func nvParamLinkTypeFromName(linkType string) string {
 	}
 }
 
-func applyDefaultNvConfigValueIfExists(
-	paramName string, desiredParameters map[string]string, query types.NvConfigQuery) {
-	defaultValues, found := query.DefaultConfig[paramName]
-	// The param's default may be absent if it is hidden on this device (e.g. ADVANCED_PCI_SETTINGS off).
-	if found {
-		// Take the default numeric value
-		desiredParameters[paramName] = defaultValues[len(defaultValues)-1]
-	}
-}
-
 // ConstructNvParamMapFromTemplate builds the full set of desired nvconfig parameters for a device by
 // combining, in increasing priority order, the Spectrum-X profile (breakout + postBreakout, when
 // enabled), the spec template params, and rawNvConfig (raw wins on key collisions). Operates under the
 // assumption that spec validation was already carried out.
 func (v *configValidationImpl) ConstructNvParamMapFromTemplate(
-	device *v1alpha1.NicDevice, query types.NvConfigQuery) (map[string]string, error) {
+	device *v1alpha1.NicDevice, linkTypeChangeSupported bool) (map[string]string, error) {
 	template := device.Spec.Configuration.Template
 	if template == nil {
 		// No template: nothing to translate. rawNvConfig / Spectrum-X live under the template, so there
@@ -105,17 +93,11 @@ func (v *configValidationImpl) ConstructNvParamMapFromTemplate(
 	// so the operator must not emit LINK_TYPE_P* here or it would fight the system configuration.
 	if template.LinkType != "" {
 		// Link type change is not allowed on some devices
-		_, canChangeLinkType := query.DefaultConfig[consts.LinkTypeP1Param]
-		if canChangeLinkType {
+		if linkTypeChangeSupported {
 			linkType := nvParamLinkTypeFromName(string(template.LinkType))
-			// Emit LINK_TYPE_P<n> for every discovered port. Firmware may expose
-			// fewer slots than the device has ports (e.g. BF3 DPU mode), so gate
-			// each entry on a presence check in the query output.
 			for portIdx := 1; portIdx <= portCount; portIdx++ {
 				name := consts.PortParam(consts.LinkTypeParamBase, portIdx)
-				if _, ok := query.DefaultConfig[name]; ok {
-					desiredParameters[name] = linkType
-				}
+				desiredParameters[name] = linkType
 			}
 		} else {
 			desiredLinkType := string(device.Spec.Configuration.Template.LinkType)
@@ -134,28 +116,9 @@ func (v *configValidationImpl) ConstructNvParamMapFromTemplate(
 	}
 
 	if template.PciPerformanceOptimized != nil && template.PciPerformanceOptimized.Enabled {
-		maxAccOutRead := template.PciPerformanceOptimized.MaxAccOutRead //nolint:staticcheck // Backward compatibility: keep honoring this field until the mapping is removed.
+		maxAccOutRead := template.PciPerformanceOptimized.MaxAccOutRead //nolint:staticcheck // Log-only read for ignored deprecated configuration.
 		if maxAccOutRead != 0 {
-			desiredParameters[consts.MaxAccOutReadParam] = strconv.Itoa(maxAccOutRead)
-		} else if values, found := query.DefaultConfig[consts.MaxAccOutReadParam]; found {
-			// MAX_ACC_OUT_READ is hidden when ADVANCED_PCI_SETTINGS is off. If the default is not
-			// in DefaultConfig the param is unsupported on this device — skip it silently and let
-			// the apply path report ApplyStatusPartiallyApplied if any other params still need work.
-			maxAccOutReadParamDefaultValue := values[len(values)-1]
-
-			// According to the PRM, setting MAX_ACC_OUT_READ to zero enables the auto mode,
-			// which applies the best suitable optimizations.
-			// However, there is a bug in certain FW versions, where the zero value is not available.
-			// In this case, until the fix is available, skipping this parameter and emitting a warning
-			if maxAccOutReadParamDefaultValue == consts.NvParamZero {
-				applyDefaultNvConfigValueIfExists(consts.MaxAccOutReadParam, desiredParameters, query)
-			} else {
-				warning := fmt.Sprintf("%s nv config parameter does not work properly on this version of FW, skipping it", consts.MaxAccOutReadParam)
-				if v.eventRecorder != nil {
-					v.eventRecorder.Event(device, v1.EventTypeWarning, "FirmwareError", warning)
-				}
-				log.Log.Error(errors.New(warning), "skipping parameter", "device", device.Name, "fw version", device.Status.FirmwareVersion)
-			}
+			log.Log.Info("maxAccOutRead is deprecated and no longer maps to MAX_ACC_OUT_READ", "device", device.Name)
 		}
 
 		// maxReadRequest is applied as runtime configuration
@@ -178,12 +141,6 @@ func (v *configValidationImpl) ConstructNvParamMapFromTemplate(
 		}
 
 		// qos settings are applied as runtime configuration
-	} else {
-		for portIdx := 1; portIdx <= portCount; portIdx++ {
-			applyDefaultNvConfigValueIfExists(consts.PortParam(consts.RoceCcPrioMaskParamBase, portIdx), desiredParameters, query)
-			applyDefaultNvConfigValueIfExists(consts.PortParam(consts.CnpDscpParamBase, portIdx), desiredParameters, query)
-			applyDefaultNvConfigValueIfExists(consts.PortParam(consts.Cnp802pPrioParamBase, portIdx), desiredParameters, query)
-		}
 	}
 
 	if template.GpuDirectOptimized != nil && template.GpuDirectOptimized.Enabled {
@@ -200,10 +157,69 @@ func (v *configValidationImpl) ConstructNvParamMapFromTemplate(
 			log.Log.Error(err, "incorrect spec", "device", device.Name)
 			return desiredParameters, err
 		}
-	} else {
-		applyDefaultNvConfigValueIfExists(consts.AtsEnabledParam, desiredParameters, query)
 	}
-	return v.mergeOverrideLayers(device, desiredParameters)
+
+	combined, err := v.mergeOverrideLayers(device, desiredParameters)
+	if err != nil {
+		return nil, err
+	}
+	extrapolatePortParamsFromNumOfPF(combined)
+	filterPortParams(combined, effectivePortCount(device, combined))
+	return combined, nil
+}
+
+func effectivePortCount(device *v1alpha1.NicDevice, params map[string]string) int {
+	portCount := len(device.Status.Ports)
+	if value, ok := params[consts.NumOfPfParam]; ok {
+		if n, err := strconv.Atoi(value); err == nil && n > portCount {
+			portCount = n
+		}
+	}
+	return portCount
+}
+
+func extrapolatePortParamsFromNumOfPF(params map[string]string) {
+	value, ok := params[consts.NumOfPfParam]
+	if !ok {
+		return
+	}
+	portCount, err := strconv.Atoi(value)
+	if err != nil || portCount < 2 {
+		return
+	}
+
+	type portParamValue struct {
+		portNum int
+		value   string
+	}
+	baseValues := map[string]portParamValue{}
+	for param, value := range params {
+		portNum, ok := consts.PortSuffixNum(param)
+		if !ok || portNum < 1 {
+			continue
+		}
+		base := param[:len(param)-len(strconv.Itoa(portNum))-2]
+		current, exists := baseValues[base]
+		if !exists || portNum < current.portNum {
+			baseValues[base] = portParamValue{portNum: portNum, value: value}
+		}
+	}
+	for base, baseValue := range baseValues {
+		for portNum := 1; portNum <= portCount; portNum++ {
+			param := consts.PortParam(base, portNum)
+			if _, exists := params[param]; !exists {
+				params[param] = baseValue.value
+			}
+		}
+	}
+}
+
+func filterPortParams(params map[string]string, portCount int) {
+	for param := range params {
+		if n, ok := consts.PortSuffixNum(param); ok && n > portCount {
+			delete(params, param)
+		}
+	}
 }
 
 // mergeOverrideLayers combines the template-derived params with the Spectrum-X profile (breakout +
@@ -225,8 +241,8 @@ func (v *configValidationImpl) mergeOverrideLayers(device *v1alpha1.NicDevice, t
 		mergeParams(combined, postBreakoutParams)
 	}
 	mergeParams(combined, templateParams)
-	// rawNvConfig has the highest priority, so it is merged last. getRawNvConfigParams already drops
-	// _Pn params whose port is beyond the device's port count.
+	// rawNvConfig has the highest priority, so it is merged last. Port-suffixed params are filtered
+	// after NUM_OF_PF-driven extrapolation determines the effective port count.
 	mergeParams(combined, getRawNvConfigParams(device))
 
 	return combined, nil

--- a/pkg/configuration/configvalidation_test.go
+++ b/pkg/configuration/configvalidation_test.go
@@ -45,7 +45,7 @@ var _ = Describe("ConfigValidationImpl", func() {
 	})
 
 	Describe("ConstructNvParamMapFromTemplate", func() {
-		It("should return default values if optional config is disabled", func() {
+		It("should not use queried defaults when optional config is disabled", func() {
 			device := &v1alpha1.NicDevice{
 				Spec: v1alpha1.NicDeviceSpec{
 					Configuration: &v1alpha1.NicDeviceConfigurationSpec{
@@ -63,31 +63,19 @@ var _ = Describe("ConfigValidationImpl", func() {
 				},
 			}
 
-			defaultValues := map[string][]string{
-				consts.RoceCcPrioMaskP1Param: {"testRoceCcP1"},
-				consts.CnpDscpP1Param:        {"testDscpP1"},
-				consts.Cnp802pPrioP1Param:    {"test802PrioP1"},
-				consts.RoceCcPrioMaskP2Param: {"testRoceCcP2"},
-				consts.CnpDscpP2Param:        {"testDscpP2"},
-				consts.Cnp802pPrioP2Param:    {"test802PrioP2"},
-				consts.AtsEnabledParam:       {"testAts"},
-			}
-			query := types.NewNvConfigQuery()
-			query.DefaultConfig = defaultValues
-			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, query)
+			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, true)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nvParams).To(HaveKeyWithValue(consts.SriovEnabledParam, consts.NvParamFalse))
 			Expect(nvParams).To(HaveKeyWithValue(consts.SriovNumOfVfsParam, "0"))
-			Expect(nvParams).To(HaveKeyWithValue(consts.RoceCcPrioMaskP1Param, "testRoceCcP1"))
-			Expect(nvParams).To(HaveKeyWithValue(consts.CnpDscpP1Param, "testDscpP1"))
-			Expect(nvParams).To(HaveKeyWithValue(consts.Cnp802pPrioP1Param, "test802PrioP1"))
-			Expect(nvParams).To(HaveKeyWithValue(consts.RoceCcPrioMaskP2Param, "testRoceCcP2"))
-			Expect(nvParams).To(HaveKeyWithValue(consts.CnpDscpP2Param, "testDscpP2"))
-			Expect(nvParams).To(HaveKeyWithValue(consts.Cnp802pPrioP2Param, "test802PrioP2"))
-			Expect(nvParams).To(HaveKeyWithValue(consts.AtsEnabledParam, "testAts"))
+			Expect(nvParams).To(HaveKeyWithValue(consts.LinkTypeP1Param, consts.NvParamLinkTypeEthernet))
+			Expect(nvParams).To(HaveKeyWithValue(consts.LinkTypeP2Param, consts.NvParamLinkTypeEthernet))
+			Expect(nvParams).NotTo(HaveKey(consts.RoceCcPrioMaskP1Param))
+			Expect(nvParams).NotTo(HaveKey(consts.CnpDscpP1Param))
+			Expect(nvParams).NotTo(HaveKey(consts.Cnp802pPrioP1Param))
+			Expect(nvParams).NotTo(HaveKey(consts.AtsEnabledParam))
 		})
 
-		It("should check if dual-port device has LINK_TYPE_P2 param", func() {
+		It("should emit LINK_TYPE params for all discovered ports when link type change is supported", func() {
 			device := &v1alpha1.NicDevice{
 				Spec: v1alpha1.NicDeviceSpec{
 					Configuration: &v1alpha1.NicDeviceConfigurationSpec{
@@ -105,15 +93,10 @@ var _ = Describe("ConfigValidationImpl", func() {
 				},
 			}
 
-			defaultValues := map[string][]string{
-				consts.LinkTypeP1Param: {"testLinkTypeP1"},
-			}
-			query := types.NewNvConfigQuery()
-			query.DefaultConfig = defaultValues
-			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, query)
+			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, true)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nvParams).To(HaveKeyWithValue(consts.LinkTypeP1Param, consts.NvParamLinkTypeEthernet))
-			Expect(nvParams).ToNot(HaveKey(consts.LinkTypeP2Param))
+			Expect(nvParams).To(HaveKeyWithValue(consts.LinkTypeP2Param, consts.NvParamLinkTypeEthernet))
 		})
 
 		It("should not emit LINK_TYPE params when linkType is unset (Network Bay)", func() {
@@ -134,14 +117,9 @@ var _ = Describe("ConfigValidationImpl", func() {
 				},
 			}
 
-			// Firmware exposes LINK_TYPE slots, but the template does not set linkType, so the
+			// Even when link type change is supported, the template does not set linkType, so the
 			// operator must not emit LINK_TYPE_P* (set_system_conf owns the link type).
-			query := types.NewNvConfigQuery()
-			query.DefaultConfig = map[string][]string{
-				consts.LinkTypeP1Param: {"2"},
-				consts.LinkTypeP2Param: {"2"},
-			}
-			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, query)
+			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, true)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nvParams).ToNot(HaveKey(consts.LinkTypeP1Param))
 			Expect(nvParams).ToNot(HaveKey(consts.LinkTypeP2Param))
@@ -163,26 +141,16 @@ var _ = Describe("ConfigValidationImpl", func() {
 					},
 				},
 			}
-			defaultValues := map[string][]string{
-				consts.RoceCcPrioMaskP1Param: {"testRoceCcP1"},
-				consts.CnpDscpP1Param:        {"testDscpP1"},
-				consts.Cnp802pPrioP1Param:    {"test802PrioP1"},
-				consts.RoceCcPrioMaskP2Param: {"testRoceCcP2"},
-				consts.CnpDscpP2Param:        {"testDscpP2"},
-				consts.Cnp802pPrioP2Param:    {"test802PrioP2"},
-				consts.AtsEnabledParam:       {"testAts"},
-			}
-			query := types.NewNvConfigQuery()
-			query.DefaultConfig = defaultValues
-
-			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, query)
+			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, true)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nvParams).To(HaveKeyWithValue(consts.SriovEnabledParam, consts.NvParamFalse))
 			Expect(nvParams).To(HaveKeyWithValue(consts.SriovNumOfVfsParam, "0"))
-			Expect(nvParams).To(HaveKeyWithValue(consts.AtsEnabledParam, "testAts"))
-			Expect(nvParams).To(HaveKeyWithValue(consts.RoceCcPrioMaskP1Param, "testRoceCcP1"))
-			Expect(nvParams).To(HaveKeyWithValue(consts.CnpDscpP1Param, "testDscpP1"))
-			Expect(nvParams).To(HaveKeyWithValue(consts.Cnp802pPrioP1Param, "test802PrioP1"))
+			Expect(nvParams).To(HaveKeyWithValue(consts.LinkTypeP1Param, consts.NvParamLinkTypeEthernet))
+			Expect(nvParams).To(Not(HaveKey(consts.LinkTypeP2Param)))
+			Expect(nvParams).To(Not(HaveKey(consts.AtsEnabledParam)))
+			Expect(nvParams).To(Not(HaveKey(consts.RoceCcPrioMaskP1Param)))
+			Expect(nvParams).To(Not(HaveKey(consts.CnpDscpP1Param)))
+			Expect(nvParams).To(Not(HaveKey(consts.Cnp802pPrioP1Param)))
 			Expect(nvParams).To(Not(HaveKey(consts.RoceCcPrioMaskP2Param)))
 			Expect(nvParams).To(Not(HaveKey(consts.CnpDscpP2Param)))
 			Expect(nvParams).To(Not(HaveKey(consts.Cnp802pPrioP2Param)))
@@ -224,11 +192,9 @@ var _ = Describe("ConfigValidationImpl", func() {
 				},
 			}
 
-			query := types.NewNvConfigQuery()
-
-			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, query)
+			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, true)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(nvParams).To(HaveKeyWithValue(consts.MaxAccOutReadParam, "1337"))
+			Expect(nvParams).NotTo(HaveKey(consts.MaxAccOutReadParam))
 			Expect(nvParams).To(HaveKeyWithValue(consts.AtsEnabledParam, "0"))
 			Expect(nvParams).To(HaveKeyWithValue(consts.RoceCcPrioMaskP1Param, "255"))
 			Expect(nvParams).To(HaveKeyWithValue(consts.CnpDscpP1Param, "4"))
@@ -238,7 +204,7 @@ var _ = Describe("ConfigValidationImpl", func() {
 			Expect(nvParams).To(HaveKeyWithValue(consts.Cnp802pPrioP2Param, "6"))
 		})
 
-		It("should skip the MaxAccOutRead if the default is not 0", func() {
+		It("should ignore MaxAccOutRead when pciPerformanceOptimized is enabled", func() {
 			mockConfigurationUtils.On("GetPCILinkSpeed", mock.Anything).Return(16, nil)
 
 			device := &v1alpha1.NicDevice{
@@ -260,48 +226,9 @@ var _ = Describe("ConfigValidationImpl", func() {
 				},
 			}
 
-			defaultValues := map[string][]string{
-				consts.MaxAccOutReadParam: {"notZero"},
-			}
-			query := types.NewNvConfigQuery()
-			query.DefaultConfig = defaultValues
-
-			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, query)
+			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, true)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(nvParams).NotTo(HaveKeyWithValue(consts.MaxAccOutReadParam, consts.NvParamZero))
-		})
-
-		It("should apply MaxAccOutRead if the default is 0", func() {
-			mockConfigurationUtils.On("GetPCILinkSpeed", mock.Anything).Return(16, nil)
-
-			device := &v1alpha1.NicDevice{
-				Spec: v1alpha1.NicDeviceSpec{
-					Configuration: &v1alpha1.NicDeviceConfigurationSpec{
-						Template: &v1alpha1.ConfigurationTemplateSpec{
-							NumVfs:   0,
-							LinkType: consts.Ethernet,
-							PciPerformanceOptimized: &v1alpha1.PciPerformanceOptimizedSpec{
-								Enabled: true,
-							},
-						},
-					},
-				},
-				Status: v1alpha1.NicDeviceStatus{
-					Ports: []v1alpha1.NicDevicePortSpec{
-						{PCI: "0000:03:00.0"},
-					},
-				},
-			}
-
-			defaultValues := map[string][]string{
-				consts.MaxAccOutReadParam: {consts.NvParamZero},
-			}
-			query := types.NewNvConfigQuery()
-			query.DefaultConfig = defaultValues
-
-			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, query)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(nvParams).To(HaveKeyWithValue(consts.MaxAccOutReadParam, consts.NvParamZero))
+			Expect(nvParams).NotTo(HaveKey(consts.MaxAccOutReadParam))
 		})
 
 		It("should not apply MaxAccOutRead if the default is unavailable", func() {
@@ -326,10 +253,7 @@ var _ = Describe("ConfigValidationImpl", func() {
 				},
 			}
 
-			// MAX_ACC_OUT_READ param is unavailable if ADVANCED_PCI_SETTINGS is disabled
-			query := types.NewNvConfigQuery()
-
-			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, query)
+			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, true)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nvParams).ToNot(HaveKeyWithValue(consts.MaxAccOutReadParam, consts.NvParamZero))
 		})
@@ -357,9 +281,7 @@ var _ = Describe("ConfigValidationImpl", func() {
 				},
 			}
 
-			query := types.NewNvConfigQuery()
-
-			_, err := validator.ConstructNvParamMapFromTemplate(device, query)
+			_, err := validator.ConstructNvParamMapFromTemplate(device, true)
 			Expect(err).To(MatchError("incorrect spec: GpuDirectOptimized should only be enabled together with PciPerformanceOptimized"))
 		})
 		It("should ignore raw config for the second port if device is single port", func() {
@@ -391,9 +313,7 @@ var _ = Describe("ConfigValidationImpl", func() {
 				},
 			}
 
-			query := types.NewNvConfigQuery()
-
-			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, query)
+			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, true)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nvParams).To(HaveKeyWithValue("TEST_P1", "test"))
 			Expect(nvParams).NotTo(HaveKey("TEST_P2"))
@@ -428,12 +348,70 @@ var _ = Describe("ConfigValidationImpl", func() {
 				},
 			}
 
-			query := types.NewNvConfigQuery()
-
-			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, query)
+			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, true)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nvParams).To(HaveKeyWithValue("TEST_P1", "test"))
 			Expect(nvParams).To(HaveKeyWithValue("TEST_P2", "test"))
+		})
+		It("should extrapolate port-suffixed params when NUM_OF_PF expands the effective port count", func() {
+			device := &v1alpha1.NicDevice{
+				Spec: v1alpha1.NicDeviceSpec{
+					Configuration: &v1alpha1.NicDeviceConfigurationSpec{
+						Template: &v1alpha1.ConfigurationTemplateSpec{
+							NumVfs: 0,
+							RawNvConfig: []v1alpha1.NvConfigParam{
+								{Name: consts.NumOfPfParam, Value: "4"},
+								{Name: "LINK_TYPE_P1", Value: consts.NvParamLinkTypeEthernet},
+								{Name: "CUSTOM_PARAM_P1", Value: "base"},
+								{Name: "CUSTOM_PARAM_P3", Value: "explicit"},
+								{Name: "CUSTOM_PARAM_P5", Value: "drop"},
+							},
+						},
+					},
+				},
+				Status: v1alpha1.NicDeviceStatus{
+					Ports: []v1alpha1.NicDevicePortSpec{{PCI: "0000:03:00.0"}},
+				},
+			}
+
+			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nvParams).To(HaveKeyWithValue(consts.NumOfPfParam, "4"))
+			Expect(nvParams).To(HaveKeyWithValue("LINK_TYPE_P1", consts.NvParamLinkTypeEthernet))
+			Expect(nvParams).To(HaveKeyWithValue("LINK_TYPE_P2", consts.NvParamLinkTypeEthernet))
+			Expect(nvParams).To(HaveKeyWithValue("LINK_TYPE_P3", consts.NvParamLinkTypeEthernet))
+			Expect(nvParams).To(HaveKeyWithValue("LINK_TYPE_P4", consts.NvParamLinkTypeEthernet))
+			Expect(nvParams).To(HaveKeyWithValue("CUSTOM_PARAM_P1", "base"))
+			Expect(nvParams).To(HaveKeyWithValue("CUSTOM_PARAM_P2", "base"))
+			Expect(nvParams).To(HaveKeyWithValue("CUSTOM_PARAM_P3", "explicit"))
+			Expect(nvParams).To(HaveKeyWithValue("CUSTOM_PARAM_P4", "base"))
+			Expect(nvParams).NotTo(HaveKey("CUSTOM_PARAM_P5"))
+		})
+		It("should extrapolate from the lowest existing port when P1 is absent", func() {
+			device := &v1alpha1.NicDevice{
+				Spec: v1alpha1.NicDeviceSpec{
+					Configuration: &v1alpha1.NicDeviceConfigurationSpec{
+						Template: &v1alpha1.ConfigurationTemplateSpec{
+							RawNvConfig: []v1alpha1.NvConfigParam{
+								{Name: consts.NumOfPfParam, Value: "5"},
+								{Name: "LINK_TYPE_P2", Value: "2"},
+								{Name: "LINK_TYPE_P3", Value: "1"},
+							},
+						},
+					},
+				},
+				Status: v1alpha1.NicDeviceStatus{
+					Ports: []v1alpha1.NicDevicePortSpec{{PCI: "0000:03:00.0"}},
+				},
+			}
+
+			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nvParams).To(HaveKeyWithValue("LINK_TYPE_P1", "2"))
+			Expect(nvParams).To(HaveKeyWithValue("LINK_TYPE_P2", "2"))
+			Expect(nvParams).To(HaveKeyWithValue("LINK_TYPE_P3", "1"))
+			Expect(nvParams).To(HaveKeyWithValue("LINK_TYPE_P4", "2"))
+			Expect(nvParams).To(HaveKeyWithValue("LINK_TYPE_P5", "2"))
 		})
 		It("should emit link type and RoCE params for every port on a quad-port device", func() {
 			mockConfigurationUtils.On("GetPCILinkSpeed", mock.Anything).Return(16, nil)
@@ -466,19 +444,10 @@ var _ = Describe("ConfigValidationImpl", func() {
 				},
 			}
 
-			query := types.NewNvConfigQuery()
-			// Firmware exposes LINK_TYPE for all four ports.
-			query.DefaultConfig = map[string][]string{
-				"LINK_TYPE_P1": {"2"},
-				"LINK_TYPE_P2": {"2"},
-				"LINK_TYPE_P3": {"2"},
-				"LINK_TYPE_P4": {"2"},
-			}
-
-			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, query)
+			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, true)
 			Expect(err).NotTo(HaveOccurred())
 
-			// Link type emitted for every port with a firmware-declared slot.
+			// Link type emitted for every discovered port when LINK_TYPE_P1 is supported.
 			for _, name := range []string{"LINK_TYPE_P1", "LINK_TYPE_P2", "LINK_TYPE_P3", "LINK_TYPE_P4"} {
 				Expect(nvParams).To(HaveKeyWithValue(name, consts.NvParamLinkTypeEthernet))
 			}
@@ -500,7 +469,7 @@ var _ = Describe("ConfigValidationImpl", func() {
 			Expect(nvParams).To(HaveKeyWithValue("CUSTOM_PARAM_NO_SUFFIX", "rawN"))
 			Expect(nvParams).NotTo(HaveKey("CUSTOM_PARAM_P5"))
 		})
-		It("should skip LINK_TYPE_Pn for ports firmware does not declare a slot for", func() {
+		It("should emit LINK_TYPE_Pn without requiring a full query for each port slot", func() {
 			mockConfigurationUtils.On("GetPCILinkSpeed", mock.Anything).Return(16, nil)
 
 			device := &v1alpha1.NicDevice{
@@ -522,19 +491,12 @@ var _ = Describe("ConfigValidationImpl", func() {
 				},
 			}
 
-			query := types.NewNvConfigQuery()
-			// Firmware exposes only P1 and P3, not P2 or P4.
-			query.DefaultConfig = map[string][]string{
-				"LINK_TYPE_P1": {"2"},
-				"LINK_TYPE_P3": {"2"},
-			}
-
-			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, query)
+			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, true)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nvParams).To(HaveKeyWithValue("LINK_TYPE_P1", consts.NvParamLinkTypeEthernet))
+			Expect(nvParams).To(HaveKeyWithValue("LINK_TYPE_P2", consts.NvParamLinkTypeEthernet))
 			Expect(nvParams).To(HaveKeyWithValue("LINK_TYPE_P3", consts.NvParamLinkTypeEthernet))
-			Expect(nvParams).NotTo(HaveKey("LINK_TYPE_P2"))
-			Expect(nvParams).NotTo(HaveKey("LINK_TYPE_P4"))
+			Expect(nvParams).To(HaveKeyWithValue("LINK_TYPE_P4", consts.NvParamLinkTypeEthernet))
 		})
 		It("should report an error when LinkType cannot be changed and template differs from the actual status", func() {
 			mockConfigurationUtils.On("GetLinkType", mock.Anything).Return(consts.Ethernet)
@@ -566,9 +528,7 @@ var _ = Describe("ConfigValidationImpl", func() {
 				},
 			}
 
-			query := types.NewNvConfigQuery()
-
-			_, err := validator.ConstructNvParamMapFromTemplate(device, query)
+			_, err := validator.ConstructNvParamMapFromTemplate(device, false)
 			Expect(err).To(MatchError("incorrect spec: device does not support link type change, wrong link type provided in the template, should be: Ethernet"))
 		})
 		It("should not report an error when LinkType can be changed and template differs from the actual status", func() {
@@ -601,13 +561,7 @@ var _ = Describe("ConfigValidationImpl", func() {
 				},
 			}
 
-			defaultValues := map[string][]string{
-				consts.LinkTypeP1Param: {consts.Ethernet},
-			}
-			query := types.NewNvConfigQuery()
-			query.DefaultConfig = defaultValues
-
-			_, err := validator.ConstructNvParamMapFromTemplate(device, query)
+			_, err := validator.ConstructNvParamMapFromTemplate(device, true)
 			Expect(err).NotTo(HaveOccurred())
 		})
 		It("should not report an error when LinkType cannot be changed and template matches the actual status", func() {
@@ -640,9 +594,7 @@ var _ = Describe("ConfigValidationImpl", func() {
 				},
 			}
 
-			query := types.NewNvConfigQuery()
-
-			_, err := validator.ConstructNvParamMapFromTemplate(device, query)
+			_, err := validator.ConstructNvParamMapFromTemplate(device, false)
 			Expect(err).NotTo(HaveOccurred())
 		})
 		It("should return an error when RoceOptimized is enabled with linkType Infiniband", func() {
@@ -667,13 +619,11 @@ var _ = Describe("ConfigValidationImpl", func() {
 				},
 			}
 
-			query := types.NewNvConfigQuery()
-
-			_, err := validator.ConstructNvParamMapFromTemplate(device, query)
+			_, err := validator.ConstructNvParamMapFromTemplate(device, true)
 			Expect(err).To(MatchError("incorrect spec: RoceOptimized settings can only be used with link type Ethernet"))
 		})
 
-		It("should take numeric values when both numeric values and string aliases are present in nv config query", func() {
+		It("should not emit deprecated MaxAccOutRead values", func() {
 			device := &v1alpha1.NicDevice{
 				Spec: v1alpha1.NicDeviceSpec{
 					Configuration: &v1alpha1.NicDeviceConfigurationSpec{
@@ -694,17 +644,11 @@ var _ = Describe("ConfigValidationImpl", func() {
 				},
 			}
 
-			defaultValues := map[string][]string{
-				consts.MaxAccOutReadParam: {"testMaxAccOutRead", "0"},
-			}
-			query := types.NewNvConfigQuery()
-			query.DefaultConfig = defaultValues
-
-			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, query)
+			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, true)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nvParams).To(HaveKeyWithValue(consts.SriovEnabledParam, consts.NvParamFalse))
 			Expect(nvParams).To(HaveKeyWithValue(consts.SriovNumOfVfsParam, "0"))
-			Expect(nvParams).To(HaveKeyWithValue(consts.MaxAccOutReadParam, "0"))
+			Expect(nvParams).NotTo(HaveKey(consts.MaxAccOutReadParam))
 		})
 	})
 
@@ -732,7 +676,7 @@ var _ = Describe("ConfigValidationImpl", func() {
 		It("returns an empty map when the template is nil", func() {
 			device := newDevice()
 			device.Spec.Configuration.Template = nil
-			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, types.NewNvConfigQuery())
+			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, true)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nvParams).To(BeEmpty())
 		})
@@ -743,7 +687,7 @@ var _ = Describe("ConfigValidationImpl", func() {
 			mockSpcXMgr.On("GetBreakoutMlxConfig", device).Return(map[string]string{"NUM_OF_PF": "2"}, nil)
 			mockSpcXMgr.On("GetPostBreakoutMlxConfig", device).Return(map[string]string{"LINK_TYPE_P1": "2"}, nil)
 
-			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, types.NewNvConfigQuery())
+			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, true)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nvParams).To(HaveKeyWithValue("NUM_OF_PF", "2"))
 			Expect(nvParams).To(HaveKeyWithValue("LINK_TYPE_P1", "2"))
@@ -756,7 +700,7 @@ var _ = Describe("ConfigValidationImpl", func() {
 			mockSpcXMgr.On("GetBreakoutMlxConfig", device).Return(map[string]string{"NUM_OF_PF": "2"}, nil)
 			mockSpcXMgr.On("GetPostBreakoutMlxConfig", device).Return(nil, nil)
 
-			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, types.NewNvConfigQuery())
+			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, true)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nvParams).To(HaveKeyWithValue("NUM_OF_PF", "8"))
 		})
@@ -766,7 +710,7 @@ var _ = Describe("ConfigValidationImpl", func() {
 			device.Spec.Configuration.Template.NumVfs = 4 // template sets SRIOV_EN=true, NUM_OF_VFS=4
 			device.Spec.Configuration.Template.RawNvConfig = []v1alpha1.NvConfigParam{{Name: consts.SriovNumOfVfsParam, Value: "16"}}
 
-			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, types.NewNvConfigQuery())
+			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, true)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nvParams).To(HaveKeyWithValue(consts.SriovNumOfVfsParam, "16"))
 		})
@@ -780,7 +724,7 @@ var _ = Describe("ConfigValidationImpl", func() {
 			mockSpcXMgr.On("GetBreakoutMlxConfig", device).Return(map[string]string{"MODULE_SPLIT_M0[2]": "1", "MODULE_SPLIT_M0[3]": "1"}, nil)
 			mockSpcXMgr.On("GetPostBreakoutMlxConfig", device).Return(nil, nil)
 
-			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, types.NewNvConfigQuery())
+			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, true)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nvParams).To(HaveKeyWithValue("MODULE_SPLIT_M0[2]", "5"))
 			Expect(nvParams).To(HaveKeyWithValue("MODULE_SPLIT_M0[3]", "1"))
@@ -792,7 +736,7 @@ var _ = Describe("ConfigValidationImpl", func() {
 				{Name: "SOME_PARAM_P1", Value: "1"},
 				{Name: "SOME_PARAM_P2", Value: "1"},
 			}
-			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, types.NewNvConfigQuery())
+			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, true)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nvParams).To(HaveKey("SOME_PARAM_P1"))
 			Expect(nvParams).ToNot(HaveKey("SOME_PARAM_P2"))
@@ -803,7 +747,7 @@ var _ = Describe("ConfigValidationImpl", func() {
 			device.Spec.Configuration.Template.SpectrumXOptimized = &v1alpha1.SpectrumXOptimizedSpec{Enabled: true}
 			mockSpcXMgr.On("GetBreakoutMlxConfig", device).Return(nil, errors.New("config not found"))
 
-			_, err := validator.ConstructNvParamMapFromTemplate(device, types.NewNvConfigQuery())
+			_, err := validator.ConstructNvParamMapFromTemplate(device, true)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("config not found"))
 		})

--- a/pkg/configuration/manager.go
+++ b/pkg/configuration/manager.go
@@ -113,7 +113,8 @@ func (h configurationManager) ValidateDeviceNvSpec(ctx context.Context, device *
 	// 4. Combined override config (Spectrum-X breakout + postBreakout + template + rawNvConfig, raw wins).
 	//    Validated against the device's next boot, exactly like the apply path — so a value already staged
 	//    for next boot but not yet rebooted reports reboot-required instead of looping.
-	overrides, err := h.configValidation.ConstructNvParamMapFromTemplate(device, firstPortConfig)
+	linkTypeChangeSupported := firstPortConfig.DefaultConfig[consts.LinkTypeP1Param] != nil
+	overrides, err := h.configValidation.ConstructNvParamMapFromTemplate(device, linkTypeChangeSupported)
 	if err != nil {
 		log.Log.Error(err, "failed to calculate desired nvconfig parameters", "device", device.Name)
 		return false, false, nil, err
@@ -190,24 +191,35 @@ func validateTemplateParamsApplied(nvConfigsForPorts map[string]types.NvConfigQu
 // returns *ConfigurationApplyResult - result of the apply operation
 // returns error - there were errors while applying nv configuration
 func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *v1alpha1.NicDevice, options *types.ConfigurationOptions) (*types.ConfigurationApplyResult, error) {
-	log.Log.Info("configurationManager.ApplyNVConfiguration", "device", device.Name)
+	log.Log.Info("configurationManager.ApplyNVConfiguration",
+		"device", device.Name,
+		"ports", len(device.Status.Ports),
+		"withDefault", options.WithDefault,
+		"force", options.Force,
+		"skipReset", options.SkipReset)
 
 	if device.Spec.Configuration == nil {
+		log.Log.V(2).Info("nv config apply skipped: device has no configuration spec", "device", device.Name)
 		return &types.ConfigurationApplyResult{Status: types.ApplyStatusNothingToDo}, nil
 	}
 
-	// 1. Query current nv config for every port.
-	nvConfigsForPorts, err := h.queryNvConfigs(ctx, device)
-	if err != nil {
-		log.Log.Error(err, "failed to query nv configs", "device", device.Name)
-		return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
-	}
 	firstPortPCIAddr := device.Status.Ports[0].PCI
-	firstPortConfig := nvConfigsForPorts[firstPortPCIAddr]
 
-	// 2. Reset-to-default takes precedence: reset and finish.
+	// 1. Reset-to-default takes precedence: query only the first port, reset, and finish.
 	if device.Spec.Configuration.ResetToDefault {
+		log.Log.Info("nv config apply entering reset-to-default flow", "device", device.Name, "pci", firstPortPCIAddr)
+		firstPortConfig, err := h.nvConfigUtils.QueryNvConfig(ctx, firstPortPCIAddr, nil)
+		if err != nil {
+			log.Log.Error(err, "failed to query nv config for reset-to-default", "device", device.Name)
+			return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
+		}
 		return h.applyResetToDefault(device, firstPortPCIAddr, firstPortConfig)
+	}
+
+	// 2. Query only LINK_TYPE_P1 to decide whether link type changes are supported on this device.
+	linkTypeChangeSupported, err := h.linkTypeChangeSupported(ctx, device)
+	if err != nil {
+		return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
 	}
 
 	// 3. Network Bay system_conf: the params that don't match the requested named profile.
@@ -217,12 +229,19 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 	}
 
 	// 4. Combined desired params: Spectrum-X breakout + postBreakout + template + rawNvConfig (raw wins).
-	desiredParams, err := h.configValidation.ConstructNvParamMapFromTemplate(device, firstPortConfig)
+	desiredParams, err := h.configValidation.ConstructNvParamMapFromTemplate(device, linkTypeChangeSupported)
 	if err != nil {
 		log.Log.Error(err, "failed to calculate desired nvconfig parameters", "device", device.Name)
 		return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
 	}
-	log.Log.V(2).Info("combined desired nv config built", "device", device.Name, "params", desiredParams, "force", options.Force)
+	log.Log.Info("combined desired nv config built",
+		"device", device.Name,
+		"paramCount", len(desiredParams),
+		"force", options.Force,
+		"withDefault", options.WithDefault)
+	log.Log.V(2).Info("combined desired nv config details",
+		"device", device.Name,
+		"params", desiredParams)
 
 	// 5. set_system_conf baseline: if the combined params do not cover all mismatched profile params
 	//    (range-aware), the baseline itself drifted on an uncovered param — re-stage set_system_conf
@@ -235,15 +254,6 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 			return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
 		}
 		systemConfApplied = true
-
-		// set_system_conf restages the whole profile, so the pre-call query is now stale. Re-query so the
-		// override batch below diffs against the restaged next-boot config and does not skip an override
-		// the baseline just overwrote.
-		nvConfigsForPorts, err = h.queryNvConfigs(ctx, device)
-		if err != nil {
-			log.Log.Error(err, "failed to re-query nv configs after set_system_conf", "device", device.Name)
-			return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
-		}
 	}
 
 	anyParamsApplied := false
@@ -255,39 +265,74 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 	//   - force=false: apply only the params visible on this PF whose value differs; params not yet
 	//     visible are skipped this round and picked up after a reboot exposes them (which sequences
 	//     breakout before postBreakout without --force).
-	for pciAddr, nvConfig := range nvConfigsForPorts {
+	for _, port := range device.Status.Ports {
+		pciAddr := port.PCI
 		batch := map[string]string{}
 		if options.Force {
+			log.Log.V(2).Info("force enabled: applying desired nv config without querying port",
+				"device", device.Name,
+				"pci", pciAddr,
+				"paramCount", len(desiredParams))
 			// Copy rather than alias desiredParams: it is reused across PF iterations, and the
 			// SetNvConfigParametersBatch contract does not forbid mutating its params argument.
 			for param, value := range desiredParams {
 				batch[param] = value
 			}
-		} else {
+		} else if len(desiredParams) > 0 {
+			log.Log.V(2).Info("querying nv config before diffing desired params",
+				"device", device.Name,
+				"pci", pciAddr,
+				"withDefault", options.WithDefault)
+			nvConfig, err := h.nvConfigUtils.QueryNvConfig(ctx, pciAddr, nil)
+			if err != nil {
+				log.Log.Error(err, "failed to query nv configs", "device", device.Name, "pci", pciAddr)
+				return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
+			}
+			unsupportedForPort := []string{}
 			for param, value := range desiredParams {
 				nextValues, found := nvConfig.NextBootConfig[param]
 				if !found {
 					hasUnsupportedParams = true
+					unsupportedForPort = append(unsupportedForPort, param)
 					continue
 				}
-				if !slices.Contains(nextValues, value) {
+				// WithDefault still requires the param to exist in the query, but applies it even
+				// when next-boot already contains the desired value.
+				if options.WithDefault || !slices.Contains(nextValues, value) {
 					batch[param] = value
 				}
 			}
+			if len(unsupportedForPort) > 0 {
+				sort.Strings(unsupportedForPort)
+				log.Log.Info("some desired nv config params are not present in query output and will be skipped",
+					"device", device.Name,
+					"pci", pciAddr,
+					"params", unsupportedForPort)
+			}
 		}
 		if len(batch) == 0 {
+			log.Log.V(2).Info("no nv config params need applying for port", "device", device.Name, "pci", pciAddr)
 			continue
 		}
-		log.Log.V(2).Info("applying nv config to device", "device", device.Name, "pci", pciAddr, "config", batch, "force", options.Force)
-		if err := h.nvConfigUtils.SetNvConfigParametersBatch(pciAddr, batch, options.WithDefault, options.Force); err != nil {
+		log.Log.Info("applying nv config batch",
+			"device", device.Name,
+			"pci", pciAddr,
+			"paramCount", len(batch),
+			"withDefault", options.WithDefault,
+			"force", options.Force)
+		log.Log.V(2).Info("applying nv config batch details", "device", device.Name, "pci", pciAddr, "config", batch)
+		applyStatus, err := h.nvConfigUtils.SetNvConfigParametersBatch(pciAddr, batch, options.WithDefault, options.Force)
+		if err != nil {
 			log.Log.Error(err, "Failed to apply nv config parameters", "device", device.Name, "params", batch)
 			return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
 		}
-		anyParamsApplied = true
+		if applyStatus == types.ApplyStatusSuccess {
+			anyParamsApplied = true
+		}
 	}
 
 	if !anyParamsApplied && !hasUnsupportedParams && !systemConfApplied {
-		log.Log.V(2).Info("nv config already up to date, nothing to apply", "device", device.Name)
+		log.Log.Info("nv config already up to date, nothing to apply", "device", device.Name)
 		return &types.ConfigurationApplyResult{Status: types.ApplyStatusNothingToDo}, nil
 	}
 
@@ -296,9 +341,42 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 		status = types.ApplyStatusPartiallyApplied
 	}
 	rebootRequired := anyParamsApplied || systemConfApplied
-	log.Log.Info("nv config applied", "device", device.Name, "status", status, "rebootRequired", rebootRequired)
+	log.Log.Info("nv config apply finished",
+		"device", device.Name,
+		"status", status,
+		"rebootRequired", rebootRequired,
+		"anyParamsApplied", anyParamsApplied,
+		"systemConfApplied", systemConfApplied,
+		"hasUnsupportedParams", hasUnsupportedParams)
 
 	return &types.ConfigurationApplyResult{Status: status, RebootRequired: rebootRequired}, nil
+}
+
+func (h configurationManager) linkTypeChangeSupported(ctx context.Context, device *v1alpha1.NicDevice) (bool, error) {
+	template := device.Spec.Configuration.Template
+	if template == nil || template.LinkType == "" {
+		return false, nil
+	}
+
+	_, err := h.nvConfigUtils.QueryNvConfig(ctx, device.Status.Ports[0].PCI, []string{consts.LinkTypeP1Param})
+	if err == nil {
+		return true, nil
+	}
+	if isUnsupportedLinkTypeParamError(err) {
+		log.Log.Info("device does not support link type change", "device", device.Name, "param", consts.LinkTypeP1Param)
+		return false, nil
+	}
+	log.Log.Error(err, "failed to query link type support", "device", device.Name, "param", consts.LinkTypeP1Param)
+	return false, err
+}
+
+func isUnsupportedLinkTypeParamError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errText := strings.ToLower(err.Error())
+	return strings.Contains(errText, strings.ToLower(consts.LinkTypeP1Param)) &&
+		(strings.Contains(errText, "doesn't support") || strings.Contains(errText, "does not support"))
 }
 
 // setSystemConf stages the requested Network Bay set_system_conf for the device's ASIC (the
@@ -582,6 +660,13 @@ func (h configurationManager) systemConfMismatchedParams(ctx context.Context, de
 	if !matches && len(mismatched) == 0 {
 		return nil, fmt.Errorf("device %s system_conf %q reports a mismatch but no mismatched params were parsed", device.Name, conf)
 	}
+
+	if len(mismatched) > 0 {
+		log.Log.V(2).Info("Network Bay system_conf mismatches found",
+			"device", device.Name,
+			"params", mismatched)
+	}
+
 	return mismatched, nil
 }
 
@@ -598,19 +683,14 @@ func (h configurationManager) queryNvConfigs(ctx context.Context, device *v1alph
 	return nvConfigs, nil
 }
 
-// getRawNvConfigParams extracts rawNvConfig params from the device template,
-// dropping _Pn params whose port index is beyond the device's port count.
+// getRawNvConfigParams extracts rawNvConfig params from the device template.
 func getRawNvConfigParams(device *v1alpha1.NicDevice) map[string]string {
 	template := device.Spec.Configuration.Template
 	if template == nil || len(template.RawNvConfig) == 0 {
 		return nil
 	}
-	portCount := len(device.Status.Ports)
 	params := make(map[string]string, len(template.RawNvConfig))
 	for _, rawParam := range template.RawNvConfig {
-		if n, ok := consts.PortSuffixNum(rawParam.Name); ok && n > portCount {
-			continue
-		}
 		params[rawParam.Name] = rawParam.Value
 	}
 	if len(params) == 0 {

--- a/pkg/configuration/manager_test.go
+++ b/pkg/configuration/manager_test.go
@@ -159,7 +159,7 @@ var _ = Describe("ConfigurationManager", func() {
 
 					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
 						Return(nvConfig, nil)
-					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 						Return(nil, constructErr)
 
 					configUpdate, reboot, _, err := manager.ValidateDeviceNvSpec(ctx, device)
@@ -184,7 +184,7 @@ var _ = Describe("ConfigurationManager", func() {
 
 					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
 						Return(nvConfig, nil)
-					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 						Return(desiredConfig, nil)
 
 					configUpdate, reboot, _, err := manager.ValidateDeviceNvSpec(ctx, device)
@@ -209,7 +209,7 @@ var _ = Describe("ConfigurationManager", func() {
 
 					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
 						Return(nvConfig, nil)
-					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 						Return(desiredConfig, nil)
 
 					configUpdate, reboot, _, err := manager.ValidateDeviceNvSpec(ctx, device)
@@ -234,7 +234,7 @@ var _ = Describe("ConfigurationManager", func() {
 
 					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
 						Return(nvConfig, nil)
-					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 						Return(desiredConfig, nil)
 
 					configUpdate, reboot, _, err := manager.ValidateDeviceNvSpec(ctx, device)
@@ -258,7 +258,7 @@ var _ = Describe("ConfigurationManager", func() {
 
 					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
 						Return(nvConfig, nil)
-					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 						Return(desiredConfig, nil)
 
 					configUpdate, reboot, _, err := manager.ValidateDeviceNvSpec(ctx, device)
@@ -283,7 +283,7 @@ var _ = Describe("ConfigurationManager", func() {
 
 					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
 						Return(nvConfig, nil)
-					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 						Return(desiredConfig, nil)
 
 					configUpdate, reboot, unsupported, err := manager.ValidateDeviceNvSpec(ctx, device)
@@ -307,7 +307,7 @@ var _ = Describe("ConfigurationManager", func() {
 
 					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
 						Return(nvConfig, nil)
-					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 						Return(desiredConfig, nil)
 
 					configUpdate, reboot, unsupported, err := manager.ValidateDeviceNvSpec(ctx, device)
@@ -332,7 +332,7 @@ var _ = Describe("ConfigurationManager", func() {
 
 					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
 						Return(nvConfig, nil)
-					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 						Return(desiredConfig, nil)
 
 					configUpdate, reboot, _, err := manager.ValidateDeviceNvSpec(ctx, device)
@@ -353,7 +353,7 @@ var _ = Describe("ConfigurationManager", func() {
 
 					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
 						Return(nvConfig, nil)
-					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 						Return(desiredConfig, nil)
 
 					configUpdate, reboot, _, err := manager.ValidateDeviceNvSpec(ctx, device)
@@ -374,7 +374,7 @@ var _ = Describe("ConfigurationManager", func() {
 
 					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
 						Return(nvConfig, nil)
-					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 						Return(desiredConfig, nil)
 
 					configUpdate, reboot, _, err := manager.ValidateDeviceNvSpec(ctx, device)
@@ -407,7 +407,7 @@ var _ = Describe("ConfigurationManager", func() {
 
 					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig0, nil)
 					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress2, []string(nil)).Return(nvConfig1, nil)
-					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig0).Return(map[string]string{"TRACER_ENABLED": "1"}, nil)
+					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).Return(map[string]string{"TRACER_ENABLED": "1"}, nil)
 
 					configUpdate, reboot, _, err := manager.ValidateDeviceNvSpec(ctx, device)
 					Expect(err).To(BeNil())
@@ -434,7 +434,7 @@ var _ = Describe("ConfigurationManager", func() {
 
 					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig0, nil)
 					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress2, []string(nil)).Return(nvConfig1, nil)
-					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig0).Return(map[string]string{"TRACER_ENABLED": "1"}, nil)
+					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).Return(map[string]string{"TRACER_ENABLED": "1"}, nil)
 
 					configUpdate, reboot, _, err := manager.ValidateDeviceNvSpec(ctx, device)
 					Expect(err).To(BeNil())
@@ -461,7 +461,7 @@ var _ = Describe("ConfigurationManager", func() {
 
 					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig0, nil)
 					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress2, []string(nil)).Return(nvConfig1, nil)
-					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig0).Return(map[string]string{"TRACER_ENABLED": "1"}, nil)
+					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).Return(map[string]string{"TRACER_ENABLED": "1"}, nil)
 
 					configUpdate, reboot, _, err := manager.ValidateDeviceNvSpec(ctx, device)
 					Expect(err).To(BeNil())
@@ -605,6 +605,8 @@ var _ = Describe("ConfigurationManager", func() {
 				Context("when QueryNvConfig returns an error", func() {
 					It("should return false and the error", func() {
 						queryErr := errors.New("failed to query nv config")
+						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
+							Return(map[string]string{"param1": "value1"}, nil)
 						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(types.NewNvConfigQuery(), queryErr)
 
 						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
@@ -616,6 +618,53 @@ var _ = Describe("ConfigurationManager", func() {
 				})
 
 				Context("when applying the desired template config", func() {
+					It("passes linkTypeChangeSupported=true after LINK_TYPE_P1 targeted query succeeds", func() {
+						device.Spec.Configuration.Template.LinkType = consts.Ethernet
+						mockNV.On("QueryNvConfig", ctx, pciAddress, []string{consts.LinkTypeP1Param}).
+							Return(types.NvConfigQuery{}, nil)
+						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, true).
+							Return(map[string]string{}, nil)
+
+						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
+						Expect(err).NotTo(HaveOccurred())
+						Expect(result.Status).To(Equal(types.ApplyStatusNothingToDo))
+					})
+
+					It("passes linkTypeChangeSupported=false when LINK_TYPE_P1 targeted query is unsupported", func() {
+						device.Spec.Configuration.Template.LinkType = consts.Ethernet
+						unsupportedErr := errors.New("exit status 3: -E- The Device doesn't support LINK_TYPE_P1 parameter")
+						mockNV.On("QueryNvConfig", ctx, pciAddress, []string{consts.LinkTypeP1Param}).
+							Return(types.NvConfigQuery{}, unsupportedErr)
+						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, false).
+							Return(map[string]string{}, nil)
+
+						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
+						Expect(err).NotTo(HaveOccurred())
+						Expect(result.Status).To(Equal(types.ApplyStatusNothingToDo))
+					})
+
+					It("returns an error when LINK_TYPE_P1 targeted query exits with status 3 without unsupported output", func() {
+						device.Spec.Configuration.Template.LinkType = consts.Ethernet
+						queryErr := errors.New("exit status 3")
+						mockNV.On("QueryNvConfig", ctx, pciAddress, []string{consts.LinkTypeP1Param}).
+							Return(types.NvConfigQuery{}, queryErr)
+
+						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
+						Expect(err).To(MatchError(queryErr))
+						Expect(result.Status).To(Equal(types.ApplyStatusFailed))
+					})
+
+					It("returns an error when LINK_TYPE_P1 targeted query fails for another reason", func() {
+						device.Spec.Configuration.Template.LinkType = consts.Ethernet
+						queryErr := errors.New("failed to run mlxconfig")
+						mockNV.On("QueryNvConfig", ctx, pciAddress, []string{consts.LinkTypeP1Param}).
+							Return(types.NvConfigQuery{}, queryErr)
+
+						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
+						Expect(err).To(MatchError(queryErr))
+						Expect(result.Status).To(Equal(types.ApplyStatusFailed))
+					})
+
 					It("should construct desiredConfig and apply no changes if desiredConfig matches NextBootConfig", func() {
 						nvConfig := types.NvConfigQuery{
 							CurrentConfig:  map[string][]string{"param1": {"value1"}},
@@ -626,7 +675,7 @@ var _ = Describe("ConfigurationManager", func() {
 
 						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
 							Return(nvConfig, nil)
-						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 							Return(desiredConfig, nil)
 
 						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
@@ -647,10 +696,10 @@ var _ = Describe("ConfigurationManager", func() {
 
 						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
 							Return(nvConfig, nil)
-						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 							Return(desiredConfig, nil)
 						mockNV.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"param1": "value2"}, false, false).
-							Return(nil)
+							Return(types.ApplyStatusSuccess, nil)
 
 						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 						Expect(result.RebootRequired).To(BeTrue())
@@ -661,23 +710,15 @@ var _ = Describe("ConfigurationManager", func() {
 					})
 
 					It("should return error if ConstructNvParamMapFromTemplate fails", func() {
-						nvConfig := types.NvConfigQuery{
-							CurrentConfig:  map[string][]string{"param1": {"value1"}},
-							NextBootConfig: map[string][]string{"param1": {"value1"}},
-							DefaultConfig:  map[string][]string{"param1": {"default1"}},
-						}
 						constructErr := errors.New("failed to construct desired config")
 
-						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
-							Return(nvConfig, nil)
-						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 							Return(nil, constructErr)
 
 						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 						Expect(result.RebootRequired).To(BeFalse())
 						Expect(err).To(MatchError(constructErr))
 
-						mockNV.AssertExpectations(GinkgoT())
 						mockConfigValidation.AssertExpectations(GinkgoT())
 					})
 
@@ -691,7 +732,7 @@ var _ = Describe("ConfigurationManager", func() {
 
 						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
 							Return(nvConfig, nil)
-						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 							Return(desiredConfig, nil)
 
 						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
@@ -713,11 +754,11 @@ var _ = Describe("ConfigurationManager", func() {
 
 						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
 							Return(nvConfig, nil)
-						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 							Return(desiredConfig, nil)
 						setParamErr := errors.New("failed to set param1")
 						mockNV.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"param1": "value3"}, false, false).
-							Return(setParamErr)
+							Return(types.ApplyStatusFailed, setParamErr)
 
 						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 						Expect(result.RebootRequired).To(BeFalse())
@@ -746,9 +787,9 @@ var _ = Describe("ConfigurationManager", func() {
 
 						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig0, nil)
 						mockNV.On("QueryNvConfig", ctx, pciAddress2, []string(nil)).Return(nvConfig1, nil)
-						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig0).Return(map[string]string{"TRACER_ENABLED": "1"}, nil)
+						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).Return(map[string]string{"TRACER_ENABLED": "1"}, nil)
 						// Only port2 should be updated
-						mockNV.On("SetNvConfigParametersBatch", pciAddress2, map[string]string{"TRACER_ENABLED": "1"}, false, false).Return(nil)
+						mockNV.On("SetNvConfigParametersBatch", pciAddress2, map[string]string{"TRACER_ENABLED": "1"}, false, false).Return(types.ApplyStatusSuccess, nil)
 
 						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 						Expect(err).To(BeNil())
@@ -774,7 +815,7 @@ var _ = Describe("ConfigurationManager", func() {
 
 						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig0, nil)
 						mockNV.On("QueryNvConfig", ctx, pciAddress2, []string(nil)).Return(nvConfig1, nil)
-						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig0).Return(map[string]string{"TRACER_ENABLED": "1"}, nil)
+						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).Return(map[string]string{"TRACER_ENABLED": "1"}, nil)
 
 						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 						Expect(result.RebootRequired).To(BeFalse())
@@ -798,10 +839,10 @@ var _ = Describe("ConfigurationManager", func() {
 
 					mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
 						Return(nvConfig, nil)
-					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 						Return(desiredConfig, nil)
 					mockNV.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"param1": "newValue3", "param2": "newValue3"}, false, false).
-						Return(nil)
+						Return(types.ApplyStatusSuccess, nil)
 
 					result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 					Expect(result.RebootRequired).To(BeTrue())
@@ -823,7 +864,7 @@ var _ = Describe("ConfigurationManager", func() {
 
 					mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
 						Return(nvConfig, nil)
-					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 						Return(desiredConfig, nil)
 
 					result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
@@ -1367,7 +1408,7 @@ var _ = Describe("ConfigurationManager", func() {
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(map[string]string{"NUM_OF_PF": "2", "LINK_TYPE_P1": "2"}, nil)
 				// NUM_OF_PF differs (1 != 2) and is applied; LINK_TYPE_P1 already matches and is skipped.
-				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"NUM_OF_PF": "2"}, false, false).Return(nil)
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"NUM_OF_PF": "2"}, false, false).Return(types.ApplyStatusSuccess, nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 				Expect(err).NotTo(HaveOccurred())
@@ -1375,11 +1416,10 @@ var _ = Describe("ConfigurationManager", func() {
 			})
 
 			It("force=true applies all combined params in a single --force batch", func() {
-				mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(types.NvConfigQuery{}, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(map[string]string{"NUM_OF_PF": "2", "LINK_TYPE_P1": "2"}, nil)
 				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress,
-					map[string]string{"NUM_OF_PF": "2", "LINK_TYPE_P1": "2"}, false, true).Return(nil)
+					map[string]string{"NUM_OF_PF": "2", "LINK_TYPE_P1": "2"}, false, true).Return(types.ApplyStatusSuccess, nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{Force: true})
 				Expect(err).NotTo(HaveOccurred())
@@ -1388,12 +1428,10 @@ var _ = Describe("ConfigurationManager", func() {
 
 			It("force=true applies the batch to every PF, not just the first", func() {
 				device.Status.Ports = []v1alpha1.NicDevicePortSpec{{PCI: pciAddress}, {PCI: pciAddress2}}
-				mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(types.NvConfigQuery{}, nil)
-				mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress2, []string(nil)).Return(types.NvConfigQuery{}, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(map[string]string{"NUM_OF_PF": "2"}, nil)
-				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"NUM_OF_PF": "2"}, false, true).Return(nil)
-				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress2, map[string]string{"NUM_OF_PF": "2"}, false, true).Return(nil)
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"NUM_OF_PF": "2"}, false, true).Return(types.ApplyStatusSuccess, nil)
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress2, map[string]string{"NUM_OF_PF": "2"}, false, true).Return(types.ApplyStatusSuccess, nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{Force: true})
 				Expect(err).NotTo(HaveOccurred())
@@ -1401,16 +1439,31 @@ var _ = Describe("ConfigurationManager", func() {
 				mockNVConfigUtils.AssertCalled(GinkgoT(), "SetNvConfigParametersBatch", pciAddress2, map[string]string{"NUM_OF_PF": "2"}, false, true)
 			})
 
-			It("propagates WithDefault=true to the combined batch", func() {
+			It("propagates WithDefault=true without applying params absent from the query", func() {
 				mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(
-					types.NvConfigQuery{NextBootConfig: map[string][]string{"NUM_OF_PF": {"1"}}}, nil)
+					types.NvConfigQuery{NextBootConfig: map[string][]string{"NUM_OF_PF": {"2"}}}, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
-					Return(map[string]string{"NUM_OF_PF": "2"}, nil)
-				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"NUM_OF_PF": "2"}, true, false).Return(nil)
+					Return(map[string]string{"NUM_OF_PF": "2", "UNSUPPORTED_PARAM": "1"}, nil)
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"NUM_OF_PF": "2"}, true, false).Return(types.ApplyStatusSuccess, nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{WithDefault: true})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.RebootRequired).To(BeTrue())
+				Expect(result.Status).To(Equal(types.ApplyStatusPartiallyApplied))
+			})
+
+			It("returns NothingToDo when WithDefault=true but mlxconfig reports no changed params", func() {
+				mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(
+					types.NvConfigQuery{NextBootConfig: map[string][]string{"NUM_OF_PF": {"2"}}}, nil)
+				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
+					Return(map[string]string{"NUM_OF_PF": "2"}, nil)
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"NUM_OF_PF": "2"}, true, false).
+					Return(types.ApplyStatusNothingToDo, nil)
+
+				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{WithDefault: true})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Status).To(Equal(types.ApplyStatusNothingToDo))
+				Expect(result.RebootRequired).To(BeFalse())
 			})
 
 			It("returns NothingToDo when the combined params already match", func() {
@@ -1426,7 +1479,6 @@ var _ = Describe("ConfigurationManager", func() {
 			})
 
 			It("returns error when ConstructNvParamMapFromTemplate fails", func() {
-				mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(types.NvConfigQuery{}, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(nil, errors.New("config not found"))
 
@@ -1442,13 +1494,12 @@ var _ = Describe("ConfigurationManager", func() {
 				})
 
 				It("applies set_system_conf when the combined params do not cover a mismatch", func() {
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(types.NvConfigQuery{}, nil)
 					mockNVConfigUtils.On("ValidateSystemConf", ctx, pciAddress, "conf3", 0).
 						Return(mismatchSystemConf("BOARD_CONFIGURATION_MODE")...)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 						Return(map[string]string{"NUM_OF_PF": "2"}, nil)
 					mockNVConfigUtils.On("SetSystemConf", ctx, pciAddress, "conf3", 0, true).Return(nil)
-					mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"NUM_OF_PF": "2"}, false, true).Return(nil)
+					mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"NUM_OF_PF": "2"}, false, true).Return(types.ApplyStatusSuccess, nil)
 
 					result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{Force: true})
 					Expect(err).NotTo(HaveOccurred())
@@ -1456,12 +1507,11 @@ var _ = Describe("ConfigurationManager", func() {
 				})
 
 				It("does not apply set_system_conf when the combined params cover all mismatches", func() {
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(types.NvConfigQuery{}, nil)
 					mockNVConfigUtils.On("ValidateSystemConf", ctx, pciAddress, "conf3", 0).
 						Return(mismatchSystemConf("NUM_OF_PF")...)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 						Return(map[string]string{"NUM_OF_PF": "2"}, nil)
-					mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"NUM_OF_PF": "2"}, false, true).Return(nil)
+					mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"NUM_OF_PF": "2"}, false, true).Return(types.ApplyStatusSuccess, nil)
 					mockNVConfigUtils.AssertNotCalled(GinkgoT(), "SetSystemConf", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 
 					result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{Force: true})
@@ -1522,7 +1572,7 @@ var _ = Describe("ConfigurationManager", func() {
 				mockNV.On("ValidateSystemConf", ctx, pciAddress, "conf3", 0).
 					Return(mismatchSystemConf("BOARD_CONFIGURATION_MODE")...)
 				mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig, nil)
-				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(map[string]string{}, nil)
 
 				configUpdate, reboot, _, err := manager.ValidateDeviceNvSpec(ctx, device)
@@ -1545,7 +1595,7 @@ var _ = Describe("ConfigurationManager", func() {
 				mockNV.On("ValidateSystemConf", ctx, pciAddress, "conf3", 0).
 					Return(okSystemConf()...)
 				mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig, nil)
-				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(map[string]string{}, nil)
 
 				configUpdate, reboot, _, err := manager.ValidateDeviceNvSpec(ctx, device)
@@ -1566,7 +1616,7 @@ var _ = Describe("ConfigurationManager", func() {
 				mockNV.On("ValidateSystemConf", ctx, pciAddress, "conf3", 0).
 					Return(mismatchSystemConf("NUM_OF_PF")...)
 				mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(portConfig, nil)
-				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, portConfig).
+				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(map[string]string{"NUM_OF_PF": "8"}, nil)
 
 				configUpdate, reboot, _, err := manager.ValidateDeviceNvSpec(ctx, device)
@@ -1595,10 +1645,9 @@ var _ = Describe("ConfigurationManager", func() {
 			// Apply checks system_conf coverage: it stages set_system_conf only when the combined override
 			// params do not cover every mismatched profile param.
 			It("stages set_system_conf when the combined params do not cover a mismatch", func() {
-				mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig, nil)
 				mockNV.On("ValidateSystemConf", ctx, pciAddress, "conf3", 0).
 					Return(mismatchSystemConf("BOARD_CONFIGURATION_MODE")...)
-				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(map[string]string{}, nil)
 				mockNV.On("SetSystemConf", ctx, pciAddress, "conf3", 0, false).Return(nil)
 
@@ -1609,10 +1658,9 @@ var _ = Describe("ConfigurationManager", func() {
 			})
 
 			It("passes --force to set_system_conf when Force is set", func() {
-				mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig, nil)
 				mockNV.On("ValidateSystemConf", ctx, pciAddress, "conf3", 0).
 					Return(mismatchSystemConf("BOARD_CONFIGURATION_MODE")...)
-				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
+				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(map[string]string{}, nil)
 				mockNV.On("SetSystemConf", ctx, pciAddress, "conf3", 0, true).Return(nil)
 
@@ -1630,12 +1678,12 @@ var _ = Describe("ConfigurationManager", func() {
 				mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(portConfig, nil)
 				mockNV.On("ValidateSystemConf", ctx, pciAddress, "conf3", 0).
 					Return(mismatchSystemConf("BOARD_CONFIGURATION_MODE")...)
-				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, portConfig).
+				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(map[string]string{"param1": "value2"}, nil)
 				setSystemConfCall := mockNV.On("SetSystemConf", ctx, pciAddress, "conf3", 0, false).Return(nil)
 				// set_system_conf is the baseline and must be staged before the override batch.
 				mockNV.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"param1": "value2"}, false, false).
-					Return(nil).NotBefore(setSystemConfCall)
+					Return(types.ApplyStatusSuccess, nil).NotBefore(setSystemConfCall)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 				Expect(err).NotTo(HaveOccurred())
@@ -1778,7 +1826,7 @@ var _ = Describe("ConfigurationManager", func() {
 					types.NvConfigQuery{NextBootConfig: staged, CurrentConfig: staged}, nil)
 				fullFlowNV.On("ValidateSystemConf", fullFlowCtx, pciAddress, "conf3", 0).
 					Return(mismatchSystemConf("NUM_OF_PF")...)
-				fullFlowNV.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"NUM_OF_PF": "8"}, false, false).Return(nil)
+				fullFlowNV.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"NUM_OF_PF": "8"}, false, false).Return(types.ApplyStatusSuccess, nil)
 
 				updateNeeded, rebootNeeded, _, err := fullFlowManager.ValidateDeviceNvSpec(fullFlowCtx, fullFlowDevice)
 				Expect(err).NotTo(HaveOccurred())
@@ -1832,7 +1880,7 @@ var _ = Describe("ConfigurationManager", func() {
 				fullFlowNV.On("ValidateSystemConf", fullFlowCtx, pciAddress, "conf3", 0).
 					Return(mismatchSystemConf("NUM_OF_PF", "LINK_TYPE_P1")...)
 				// Only LINK_TYPE_P1 differs from next boot; the raw value 2 wins over the Spectrum-X value 1.
-				fullFlowNV.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"LINK_TYPE_P1": "2"}, false, false).Return(nil)
+				fullFlowNV.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"LINK_TYPE_P1": "2"}, false, false).Return(types.ApplyStatusSuccess, nil)
 
 				updateNeeded, rebootNeeded, _, err := fullFlowManager.ValidateDeviceNvSpec(fullFlowCtx, fullFlowDevice)
 				Expect(err).NotTo(HaveOccurred())
@@ -1841,7 +1889,7 @@ var _ = Describe("ConfigurationManager", func() {
 
 				result, err := fullFlowManager.ApplyNVConfiguration(fullFlowCtx, fullFlowDevice, &types.ConfigurationOptions{})
 				Expect(err).NotTo(HaveOccurred())
-				Expect(result.Status).To(Equal(types.ApplyStatusSuccess))
+				Expect(result.Status).To(Equal(types.ApplyStatusPartiallyApplied))
 				Expect(result.RebootRequired).To(BeTrue())
 				fullFlowNV.AssertNotCalled(GinkgoT(), "SetSystemConf", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 			})
@@ -1870,7 +1918,7 @@ var _ = Describe("ConfigurationManager", func() {
 					Return(mismatchSystemConf("NUM_OF_PF", "LINK_TYPE_P1")...)
 				// Raw wins on both: LINK_TYPE_P1 over Spectrum-X (1→2) and NUM_OF_VFS over template (4→16).
 				fullFlowNV.On("SetNvConfigParametersBatch", pciAddress,
-					map[string]string{"LINK_TYPE_P1": "2", consts.SriovNumOfVfsParam: "16"}, false, false).Return(nil)
+					map[string]string{"LINK_TYPE_P1": "2", consts.SriovNumOfVfsParam: "16"}, false, false).Return(types.ApplyStatusSuccess, nil)
 
 				updateNeeded, rebootNeeded, _, err := fullFlowManager.ValidateDeviceNvSpec(fullFlowCtx, fullFlowDevice)
 				Expect(err).NotTo(HaveOccurred())
@@ -1879,7 +1927,7 @@ var _ = Describe("ConfigurationManager", func() {
 
 				result, err := fullFlowManager.ApplyNVConfiguration(fullFlowCtx, fullFlowDevice, &types.ConfigurationOptions{})
 				Expect(err).NotTo(HaveOccurred())
-				Expect(result.Status).To(Equal(types.ApplyStatusSuccess))
+				Expect(result.Status).To(Equal(types.ApplyStatusPartiallyApplied))
 				Expect(result.RebootRequired).To(BeTrue())
 				fullFlowNV.AssertNotCalled(GinkgoT(), "SetSystemConf", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 			})

--- a/pkg/configuration/mocks/ConfigValidation.go
+++ b/pkg/configuration/mocks/ConfigValidation.go
@@ -31,9 +31,9 @@ func (_m *ConfigValidation) CalculateDesiredRuntimeConfig(device *v1alpha1.NicDe
 	return r0
 }
 
-// ConstructNvParamMapFromTemplate provides a mock function with given fields: device, nvConfigQuery
-func (_m *ConfigValidation) ConstructNvParamMapFromTemplate(device *v1alpha1.NicDevice, nvConfigQuery types.NvConfigQuery) (map[string]string, error) {
-	ret := _m.Called(device, nvConfigQuery)
+// ConstructNvParamMapFromTemplate provides a mock function with given fields: device, linkTypeChangeSupported
+func (_m *ConfigValidation) ConstructNvParamMapFromTemplate(device *v1alpha1.NicDevice, linkTypeChangeSupported bool) (map[string]string, error) {
+	ret := _m.Called(device, linkTypeChangeSupported)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ConstructNvParamMapFromTemplate")
@@ -41,19 +41,19 @@ func (_m *ConfigValidation) ConstructNvParamMapFromTemplate(device *v1alpha1.Nic
 
 	var r0 map[string]string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*v1alpha1.NicDevice, types.NvConfigQuery) (map[string]string, error)); ok {
-		return rf(device, nvConfigQuery)
+	if rf, ok := ret.Get(0).(func(*v1alpha1.NicDevice, bool) (map[string]string, error)); ok {
+		return rf(device, linkTypeChangeSupported)
 	}
-	if rf, ok := ret.Get(0).(func(*v1alpha1.NicDevice, types.NvConfigQuery) map[string]string); ok {
-		r0 = rf(device, nvConfigQuery)
+	if rf, ok := ret.Get(0).(func(*v1alpha1.NicDevice, bool) map[string]string); ok {
+		r0 = rf(device, linkTypeChangeSupported)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string]string)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(*v1alpha1.NicDevice, types.NvConfigQuery) error); ok {
-		r1 = rf(device, nvConfigQuery)
+	if rf, ok := ret.Get(1).(func(*v1alpha1.NicDevice, bool) error); ok {
+		r1 = rf(device, linkTypeChangeSupported)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -91,6 +91,7 @@ const (
 
 	SriovEnabledParam        = "SRIOV_EN"
 	SriovNumOfVfsParam       = "NUM_OF_VFS"
+	NumOfPfParam             = "NUM_OF_PF"
 	LinkTypeP1Param          = "LINK_TYPE_P1"
 	LinkTypeP2Param          = "LINK_TYPE_P2"
 	MaxAccOutReadParam       = "MAX_ACC_OUT_READ"

--- a/pkg/nvconfig/mocks/NVConfigUtils.go
+++ b/pkg/nvconfig/mocks/NVConfigUtils.go
@@ -80,21 +80,31 @@ func (_m *NVConfigUtils) SetNvConfigParameter(pciAddr string, paramName string, 
 }
 
 // SetNvConfigParametersBatch provides a mock function with given fields: pciAddr, params, withDefault, force
-func (_m *NVConfigUtils) SetNvConfigParametersBatch(pciAddr string, params map[string]string, withDefault bool, force bool) error {
+func (_m *NVConfigUtils) SetNvConfigParametersBatch(pciAddr string, params map[string]string, withDefault bool, force bool) (types.ApplyStatus, error) {
 	ret := _m.Called(pciAddr, params, withDefault, force)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SetNvConfigParametersBatch")
 	}
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(string, map[string]string, bool, bool) error); ok {
+	var r0 types.ApplyStatus
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string, map[string]string, bool, bool) (types.ApplyStatus, error)); ok {
+		return rf(pciAddr, params, withDefault, force)
+	}
+	if rf, ok := ret.Get(0).(func(string, map[string]string, bool, bool) types.ApplyStatus); ok {
 		r0 = rf(pciAddr, params, withDefault, force)
 	} else {
-		r0 = ret.Error(0)
+		r0 = ret.Get(0).(types.ApplyStatus)
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(string, map[string]string, bool, bool) error); ok {
+		r1 = rf(pciAddr, params, withDefault, force)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // SetSystemConf provides a mock function with given fields: ctx, pciAddr, conf, asic, force

--- a/pkg/nvconfig/utils.go
+++ b/pkg/nvconfig/utils.go
@@ -56,7 +56,7 @@ type NVConfigUtils interface {
 	// SetNvConfigParametersBatch sets multiple nv config parameters for a mellanox device in a single mlxconfig call
 	// When force is true, --force is passed to mlxconfig so it accepts a batch it would otherwise refuse
 	// due to implicit parameter dependencies.
-	SetNvConfigParametersBatch(pciAddr string, params map[string]string, withDefault bool, force bool) error
+	SetNvConfigParametersBatch(pciAddr string, params map[string]string, withDefault bool, force bool) (types.ApplyStatus, error)
 	// ResetNvConfig resets NIC's nv config
 	ResetNvConfig(pciAddr string) error
 	// SetSystemConf applies a ConnectX-9 Network Bay system configuration for a single ASIC via
@@ -90,6 +90,9 @@ func (h *nvConfigUtils) queryMLXConfig(ctx context.Context, query types.NvConfig
 	output, err := utils.RunCommand(cmd)
 	if err != nil {
 		log.Log.Error(err, "queryMLXConfig(): Failed to run mlxconfig", "output", string(output))
+		if trimmedOutput := strings.TrimSpace(string(output)); trimmedOutput != "" {
+			return fmt.Errorf("%w: %s", err, trimmedOutput)
+		}
 		return err
 	}
 
@@ -197,12 +200,22 @@ func (h *nvConfigUtils) SetNvConfigParameter(pciAddr string, paramName string, p
 	return nil
 }
 
+func parseSetNvConfigParametersBatchStatus(output []byte, withDefault bool) types.ApplyStatus {
+	if strings.Contains(string(output), "Configurations:") {
+		return types.ApplyStatusSuccess
+	}
+	if withDefault {
+		return types.ApplyStatusNothingToDo
+	}
+	return types.ApplyStatusSuccess
+}
+
 // SetNvConfigParametersBatch sets multiple nv config parameters for a mellanox device in a single mlxconfig call
-func (h *nvConfigUtils) SetNvConfigParametersBatch(pciAddr string, params map[string]string, withDefault bool, force bool) error {
+func (h *nvConfigUtils) SetNvConfigParametersBatch(pciAddr string, params map[string]string, withDefault bool, force bool) (types.ApplyStatus, error) {
 	log.Log.Info("ConfigurationUtils.SetNvConfigParametersBatch()", "pciAddr", pciAddr, "params", params, "withDefault", withDefault, "force", force)
 
 	if len(params) == 0 {
-		return nil
+		return types.ApplyStatusNothingToDo, nil
 	}
 
 	// Build sorted param list for deterministic command
@@ -217,9 +230,11 @@ func (h *nvConfigUtils) SetNvConfigParametersBatch(pciAddr string, params map[st
 		paramArgs = append(paramArgs, name+"="+params[name])
 	}
 
-	args := []string{"-d", pciAddr, "--yes"}
+	args := []string{"-d", pciAddr}
 	if withDefault {
-		args = append(args, "--with_default")
+		args = append(args, "-e", "--with_default", "-y")
+	} else {
+		args = append(args, "--yes")
 	}
 	if force {
 		args = append(args, "--force")
@@ -231,9 +246,9 @@ func (h *nvConfigUtils) SetNvConfigParametersBatch(pciAddr string, params map[st
 	output, err := utils.RunCommand(cmd)
 	if err != nil {
 		log.Log.Error(err, "SetNvConfigParametersBatch(): Failed to run mlxconfig", "output", string(output))
-		return err
+		return types.ApplyStatusFailed, err
 	}
-	return nil
+	return parseSetNvConfigParametersBatchStatus(output, withDefault), nil
 }
 
 // systemConfToken builds the `<conf>[<asic>]` argument for set/validate_system_conf, e.g. conf3[0].

--- a/pkg/nvconfig/utils_test.go
+++ b/pkg/nvconfig/utils_test.go
@@ -21,6 +21,7 @@ import (
 	"regexp"
 
 	"github.com/Mellanox/nic-configuration-operator/pkg/consts"
+	"github.com/Mellanox/nic-configuration-operator/pkg/types"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/exec"
@@ -594,7 +595,9 @@ Result: Device configuration does NOT match the system configuration.
 					return cmd
 				},
 			}
-			Expect(h.SetNvConfigParametersBatch(pciAddress, map[string]string{"PARAM": "1"}, false, true)).To(Succeed())
+			status, err := h.SetNvConfigParametersBatch(pciAddress, map[string]string{"PARAM": "1"}, false, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).To(Equal(types.ApplyStatusSuccess))
 		})
 
 		It("omits --force when force is false", func() {
@@ -608,7 +611,62 @@ Result: Device configuration does NOT match the system configuration.
 					return cmd
 				},
 			}
-			Expect(h.SetNvConfigParametersBatch(pciAddress, map[string]string{"PARAM": "1"}, false, false)).To(Succeed())
+			status, err := h.SetNvConfigParametersBatch(pciAddress, map[string]string{"PARAM": "1"}, false, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).To(Equal(types.ApplyStatusSuccess))
+		})
+
+		It("passes -y with --with_default and returns nothing-to-do when output has no configurations section", func() {
+			output := `Param SAFE_MODE_ENABLE is not going to be set since value matches next value
+Param SAFE_MODE_THRESHOLD is not going to be set since value matches next value
+
+ Apply reset and set? (y/n) [n] : y
+Done!
+-I- Please reboot machine to load new configurations.
+`
+			cmd := &execTesting.FakeCmd{}
+			cmd.OutputScript = append(cmd.OutputScript, func() ([]byte, []byte, error) {
+				return []byte(output), nil, nil
+			})
+			fakeExec.CommandScript = []execTesting.FakeCommandAction{
+				func(name string, args ...string) exec.Cmd {
+					Expect(args).To(Equal([]string{"-d", pciAddress, "-e", "--with_default", "-y", "set", "SAFE_MODE_ENABLE=1", "SAFE_MODE_THRESHOLD=10"}))
+					return cmd
+				},
+			}
+			status, err := h.SetNvConfigParametersBatch(pciAddress, map[string]string{"SAFE_MODE_ENABLE": "1", "SAFE_MODE_THRESHOLD": "10"}, true, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).To(Equal(types.ApplyStatusNothingToDo))
+		})
+
+		It("returns success with --with_default when output has a configurations section", func() {
+			output := `Param SAFE_MODE_ENABLE is not going to be set since value matches next value
+Param SAFE_MODE_THRESHOLD is not going to be set since value matches next value
+
+ Apply reset and set? (y/n) [n] : y
+
+Device #1:
+----------
+
+Configurations:                                         Default                           Current                           Next Boot                         New
+*       SRIOV_EN                                        True(1)                           False(0)                          True(1)                           False(0)
+The '*' shows parameters with next value different from default/current value.
+Applying... Done!
+-I- Please reboot machine to load new configurations.
+`
+			cmd := &execTesting.FakeCmd{}
+			cmd.OutputScript = append(cmd.OutputScript, func() ([]byte, []byte, error) {
+				return []byte(output), nil, nil
+			})
+			fakeExec.CommandScript = []execTesting.FakeCommandAction{
+				func(name string, args ...string) exec.Cmd {
+					Expect(args).To(Equal([]string{"-d", pciAddress, "-e", "--with_default", "-y", "set", "SAFE_MODE_ENABLE=1", "SAFE_MODE_THRESHOLD=10", "SRIOV_EN=0"}))
+					return cmd
+				},
+			}
+			status, err := h.SetNvConfigParametersBatch(pciAddress, map[string]string{"SAFE_MODE_ENABLE": "1", "SAFE_MODE_THRESHOLD": "10", "SRIOV_EN": "0"}, true, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).To(Equal(types.ApplyStatusSuccess))
 		})
 	})
 })


### PR DESCRIPTION
## Summary
- Avoid the initial full `mlxconfig query` in `ApplyNVConfiguration`; use a targeted `LINK_TYPE_P1` capability query and a reset-only query path.
- Apply `set_system_conf` before per-port diffing, then query each port only when a non-force diff is needed.
- Extrapolate port-suffixed params from `NUM_OF_PF`, preserve `WithDefault` semantics for query-visible params only, and improve ApplyNVConfiguration info/debug logging.

## Validation
- `git diff --check upstream/main..deprecate-max-acc-out-read`
- `git diff --check deprecate-max-acc-out-read..optimize-apply-nv-config`
- `go test ./pkg/configuration/... ./pkg/nvconfig/... -v`