### PR TITLE
fix: handle with-default no-op apply status

### DIFF
--- a/docs/nic-configuration-library.md
+++ b/docs/nic-configuration-library.md
@@ -166,13 +166,13 @@ func NewConfigurationManager(
 1. **Query** current NV config via `nvConfigUtils.QueryNvConfig()`
 2. **Network Bay `set_system_conf` (baseline, applied first)** — for ConnectX-9 Network Bay devices (`template.networkBay` set and `status.networkBay` detected), the per-ASIC `set_system_conf <conf>[<asic>]` is applied **before** the regular / Spectrum-X params so those layer on top of it (override priority: `rawNvConfig` > Spectrum-X > system_conf). Drift is detected per-param via `nvconfig.ValidateSystemConf()`, which returns the overall match bit plus the names of the mismatched params; the manager ignores MISMATCH rows for params owned by a higher-priority layer (matched by exact per-index key — `rawNvConfig` index-range syntax like `MODULE_SPLIT_M0[0..3]` is rejected by CRD validation, so keys are always concrete); a change requires a reboot. Skipped for devices with `ResetToDefault`
 3. **Diff** desired vs current parameters. Params not present in the device's next-boot config are unsupported on this device (e.g. hidden because `ADVANCED_PCI_SETTINGS` is off) and are skipped — the operator does **not** auto-manage `ADVANCED_PCI_SETTINGS`; drive it explicitly via `template.rawNvConfig` if needed
-4. **Batch set** via `nvConfigUtils.SetNvConfigParametersBatch()` — single `mlxconfig set` call (`--force` added when `ConfigurationOptions.Force=true`). Apply reports `ApplyStatusPartiallyApplied` when any desired param was skipped as unsupported
+4. **Batch set** via `nvConfigUtils.SetNvConfigParametersBatch()` — single `mlxconfig set` call (`--force` added when `ConfigurationOptions.Force=true`). Apply reports `ApplyStatusPartiallyApplied` when any desired param was skipped as unsupported. With `ConfigurationOptions.WithDefault=true`, the batch setter parses `mlxconfig` output and returns `ApplyStatusNothingToDo` when the command succeeds but no params are changed.
 5. **Optional reset** — `mlxfwreset` unless `ConfigurationOptions.SkipReset=true`
 
 **`ConfigurationOptions`:**
 - `SkipReset` — skip `mlxfwreset` after applying NV config
 - `WithDefault` — add `--with_default` to `mlxconfig set`
-- `Force` — add `--force` to `mlxconfig set` and `set_system_conf` (lets mlxconfig accept a batch it would otherwise refuse due to implicit parameter dependencies)
+- `Force` — add `--force` to `mlxconfig set` and `set_system_conf` (lets mlxconfig accept a batch it would otherwise refuse due to implicit parameter dependencies). When `NUM_OF_PF` is present, force mode extrapolates `_P<n>` params up to the requested PF count before applying.
 
 #### Runtime Configuration Flow
 
@@ -360,7 +360,7 @@ type NVConfigUtils interface {
     // params: map of paramName → paramValue
     // withDefault: add --with_default flag
     // force: add --force flag
-    SetNvConfigParametersBatch(pciAddr string, params map[string]string, withDefault bool, force bool) error
+    SetNvConfigParametersBatch(pciAddr string, params map[string]string, withDefault bool, force bool) (types.ApplyStatus, error)
 
     // ResetNvConfig resets NIC's NV config to defaults
     ResetNvConfig(pciAddr string) error
@@ -383,7 +383,8 @@ func NewNVConfigUtils() NVConfigUtils
 
 **Batch command format:**
 ```
-mlxconfig -d <pci> --yes [--with_default] [--force] set PARAM1=VAL1 PARAM2=VAL2 ...
+mlxconfig -d <pci> --yes [--force] set PARAM1=VAL1 PARAM2=VAL2 ...
+mlxconfig -d <pci> -e --with_default -y [--force] set PARAM1=VAL1 PARAM2=VAL2 ...
 ```
 Parameter names are sorted for deterministic command generation.
 

--- a/docs/nic-configuration-library.md
+++ b/docs/nic-configuration-library.md
@@ -167,13 +167,13 @@ func NewConfigurationManager(
 2. **Query** current NV config via `nvConfigUtils.QueryNvConfig()`
 3. **Network Bay `set_system_conf` (baseline, applied first)** — for ConnectX-9 Network Bay devices (`template.networkBay` set and `status.networkBay` detected), the per-ASIC `set_system_conf <conf>[<asic>]` is applied **before** the regular / Spectrum-X params so those layer on top of it (override priority: `rawNvConfig` > Spectrum-X > system_conf). Drift is detected per-param via `nvconfig.ValidateSystemConf()`, which returns the overall match bit plus the names of the mismatched params; the manager ignores MISMATCH rows for params owned by a higher-priority layer (matched by exact per-index key — `rawNvConfig` index-range syntax like `MODULE_SPLIT_M0[0..3]` is rejected by CRD validation, so keys are always concrete); a change requires a reboot. Skipped for devices with `ResetToDefault`
 4. **Diff** desired vs current parameters. Params not present in the device's next-boot config are unsupported on this device (e.g. hidden because `ADVANCED_PCI_SETTINGS` is off) and are skipped — the operator does **not** auto-manage `ADVANCED_PCI_SETTINGS`; drive it explicitly via `template.rawNvConfig` if needed
-5. **Batch set** via `nvConfigUtils.SetNvConfigParametersBatch()` — one agentless `dms-cli` `/nvidia/nvconfig/apply` action per PCI target. The action carries the existing raw batch plus `with-default` and `force`; DMS compiles it into one `mlxconfig` invocation. Apply reports `ApplyStatusPartiallyApplied` when any desired param was skipped as unsupported
+5. **Batch set** via `nvConfigUtils.SetNvConfigParametersBatch()` — one agentless `dms-cli` `/nvidia/nvconfig/apply` action per PCI target. The action carries the existing raw batch plus `with-default` and `force`; DMS compiles it into one `mlxconfig` invocation. The DMS `requires-reset` result maps to `ApplyStatusSuccess` when true and `ApplyStatusNothingToDo` when false. Apply reports `ApplyStatusPartiallyApplied` when any desired param was skipped as unsupported
 6. **Optional reset** — `mlxfwreset` unless `ConfigurationOptions.SkipReset=true`
 
 **`ConfigurationOptions`:**
 - `SkipReset` — skip `mlxfwreset` after applying NV config
 - `WithDefault` — request `--with_default` through the DMS NVConfig apply action
-- `Force` — request `--force` through the DMS NVConfig apply action and add it to `set_system_conf` (lets mlxconfig accept a batch it would otherwise refuse due to implicit parameter dependencies)
+- `Force` — request `--force` through the DMS NVConfig apply action and add it to `set_system_conf` (lets mlxconfig accept a batch it would otherwise refuse due to implicit parameter dependencies). When `NUM_OF_PF` and a `_P1` value are present, force mode copies that value to missing higher ports up to the requested PF count before applying; explicit per-port values are preserved
 
 #### Runtime Configuration Flow
 
@@ -523,7 +523,7 @@ type NVConfigUtils interface {
     // params: map of paramName → paramValue
     // withDefault: request --with_default from DMS
     // force: request --force from DMS
-    SetNvConfigParametersBatch(port v1alpha1.NicDevicePortSpec, params map[string]string, withDefault bool, force bool) error
+    SetNvConfigParametersBatch(port v1alpha1.NicDevicePortSpec, params map[string]string, withDefault bool, force bool) (types.ApplyStatus, error)
 
     // ResetNvConfig resets NIC's NV config to defaults
     ResetNvConfig(port v1alpha1.NicDevicePortSpec) error

--- a/pkg/configuration/manager.go
+++ b/pkg/configuration/manager.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 
 	"k8s.io/client-go/tools/record"
@@ -222,6 +223,9 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 		log.Log.Error(err, "failed to calculate desired nvconfig parameters", "device", device.Name)
 		return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
 	}
+	if options.Force {
+		extrapolatePortParamsFromNumOfPF(desiredParams)
+	}
 	log.Log.V(2).Info("combined desired nv config built", "device", device.Name, "params", desiredParams, "force", options.Force)
 
 	// 5. set_system_conf baseline: if the combined params do not cover all mismatched profile params
@@ -270,7 +274,9 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 					hasUnsupportedParams = true
 					continue
 				}
-				if !slices.Contains(nextValues, value) {
+				// WithDefault still requires the param to exist in the query, but applies it even
+				// when next-boot already contains the desired value.
+				if options.WithDefault || !slices.Contains(nextValues, value) {
 					batch[param] = value
 				}
 			}
@@ -279,11 +285,14 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 			continue
 		}
 		log.Log.V(2).Info("applying nv config to device", "device", device.Name, "pci", pciAddr, "config", batch, "force", options.Force)
-		if err := h.nvConfigUtils.SetNvConfigParametersBatch(pciAddr, batch, options.WithDefault, options.Force); err != nil {
+		applyStatus, err := h.nvConfigUtils.SetNvConfigParametersBatch(pciAddr, batch, options.WithDefault, options.Force)
+		if err != nil {
 			log.Log.Error(err, "Failed to apply nv config parameters", "device", device.Name, "params", batch)
 			return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
 		}
-		anyParamsApplied = true
+		if applyStatus == types.ApplyStatusSuccess {
+			anyParamsApplied = true
+		}
 	}
 
 	if !anyParamsApplied && !hasUnsupportedParams && !systemConfApplied {
@@ -299,6 +308,42 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 	log.Log.Info("nv config applied", "device", device.Name, "status", status, "rebootRequired", rebootRequired)
 
 	return &types.ConfigurationApplyResult{Status: status, RebootRequired: rebootRequired}, nil
+}
+
+func extrapolatePortParamsFromNumOfPF(params map[string]string) {
+	value, ok := params[consts.NumOfPfParam]
+	if !ok {
+		return
+	}
+	portCount, err := strconv.Atoi(value)
+	if err != nil || portCount < 2 {
+		return
+	}
+
+	type portParamValue struct {
+		portNum int
+		value   string
+	}
+	baseValues := map[string]portParamValue{}
+	for param, value := range params {
+		portNum, ok := consts.PortSuffixNum(param)
+		if !ok || portNum < 1 {
+			continue
+		}
+		base := param[:len(param)-len(strconv.Itoa(portNum))-2]
+		current, exists := baseValues[base]
+		if !exists || portNum < current.portNum {
+			baseValues[base] = portParamValue{portNum: portNum, value: value}
+		}
+	}
+	for base, baseValue := range baseValues {
+		for portNum := 1; portNum <= portCount; portNum++ {
+			param := consts.PortParam(base, portNum)
+			if _, exists := params[param]; !exists {
+				params[param] = baseValue.value
+			}
+		}
+	}
 }
 
 // setSystemConf stages the requested Network Bay set_system_conf for the device's ASIC (the

--- a/pkg/configuration/manager.go
+++ b/pkg/configuration/manager.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 
 	"k8s.io/client-go/tools/record"
@@ -193,7 +194,7 @@ type nvConfigApplyDiff struct {
 	unsupported []string
 }
 
-func buildNVConfigApplyDiff(nvConfig types.NvConfigQuery, desiredConfig map[string]string, force bool) nvConfigApplyDiff {
+func buildNVConfigApplyDiff(nvConfig types.NvConfigQuery, desiredConfig map[string]string, withDefault, force bool) nvConfigApplyDiff {
 	diff := nvConfigApplyDiff{
 		changed:     make(map[string]string, len(desiredConfig)),
 		unchanged:   []string{},
@@ -209,7 +210,7 @@ func buildNVConfigApplyDiff(nvConfig types.NvConfigQuery, desiredConfig map[stri
 			diff.unsupported = append(diff.unsupported, param)
 			continue
 		}
-		if slices.Contains(nextValues, value) {
+		if !withDefault && slices.Contains(nextValues, value) {
 			diff.unchanged = append(diff.unchanged, param)
 			continue
 		}
@@ -259,6 +260,9 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 		log.Log.Error(err, "failed to calculate desired nvconfig parameters", "device", device.Name)
 		return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
 	}
+	if options.Force {
+		extrapolatePortParamsFromNumOfPF(desiredParams)
+	}
 	log.Log.V(2).Info("combined desired nv config built", "device", device.Name, "params", desiredParams, "force", options.Force)
 
 	// 5. set_system_conf baseline: if the combined params do not cover all mismatched profile params
@@ -289,20 +293,23 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 	// 6 & 7. Apply the combined override params on every PF the device exposes.
 	//   - force=true: apply every param (mlxconfig --force accepts params not currently visible, e.g.
 	//     per-port params staged before a breakout reboot exposes their ports).
-	//   - force=false: apply only the params visible on this PF whose value differs; params not yet
+	//   - withDefault=true: apply every param visible on this PF so DMS can reset unspecified params
+	//     to their defaults and report whether the operation requires a reset.
+	//   - otherwise: apply only the params visible on this PF whose value differs; params not yet
 	//     visible are skipped this round and picked up after a reboot exposes them (which sequences
 	//     breakout before postBreakout without --force).
 	for _, port := range device.Status.Ports {
 		nvConfig := nvConfigsForPorts[port.PCI]
-		diff := buildNVConfigApplyDiff(nvConfig, desiredParams, options.Force)
+		diff := buildNVConfigApplyDiff(nvConfig, desiredParams, options.WithDefault, options.Force)
 		batch := diff.changed
 		hasUnsupportedParams = hasUnsupportedParams || len(diff.unsupported) > 0
 		target := "pci/" + port.PCI
 		log.Log.V(2).Info("nv config apply diff",
 			"device", device.Name,
 			"target", target,
+			"withDefault", options.WithDefault,
 			"force", options.Force,
-			"comparedToNextBoot", !options.Force,
+			"comparedToNextBoot", !options.WithDefault && !options.Force,
 			"desiredCount", len(desiredParams),
 			"changedCount", len(batch),
 			"changedParams", batch,
@@ -314,11 +321,14 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 			continue
 		}
 		log.Log.V(2).Info("applying nv config batch", "device", device.Name, "target", target, "params", batch, "force", options.Force)
-		if err := h.nvConfigUtils.SetNvConfigParametersBatch(port, batch, options.WithDefault, options.Force); err != nil {
+		applyStatus, err := h.nvConfigUtils.SetNvConfigParametersBatch(port, batch, options.WithDefault, options.Force)
+		if err != nil {
 			log.Log.Error(err, "Failed to apply nv config parameters", "device", device.Name, "params", batch)
 			return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
 		}
-		anyParamsApplied = true
+		if applyStatus == types.ApplyStatusSuccess {
+			anyParamsApplied = true
+		}
 	}
 
 	if !anyParamsApplied && !hasUnsupportedParams && !systemConfApplied {
@@ -334,6 +344,35 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 	log.Log.Info("nv config applied", "device", device.Name, "status", status, "rebootRequired", rebootRequired)
 
 	return &types.ConfigurationApplyResult{Status: status, RebootRequired: rebootRequired}, nil
+}
+
+func extrapolatePortParamsFromNumOfPF(params map[string]string) {
+	value, ok := params[consts.NumOfPfParam]
+	if !ok {
+		return
+	}
+	portCount, err := strconv.Atoi(value)
+	if err != nil || portCount < 2 {
+		return
+	}
+
+	baseValues := map[string]string{}
+	for param, value := range params {
+		portNum, ok := consts.PortSuffixNum(param)
+		if !ok || portNum != 1 {
+			continue
+		}
+		base := param[:len(param)-len(strconv.Itoa(portNum))-2]
+		baseValues[base] = value
+	}
+	for base, baseValue := range baseValues {
+		for portNum := 1; portNum <= portCount; portNum++ {
+			param := consts.PortParam(base, portNum)
+			if _, exists := params[param]; !exists {
+				params[param] = baseValue
+			}
+		}
+	}
 }
 
 // setSystemConf stages the requested Network Bay set_system_conf for the device's ASIC (the

--- a/pkg/configuration/manager_test.go
+++ b/pkg/configuration/manager_test.go
@@ -650,7 +650,7 @@ var _ = Describe("ConfigurationManager", func() {
 						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 							Return(desiredConfig, nil)
 						mockNV.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"param1": "value2"}, false, false).
-							Return(nil)
+							Return(types.ApplyStatusSuccess, nil)
 
 						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 						Expect(result.RebootRequired).To(BeTrue())
@@ -717,7 +717,7 @@ var _ = Describe("ConfigurationManager", func() {
 							Return(desiredConfig, nil)
 						setParamErr := errors.New("failed to set param1")
 						mockNV.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"param1": "value3"}, false, false).
-							Return(setParamErr)
+							Return(types.ApplyStatusFailed, setParamErr)
 
 						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 						Expect(result.RebootRequired).To(BeFalse())
@@ -748,7 +748,7 @@ var _ = Describe("ConfigurationManager", func() {
 						mockNV.On("QueryNvConfig", ctx, pciAddress2, []string(nil)).Return(nvConfig1, nil)
 						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig0).Return(map[string]string{"TRACER_ENABLED": "1"}, nil)
 						// Only port2 should be updated
-						mockNV.On("SetNvConfigParametersBatch", pciAddress2, map[string]string{"TRACER_ENABLED": "1"}, false, false).Return(nil)
+						mockNV.On("SetNvConfigParametersBatch", pciAddress2, map[string]string{"TRACER_ENABLED": "1"}, false, false).Return(types.ApplyStatusSuccess, nil)
 
 						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 						Expect(err).To(BeNil())
@@ -801,7 +801,7 @@ var _ = Describe("ConfigurationManager", func() {
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 						Return(desiredConfig, nil)
 					mockNV.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"param1": "newValue3", "param2": "newValue3"}, false, false).
-						Return(nil)
+						Return(types.ApplyStatusSuccess, nil)
 
 					result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 					Expect(result.RebootRequired).To(BeTrue())
@@ -1367,7 +1367,7 @@ var _ = Describe("ConfigurationManager", func() {
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(map[string]string{"NUM_OF_PF": "2", "LINK_TYPE_P1": "2"}, nil)
 				// NUM_OF_PF differs (1 != 2) and is applied; LINK_TYPE_P1 already matches and is skipped.
-				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"NUM_OF_PF": "2"}, false, false).Return(nil)
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"NUM_OF_PF": "2"}, false, false).Return(types.ApplyStatusSuccess, nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 				Expect(err).NotTo(HaveOccurred())
@@ -1379,7 +1379,7 @@ var _ = Describe("ConfigurationManager", func() {
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(map[string]string{"NUM_OF_PF": "2", "LINK_TYPE_P1": "2"}, nil)
 				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress,
-					map[string]string{"NUM_OF_PF": "2", "LINK_TYPE_P1": "2"}, false, true).Return(nil)
+					map[string]string{"NUM_OF_PF": "2", "LINK_TYPE_P1": "2", "LINK_TYPE_P2": "2"}, false, true).Return(types.ApplyStatusSuccess, nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{Force: true})
 				Expect(err).NotTo(HaveOccurred())
@@ -1392,8 +1392,8 @@ var _ = Describe("ConfigurationManager", func() {
 				mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress2, []string(nil)).Return(types.NvConfigQuery{}, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(map[string]string{"NUM_OF_PF": "2"}, nil)
-				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"NUM_OF_PF": "2"}, false, true).Return(nil)
-				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress2, map[string]string{"NUM_OF_PF": "2"}, false, true).Return(nil)
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"NUM_OF_PF": "2"}, false, true).Return(types.ApplyStatusSuccess, nil)
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress2, map[string]string{"NUM_OF_PF": "2"}, false, true).Return(types.ApplyStatusSuccess, nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{Force: true})
 				Expect(err).NotTo(HaveOccurred())
@@ -1406,11 +1406,25 @@ var _ = Describe("ConfigurationManager", func() {
 					types.NvConfigQuery{NextBootConfig: map[string][]string{"NUM_OF_PF": {"1"}}}, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(map[string]string{"NUM_OF_PF": "2"}, nil)
-				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"NUM_OF_PF": "2"}, true, false).Return(nil)
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"NUM_OF_PF": "2"}, true, false).Return(types.ApplyStatusSuccess, nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{WithDefault: true})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.RebootRequired).To(BeTrue())
+			})
+
+			It("returns NothingToDo when WithDefault=true but mlxconfig reports no changed params", func() {
+				mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(
+					types.NvConfigQuery{NextBootConfig: map[string][]string{"NUM_OF_PF": {"2"}}}, nil)
+				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
+					Return(map[string]string{"NUM_OF_PF": "2"}, nil)
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"NUM_OF_PF": "2"}, true, false).
+					Return(types.ApplyStatusNothingToDo, nil)
+
+				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{WithDefault: true})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Status).To(Equal(types.ApplyStatusNothingToDo))
+				Expect(result.RebootRequired).To(BeFalse())
 			})
 
 			It("returns NothingToDo when the combined params already match", func() {
@@ -1448,7 +1462,7 @@ var _ = Describe("ConfigurationManager", func() {
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 						Return(map[string]string{"NUM_OF_PF": "2"}, nil)
 					mockNVConfigUtils.On("SetSystemConf", ctx, pciAddress, "conf3", 0, true).Return(nil)
-					mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"NUM_OF_PF": "2"}, false, true).Return(nil)
+					mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"NUM_OF_PF": "2"}, false, true).Return(types.ApplyStatusSuccess, nil)
 
 					result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{Force: true})
 					Expect(err).NotTo(HaveOccurred())
@@ -1461,7 +1475,7 @@ var _ = Describe("ConfigurationManager", func() {
 						Return(mismatchSystemConf("NUM_OF_PF")...)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 						Return(map[string]string{"NUM_OF_PF": "2"}, nil)
-					mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"NUM_OF_PF": "2"}, false, true).Return(nil)
+					mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"NUM_OF_PF": "2"}, false, true).Return(types.ApplyStatusSuccess, nil)
 					mockNVConfigUtils.AssertNotCalled(GinkgoT(), "SetSystemConf", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 
 					result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{Force: true})
@@ -1635,7 +1649,7 @@ var _ = Describe("ConfigurationManager", func() {
 				setSystemConfCall := mockNV.On("SetSystemConf", ctx, pciAddress, "conf3", 0, false).Return(nil)
 				// set_system_conf is the baseline and must be staged before the override batch.
 				mockNV.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"param1": "value2"}, false, false).
-					Return(nil).NotBefore(setSystemConfCall)
+					Return(types.ApplyStatusSuccess, nil).NotBefore(setSystemConfCall)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 				Expect(err).NotTo(HaveOccurred())
@@ -1778,7 +1792,7 @@ var _ = Describe("ConfigurationManager", func() {
 					types.NvConfigQuery{NextBootConfig: staged, CurrentConfig: staged}, nil)
 				fullFlowNV.On("ValidateSystemConf", fullFlowCtx, pciAddress, "conf3", 0).
 					Return(mismatchSystemConf("NUM_OF_PF")...)
-				fullFlowNV.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"NUM_OF_PF": "8"}, false, false).Return(nil)
+				fullFlowNV.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"NUM_OF_PF": "8"}, false, false).Return(types.ApplyStatusSuccess, nil)
 
 				updateNeeded, rebootNeeded, _, err := fullFlowManager.ValidateDeviceNvSpec(fullFlowCtx, fullFlowDevice)
 				Expect(err).NotTo(HaveOccurred())
@@ -1832,7 +1846,7 @@ var _ = Describe("ConfigurationManager", func() {
 				fullFlowNV.On("ValidateSystemConf", fullFlowCtx, pciAddress, "conf3", 0).
 					Return(mismatchSystemConf("NUM_OF_PF", "LINK_TYPE_P1")...)
 				// Only LINK_TYPE_P1 differs from next boot; the raw value 2 wins over the Spectrum-X value 1.
-				fullFlowNV.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"LINK_TYPE_P1": "2"}, false, false).Return(nil)
+				fullFlowNV.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"LINK_TYPE_P1": "2"}, false, false).Return(types.ApplyStatusSuccess, nil)
 
 				updateNeeded, rebootNeeded, _, err := fullFlowManager.ValidateDeviceNvSpec(fullFlowCtx, fullFlowDevice)
 				Expect(err).NotTo(HaveOccurred())
@@ -1870,7 +1884,7 @@ var _ = Describe("ConfigurationManager", func() {
 					Return(mismatchSystemConf("NUM_OF_PF", "LINK_TYPE_P1")...)
 				// Raw wins on both: LINK_TYPE_P1 over Spectrum-X (1→2) and NUM_OF_VFS over template (4→16).
 				fullFlowNV.On("SetNvConfigParametersBatch", pciAddress,
-					map[string]string{"LINK_TYPE_P1": "2", consts.SriovNumOfVfsParam: "16"}, false, false).Return(nil)
+					map[string]string{"LINK_TYPE_P1": "2", consts.SriovNumOfVfsParam: "16"}, false, false).Return(types.ApplyStatusSuccess, nil)
 
 				updateNeeded, rebootNeeded, _, err := fullFlowManager.ValidateDeviceNvSpec(fullFlowCtx, fullFlowDevice)
 				Expect(err).NotTo(HaveOccurred())

--- a/pkg/configuration/manager_test.go
+++ b/pkg/configuration/manager_test.go
@@ -63,7 +63,7 @@ var _ = Describe("ConfigurationManager", func() {
 				"CHANGED":     "requested",
 				"UNCHANGED":   "requested",
 				"UNSUPPORTED": "requested",
-			}, false)
+			}, false, false)
 
 			Expect(diff.changed).To(Equal(map[string]string{"CHANGED": "requested"}))
 			Expect(diff.unchanged).To(Equal([]string{"UNCHANGED"}))
@@ -72,11 +72,44 @@ var _ = Describe("ConfigurationManager", func() {
 
 		It("classifies every desired parameter as changed when force is enabled", func() {
 			desired := map[string]string{"A": "1", "B": "2"}
-			diff := buildNVConfigApplyDiff(types.NewNvConfigQuery(), desired, true)
+			diff := buildNVConfigApplyDiff(types.NewNvConfigQuery(), desired, false, true)
 
 			Expect(diff.changed).To(Equal(desired))
 			Expect(diff.unchanged).To(BeEmpty())
 			Expect(diff.unsupported).To(BeEmpty())
+		})
+
+		It("classifies matching supported parameters as changed when with-default is enabled", func() {
+			diff := buildNVConfigApplyDiff(types.NvConfigQuery{
+				NextBootConfig: map[string][]string{"MATCHING": {"requested"}},
+			}, map[string]string{
+				"MATCHING":    "requested",
+				"UNSUPPORTED": "requested",
+			}, true, false)
+
+			Expect(diff.changed).To(Equal(map[string]string{"MATCHING": "requested"}))
+			Expect(diff.unchanged).To(BeEmpty())
+			Expect(diff.unsupported).To(Equal([]string{"UNSUPPORTED"}))
+		})
+	})
+
+	Describe("extrapolatePortParamsFromNumOfPF", func() {
+		It("copies P1 values to missing ports while preserving explicit overrides", func() {
+			params := map[string]string{"NUM_OF_PF": "3", "LINK_TYPE_P1": "2", "LINK_TYPE_P3": "1"}
+
+			extrapolatePortParamsFromNumOfPF(params)
+
+			Expect(params).To(Equal(map[string]string{
+				"NUM_OF_PF": "3", "LINK_TYPE_P1": "2", "LINK_TYPE_P2": "2", "LINK_TYPE_P3": "1",
+			}))
+		})
+
+		It("does not extrapolate from a higher port when P1 is absent", func() {
+			params := map[string]string{"NUM_OF_PF": "3", "LINK_TYPE_P2": "2"}
+
+			extrapolatePortParamsFromNumOfPF(params)
+
+			Expect(params).To(Equal(map[string]string{"NUM_OF_PF": "3", "LINK_TYPE_P2": "2"}))
 		})
 	})
 
@@ -683,7 +716,7 @@ var _ = Describe("ConfigurationManager", func() {
 						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 							Return(desiredConfig, nil)
 						mockNV.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"param1": "value2"}, false, false).
-							Return(nil)
+							Return(types.ApplyStatusSuccess, nil)
 
 						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 						Expect(result.RebootRequired).To(BeTrue())
@@ -750,7 +783,7 @@ var _ = Describe("ConfigurationManager", func() {
 							Return(desiredConfig, nil)
 						setParamErr := errors.New("failed to set param1")
 						mockNV.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"param1": "value3"}, false, false).
-							Return(setParamErr)
+							Return(types.ApplyStatusFailed, setParamErr)
 
 						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 						Expect(result.RebootRequired).To(BeFalse())
@@ -781,7 +814,8 @@ var _ = Describe("ConfigurationManager", func() {
 						mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress2), []string(nil)).Return(nvConfig1, nil)
 						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig0).Return(map[string]string{"TRACER_ENABLED": "1"}, nil)
 						// Only port2 should be updated
-						mockNV.On("SetNvConfigParametersBatch", portSpec(pciAddress2), map[string]string{"TRACER_ENABLED": "1"}, false, false).Return(nil)
+						mockNV.On("SetNvConfigParametersBatch", portSpec(pciAddress2), map[string]string{"TRACER_ENABLED": "1"}, false, false).
+							Return(types.ApplyStatusSuccess, nil)
 
 						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 						Expect(err).To(BeNil())
@@ -834,7 +868,7 @@ var _ = Describe("ConfigurationManager", func() {
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 						Return(desiredConfig, nil)
 					mockNV.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"param1": "newValue3", "param2": "newValue3"}, false, false).
-						Return(nil)
+						Return(types.ApplyStatusSuccess, nil)
 
 					result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 					Expect(result.RebootRequired).To(BeTrue())
@@ -1452,7 +1486,8 @@ var _ = Describe("ConfigurationManager", func() {
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(map[string]string{"NUM_OF_PF": "2", "LINK_TYPE_P1": "2"}, nil)
 				// NUM_OF_PF differs (1 != 2) and is applied; LINK_TYPE_P1 already matches and is skipped.
-				mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, false, false).Return(nil)
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, false, false).
+					Return(types.ApplyStatusSuccess, nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 				Expect(err).NotTo(HaveOccurred())
@@ -1464,7 +1499,7 @@ var _ = Describe("ConfigurationManager", func() {
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(map[string]string{"NUM_OF_PF": "2", "LINK_TYPE_P1": "2"}, nil)
 				mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress),
-					map[string]string{"NUM_OF_PF": "2", "LINK_TYPE_P1": "2"}, false, true).Return(nil)
+					map[string]string{"NUM_OF_PF": "2", "LINK_TYPE_P1": "2", "LINK_TYPE_P2": "2"}, false, true).Return(types.ApplyStatusSuccess, nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{Force: true})
 				Expect(err).NotTo(HaveOccurred())
@@ -1477,8 +1512,10 @@ var _ = Describe("ConfigurationManager", func() {
 				mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress2), []string(nil)).Return(types.NvConfigQuery{}, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(map[string]string{"NUM_OF_PF": "2"}, nil)
-				mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, false, true).Return(nil)
-				mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress2), map[string]string{"NUM_OF_PF": "2"}, false, true).Return(nil)
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, false, true).
+					Return(types.ApplyStatusSuccess, nil)
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress2), map[string]string{"NUM_OF_PF": "2"}, false, true).
+					Return(types.ApplyStatusSuccess, nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{Force: true})
 				Expect(err).NotTo(HaveOccurred())
@@ -1491,11 +1528,39 @@ var _ = Describe("ConfigurationManager", func() {
 					types.NvConfigQuery{NextBootConfig: map[string][]string{"NUM_OF_PF": {"1"}}}, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(map[string]string{"NUM_OF_PF": "2"}, nil)
-				mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, true, false).Return(nil)
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, true, false).
+					Return(types.ApplyStatusSuccess, nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{WithDefault: true})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.RebootRequired).To(BeTrue())
+			})
+
+			It("returns NothingToDo when WithDefault=true but DMS reports no reset is required", func() {
+				mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(
+					types.NvConfigQuery{NextBootConfig: map[string][]string{"NUM_OF_PF": {"2"}}}, nil)
+				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
+					Return(map[string]string{"NUM_OF_PF": "2"}, nil)
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, true, false).
+					Return(types.ApplyStatusNothingToDo, nil)
+
+				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{WithDefault: true})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Status).To(Equal(types.ApplyStatusNothingToDo))
+				Expect(result.RebootRequired).To(BeFalse())
+			})
+
+			It("returns NothingToDo when Force and WithDefault are true but DMS reports no reset is required", func() {
+				mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(types.NvConfigQuery{}, nil)
+				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
+					Return(map[string]string{"NUM_OF_PF": "2"}, nil)
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, true, true).
+					Return(types.ApplyStatusNothingToDo, nil)
+
+				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{Force: true, WithDefault: true})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Status).To(Equal(types.ApplyStatusNothingToDo))
+				Expect(result.RebootRequired).To(BeFalse())
 			})
 
 			It("returns NothingToDo when the combined params already match", func() {
@@ -1533,7 +1598,8 @@ var _ = Describe("ConfigurationManager", func() {
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 						Return(map[string]string{"NUM_OF_PF": "2"}, nil)
 					mockNVConfigUtils.On("SetSystemConf", ctx, portSpec(pciAddress), "conf3", 0, true).Return(nil)
-					mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, false, true).Return(nil)
+					mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, false, true).
+						Return(types.ApplyStatusSuccess, nil)
 
 					result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{Force: true})
 					Expect(err).NotTo(HaveOccurred())
@@ -1546,7 +1612,8 @@ var _ = Describe("ConfigurationManager", func() {
 						Return(mismatchSystemConf("NUM_OF_PF")...)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 						Return(map[string]string{"NUM_OF_PF": "2"}, nil)
-					mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, false, true).Return(nil)
+					mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, false, true).
+						Return(types.ApplyStatusSuccess, nil)
 					mockNVConfigUtils.AssertNotCalled(GinkgoT(), "SetSystemConf", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 
 					result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{Force: true})
@@ -1720,7 +1787,7 @@ var _ = Describe("ConfigurationManager", func() {
 				setSystemConfCall := mockNV.On("SetSystemConf", ctx, portSpec(pciAddress), "conf3", 0, false).Return(nil)
 				// set_system_conf is the baseline and must be staged before the override batch.
 				mockNV.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"param1": "value2"}, false, false).
-					Return(nil).NotBefore(setSystemConfCall)
+					Return(types.ApplyStatusSuccess, nil).NotBefore(setSystemConfCall)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 				Expect(err).NotTo(HaveOccurred())
@@ -1865,7 +1932,8 @@ var _ = Describe("ConfigurationManager", func() {
 					types.NvConfigQuery{NextBootConfig: staged, CurrentConfig: staged}, nil)
 				fullFlowNV.On("ValidateSystemConf", fullFlowCtx, portSpec(pciAddress), "conf3", 0).
 					Return(mismatchSystemConf("NUM_OF_PF")...)
-				fullFlowNV.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "8"}, false, false).Return(nil)
+				fullFlowNV.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "8"}, false, false).
+					Return(types.ApplyStatusSuccess, nil)
 
 				updateNeeded, rebootNeeded, _, err := fullFlowManager.ValidateDeviceNvSpec(fullFlowCtx, fullFlowDevice)
 				Expect(err).NotTo(HaveOccurred())
@@ -1919,7 +1987,8 @@ var _ = Describe("ConfigurationManager", func() {
 				fullFlowNV.On("ValidateSystemConf", fullFlowCtx, portSpec(pciAddress), "conf3", 0).
 					Return(mismatchSystemConf("NUM_OF_PF", "LINK_TYPE_P1")...)
 				// Only LINK_TYPE_P1 differs from next boot; the raw value 2 wins over the Spectrum-X value 1.
-				fullFlowNV.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"LINK_TYPE_P1": "2"}, false, false).Return(nil)
+				fullFlowNV.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"LINK_TYPE_P1": "2"}, false, false).
+					Return(types.ApplyStatusSuccess, nil)
 
 				updateNeeded, rebootNeeded, _, err := fullFlowManager.ValidateDeviceNvSpec(fullFlowCtx, fullFlowDevice)
 				Expect(err).NotTo(HaveOccurred())
@@ -1957,7 +2026,7 @@ var _ = Describe("ConfigurationManager", func() {
 					Return(mismatchSystemConf("NUM_OF_PF", "LINK_TYPE_P1")...)
 				// Raw wins on both: LINK_TYPE_P1 over Spectrum-X (1→2) and NUM_OF_VFS over template (4→16).
 				fullFlowNV.On("SetNvConfigParametersBatch", portSpec(pciAddress),
-					map[string]string{"LINK_TYPE_P1": "2", consts.SriovNumOfVfsParam: "16"}, false, false).Return(nil)
+					map[string]string{"LINK_TYPE_P1": "2", consts.SriovNumOfVfsParam: "16"}, false, false).Return(types.ApplyStatusSuccess, nil)
 
 				updateNeeded, rebootNeeded, _, err := fullFlowManager.ValidateDeviceNvSpec(fullFlowCtx, fullFlowDevice)
 				Expect(err).NotTo(HaveOccurred())

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -91,6 +91,7 @@ const (
 
 	SriovEnabledParam        = "SRIOV_EN"
 	SriovNumOfVfsParam       = "NUM_OF_VFS"
+	NumOfPfParam             = "NUM_OF_PF"
 	LinkTypeP1Param          = "LINK_TYPE_P1"
 	LinkTypeP2Param          = "LINK_TYPE_P2"
 	MaxAccOutReadParam       = "MAX_ACC_OUT_READ"

--- a/pkg/nvconfig/mocks/NVConfigUtils.go
+++ b/pkg/nvconfig/mocks/NVConfigUtils.go
@@ -80,21 +80,31 @@ func (_m *NVConfigUtils) SetNvConfigParameter(pciAddr string, paramName string, 
 }
 
 // SetNvConfigParametersBatch provides a mock function with given fields: pciAddr, params, withDefault, force
-func (_m *NVConfigUtils) SetNvConfigParametersBatch(pciAddr string, params map[string]string, withDefault bool, force bool) error {
+func (_m *NVConfigUtils) SetNvConfigParametersBatch(pciAddr string, params map[string]string, withDefault bool, force bool) (types.ApplyStatus, error) {
 	ret := _m.Called(pciAddr, params, withDefault, force)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SetNvConfigParametersBatch")
 	}
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(string, map[string]string, bool, bool) error); ok {
+	var r0 types.ApplyStatus
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string, map[string]string, bool, bool) (types.ApplyStatus, error)); ok {
+		return rf(pciAddr, params, withDefault, force)
+	}
+	if rf, ok := ret.Get(0).(func(string, map[string]string, bool, bool) types.ApplyStatus); ok {
 		r0 = rf(pciAddr, params, withDefault, force)
 	} else {
-		r0 = ret.Error(0)
+		r0 = ret.Get(0).(types.ApplyStatus)
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(string, map[string]string, bool, bool) error); ok {
+		r1 = rf(pciAddr, params, withDefault, force)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // SetSystemConf provides a mock function with given fields: ctx, pciAddr, conf, asic, force

--- a/pkg/nvconfig/mocks/NVConfigUtils.go
+++ b/pkg/nvconfig/mocks/NVConfigUtils.go
@@ -81,21 +81,31 @@ func (_m *NVConfigUtils) SetNvConfigParameter(port v1alpha1.NicDevicePortSpec, p
 }
 
 // SetNvConfigParametersBatch provides a mock function with given fields: port, params, withDefault, force
-func (_m *NVConfigUtils) SetNvConfigParametersBatch(port v1alpha1.NicDevicePortSpec, params map[string]string, withDefault bool, force bool) error {
+func (_m *NVConfigUtils) SetNvConfigParametersBatch(port v1alpha1.NicDevicePortSpec, params map[string]string, withDefault bool, force bool) (types.ApplyStatus, error) {
 	ret := _m.Called(port, params, withDefault, force)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SetNvConfigParametersBatch")
 	}
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(v1alpha1.NicDevicePortSpec, map[string]string, bool, bool) error); ok {
+	var r0 types.ApplyStatus
+	var r1 error
+	if rf, ok := ret.Get(0).(func(v1alpha1.NicDevicePortSpec, map[string]string, bool, bool) (types.ApplyStatus, error)); ok {
+		return rf(port, params, withDefault, force)
+	}
+	if rf, ok := ret.Get(0).(func(v1alpha1.NicDevicePortSpec, map[string]string, bool, bool) types.ApplyStatus); ok {
 		r0 = rf(port, params, withDefault, force)
 	} else {
-		r0 = ret.Error(0)
+		r0 = ret.Get(0).(types.ApplyStatus)
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(v1alpha1.NicDevicePortSpec, map[string]string, bool, bool) error); ok {
+		r1 = rf(port, params, withDefault, force)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // SetSystemConf provides a mock function with given fields: ctx, port, conf, asic, force

--- a/pkg/nvconfig/utils.go
+++ b/pkg/nvconfig/utils.go
@@ -56,7 +56,7 @@ type NVConfigUtils interface {
 	// SetNvConfigParametersBatch sets multiple nv config parameters for a mellanox device in a single mlxconfig call
 	// When force is true, --force is passed to mlxconfig so it accepts a batch it would otherwise refuse
 	// due to implicit parameter dependencies.
-	SetNvConfigParametersBatch(pciAddr string, params map[string]string, withDefault bool, force bool) error
+	SetNvConfigParametersBatch(pciAddr string, params map[string]string, withDefault bool, force bool) (types.ApplyStatus, error)
 	// ResetNvConfig resets NIC's nv config
 	ResetNvConfig(pciAddr string) error
 	// SetSystemConf applies a ConnectX-9 Network Bay system configuration for a single ASIC via
@@ -197,12 +197,22 @@ func (h *nvConfigUtils) SetNvConfigParameter(pciAddr string, paramName string, p
 	return nil
 }
 
+func parseSetNvConfigParametersBatchStatus(output []byte, withDefault bool) types.ApplyStatus {
+	if strings.Contains(string(output), "Configurations:") {
+		return types.ApplyStatusSuccess
+	}
+	if withDefault {
+		return types.ApplyStatusNothingToDo
+	}
+	return types.ApplyStatusSuccess
+}
+
 // SetNvConfigParametersBatch sets multiple nv config parameters for a mellanox device in a single mlxconfig call
-func (h *nvConfigUtils) SetNvConfigParametersBatch(pciAddr string, params map[string]string, withDefault bool, force bool) error {
+func (h *nvConfigUtils) SetNvConfigParametersBatch(pciAddr string, params map[string]string, withDefault bool, force bool) (types.ApplyStatus, error) {
 	log.Log.Info("ConfigurationUtils.SetNvConfigParametersBatch()", "pciAddr", pciAddr, "params", params, "withDefault", withDefault, "force", force)
 
 	if len(params) == 0 {
-		return nil
+		return types.ApplyStatusNothingToDo, nil
 	}
 
 	// Build sorted param list for deterministic command
@@ -217,9 +227,11 @@ func (h *nvConfigUtils) SetNvConfigParametersBatch(pciAddr string, params map[st
 		paramArgs = append(paramArgs, name+"="+params[name])
 	}
 
-	args := []string{"-d", pciAddr, "--yes"}
+	args := []string{"-d", pciAddr}
 	if withDefault {
-		args = append(args, "--with_default")
+		args = append(args, "-e", "--with_default", "-y")
+	} else {
+		args = append(args, "--yes")
 	}
 	if force {
 		args = append(args, "--force")
@@ -231,9 +243,9 @@ func (h *nvConfigUtils) SetNvConfigParametersBatch(pciAddr string, params map[st
 	output, err := utils.RunCommand(cmd)
 	if err != nil {
 		log.Log.Error(err, "SetNvConfigParametersBatch(): Failed to run mlxconfig", "output", string(output))
-		return err
+		return types.ApplyStatusFailed, err
 	}
-	return nil
+	return parseSetNvConfigParametersBatchStatus(output, withDefault), nil
 }
 
 // systemConfToken builds the `<conf>[<asic>]` argument for set/validate_system_conf, e.g. conf3[0].

--- a/pkg/nvconfig/utils.go
+++ b/pkg/nvconfig/utils.go
@@ -57,8 +57,8 @@ type NVConfigUtils interface {
 	// SetNvConfigParameter sets a nv config parameter for a mellanox device
 	SetNvConfigParameter(port v1alpha1.NicDevicePortSpec, paramName string, paramValue string) error
 	// SetNvConfigParametersBatch sets multiple NVConfig parameters in one DMS NVConfig action.
-	// withDefault and force are forwarded to DMS, which applies them to the compiled mlxconfig batch.
-	SetNvConfigParametersBatch(port v1alpha1.NicDevicePortSpec, params map[string]string, withDefault bool, force bool) error
+	// withDefault and force are forwarded to DMS, and the returned status reflects its requires-reset result.
+	SetNvConfigParametersBatch(port v1alpha1.NicDevicePortSpec, params map[string]string, withDefault bool, force bool) (types.ApplyStatus, error)
 	// ResetNvConfig resets NIC's nv config
 	ResetNvConfig(port v1alpha1.NicDevicePortSpec) error
 	// SetSystemConf applies a ConnectX-9 Network Bay system configuration for a single ASIC via
@@ -210,12 +210,12 @@ func (h *nvConfigUtils) SetNvConfigParameter(port v1alpha1.NicDevicePortSpec, pa
 }
 
 // SetNvConfigParametersBatch sets multiple nv config parameters for a Mellanox device in one DMS NVConfig action.
-func (h *nvConfigUtils) SetNvConfigParametersBatch(port v1alpha1.NicDevicePortSpec, params map[string]string, withDefault bool, force bool) error {
+func (h *nvConfigUtils) SetNvConfigParametersBatch(port v1alpha1.NicDevicePortSpec, params map[string]string, withDefault bool, force bool) (types.ApplyStatus, error) {
 	if len(params) == 0 {
-		return nil
+		return types.ApplyStatusNothingToDo, nil
 	}
 	if h.execInterface == nil {
-		return fmt.Errorf("command executor must not be nil")
+		return types.ApplyStatusFailed, fmt.Errorf("command executor must not be nil")
 	}
 
 	target := "pci/" + port.PCI
@@ -242,7 +242,7 @@ func (h *nvConfigUtils) SetNvConfigParametersBatch(port v1alpha1.NicDevicePortSp
 	})
 	if err != nil {
 		log.Log.Error(err, "SetNvConfigParametersBatch(): DMS NVConfig apply failed", "target", target)
-		return err
+		return types.ApplyStatusFailed, err
 	}
 	log.Log.V(2).Info("DMS NVConfig apply succeeded",
 		"target", target,
@@ -252,7 +252,10 @@ func (h *nvConfigUtils) SetNvConfigParametersBatch(port v1alpha1.NicDevicePortSp
 		"withDefault", result.WithDefault,
 		"force", result.Force,
 		"params", result.Params)
-	return nil
+	if result.RequiresReset {
+		return types.ApplyStatusSuccess, nil
+	}
+	return types.ApplyStatusNothingToDo, nil
 }
 
 // systemConfToken builds the `<conf>[<asic>]` argument for set/validate_system_conf, e.g. conf3[0].

--- a/pkg/nvconfig/utils_test.go
+++ b/pkg/nvconfig/utils_test.go
@@ -21,6 +21,7 @@ import (
 	"regexp"
 
 	"github.com/Mellanox/nic-configuration-operator/pkg/consts"
+	"github.com/Mellanox/nic-configuration-operator/pkg/types"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/exec"
@@ -594,7 +595,9 @@ Result: Device configuration does NOT match the system configuration.
 					return cmd
 				},
 			}
-			Expect(h.SetNvConfigParametersBatch(pciAddress, map[string]string{"PARAM": "1"}, false, true)).To(Succeed())
+			status, err := h.SetNvConfigParametersBatch(pciAddress, map[string]string{"PARAM": "1"}, false, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).To(Equal(types.ApplyStatusSuccess))
 		})
 
 		It("omits --force when force is false", func() {
@@ -608,7 +611,62 @@ Result: Device configuration does NOT match the system configuration.
 					return cmd
 				},
 			}
-			Expect(h.SetNvConfigParametersBatch(pciAddress, map[string]string{"PARAM": "1"}, false, false)).To(Succeed())
+			status, err := h.SetNvConfigParametersBatch(pciAddress, map[string]string{"PARAM": "1"}, false, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).To(Equal(types.ApplyStatusSuccess))
+		})
+
+		It("passes -y with --with_default and returns nothing-to-do when output has no configurations section", func() {
+			output := `Param SAFE_MODE_ENABLE is not going to be set since value matches next value
+Param SAFE_MODE_THRESHOLD is not going to be set since value matches next value
+
+ Apply reset and set? (y/n) [n] : y
+Done!
+-I- Please reboot machine to load new configurations.
+`
+			cmd := &execTesting.FakeCmd{}
+			cmd.OutputScript = append(cmd.OutputScript, func() ([]byte, []byte, error) {
+				return []byte(output), nil, nil
+			})
+			fakeExec.CommandScript = []execTesting.FakeCommandAction{
+				func(name string, args ...string) exec.Cmd {
+					Expect(args).To(Equal([]string{"-d", pciAddress, "-e", "--with_default", "-y", "set", "SAFE_MODE_ENABLE=1", "SAFE_MODE_THRESHOLD=10"}))
+					return cmd
+				},
+			}
+			status, err := h.SetNvConfigParametersBatch(pciAddress, map[string]string{"SAFE_MODE_ENABLE": "1", "SAFE_MODE_THRESHOLD": "10"}, true, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).To(Equal(types.ApplyStatusNothingToDo))
+		})
+
+		It("returns success with --with_default when output has a configurations section", func() {
+			output := `Param SAFE_MODE_ENABLE is not going to be set since value matches next value
+Param SAFE_MODE_THRESHOLD is not going to be set since value matches next value
+
+ Apply reset and set? (y/n) [n] : y
+
+Device #1:
+----------
+
+Configurations:                                         Default                           Current                           Next Boot                         New
+*       SRIOV_EN                                        True(1)                           False(0)                          True(1)                           False(0)
+The '*' shows parameters with next value different from default/current value.
+Applying... Done!
+-I- Please reboot machine to load new configurations.
+`
+			cmd := &execTesting.FakeCmd{}
+			cmd.OutputScript = append(cmd.OutputScript, func() ([]byte, []byte, error) {
+				return []byte(output), nil, nil
+			})
+			fakeExec.CommandScript = []execTesting.FakeCommandAction{
+				func(name string, args ...string) exec.Cmd {
+					Expect(args).To(Equal([]string{"-d", pciAddress, "-e", "--with_default", "-y", "set", "SAFE_MODE_ENABLE=1", "SAFE_MODE_THRESHOLD=10", "SRIOV_EN=0"}))
+					return cmd
+				},
+			}
+			status, err := h.SetNvConfigParametersBatch(pciAddress, map[string]string{"SAFE_MODE_ENABLE": "1", "SAFE_MODE_THRESHOLD": "10", "SRIOV_EN": "0"}, true, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).To(Equal(types.ApplyStatusSuccess))
 		})
 	})
 })

--- a/pkg/nvconfig/utils_test.go
+++ b/pkg/nvconfig/utils_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Mellanox/nic-configuration-operator/api/v1alpha1"
 	"github.com/Mellanox/nic-configuration-operator/pkg/consts"
 	"github.com/Mellanox/nic-configuration-operator/pkg/dmscli"
+	"github.com/Mellanox/nic-configuration-operator/pkg/types"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/exec"
@@ -616,7 +617,7 @@ Result: Device configuration does NOT match the system configuration.
 		BeforeEach(func() {
 			commandName = ""
 			commandArgs = nil
-			commandOutput = []byte(`{"status":"ok"}`)
+			commandOutput = []byte(`{"status":"ok","requires-reset":true}`)
 			commandErr = nil
 
 			cmd := &execTesting.FakeCmd{}
@@ -635,10 +636,12 @@ Result: Device configuration does NOT match the system configuration.
 		})
 
 		It("sends a sorted raw batch and forwards with-default and force", func() {
-			Expect(h.SetNvConfigParametersBatch(nvconfigPort(pciAddress), map[string]string{
+			status, err := h.SetNvConfigParametersBatch(nvconfigPort(pciAddress), map[string]string{
 				"Z_PARAM": "2",
 				"A_PARAM": "1",
-			}, true, true)).To(Succeed())
+			}, true, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).To(Equal(types.ApplyStatusSuccess))
 
 			Expect(commandName).To(Equal("dms-cli"))
 			Expect(commandArgs[0:4]).To(Equal([]string{"--json", "-t", "pci/" + pciAddress, "--input"}))
@@ -670,7 +673,9 @@ Result: Device configuration does NOT match the system configuration.
 		})
 
 		It("forwards false flag values explicitly", func() {
-			Expect(h.SetNvConfigParametersBatch(nvconfigPort(pciAddress), map[string]string{"PARAM": "1"}, false, false)).To(Succeed())
+			status, err := h.SetNvConfigParametersBatch(nvconfigPort(pciAddress), map[string]string{"PARAM": "1"}, false, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).To(Equal(types.ApplyStatusSuccess))
 
 			var payload map[string]any
 			Expect(json.Unmarshal([]byte(commandArgs[4]), &payload)).To(Succeed())
@@ -680,14 +685,26 @@ Result: Device configuration does NOT match the system configuration.
 
 		It("passes the PCI target and does not use fwctl metadata", func() {
 			port := v1alpha1.NicDevicePortSpec{PCI: pciAddress, FwctlDevice: "/dev/fwctl/fwctl3"}
-			Expect(h.SetNvConfigParametersBatch(port, map[string]string{"PARAM": "1"}, false, false)).To(Succeed())
+			status, err := h.SetNvConfigParametersBatch(port, map[string]string{"PARAM": "1"}, false, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).To(Equal(types.ApplyStatusSuccess))
 
 			Expect(commandArgs[0:3]).To(Equal([]string{"--json", "-t", "pci/" + pciAddress}))
 		})
 
 		It("does not invoke DMS for an empty batch", func() {
-			Expect(h.SetNvConfigParametersBatch(nvconfigPort(pciAddress), map[string]string{}, true, true)).To(Succeed())
+			status, err := h.SetNvConfigParametersBatch(nvconfigPort(pciAddress), map[string]string{}, true, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).To(Equal(types.ApplyStatusNothingToDo))
 			Expect(fakeExec.CommandCalls).To(BeZero())
+		})
+
+		It("returns nothing-to-do when DMS reports that no reset is required", func() {
+			commandOutput = []byte(`{"status":"ok","requires-reset":false}`)
+
+			status, err := h.SetNvConfigParametersBatch(nvconfigPort(pciAddress), map[string]string{"PARAM": "1"}, true, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).To(Equal(types.ApplyStatusNothingToDo))
 		})
 
 		It("propagates DMS apply failures", func() {
@@ -695,7 +712,8 @@ Result: Device configuration does NOT match the system configuration.
 			commandOutput = []byte(`{"status":"error","error_msg":"DMS apply failed"}`)
 			commandErr = applyErr
 
-			err := h.SetNvConfigParametersBatch(nvconfigPort(pciAddress), map[string]string{"PARAM": "1"}, false, false)
+			status, err := h.SetNvConfigParametersBatch(nvconfigPort(pciAddress), map[string]string{"PARAM": "1"}, false, false)
+			Expect(status).To(Equal(types.ApplyStatusFailed))
 			Expect(err).To(MatchError(ContainSubstring("DMS apply failed")))
 			Expect(errors.Is(err, applyErr)).To(BeTrue())
 		})
@@ -703,7 +721,9 @@ Result: Device configuration does NOT match the system configuration.
 		It("returns an error when the command executor is not initialized", func() {
 			h.execInterface = nil
 
-			Expect(h.SetNvConfigParametersBatch(nvconfigPort(pciAddress), map[string]string{"PARAM": "1"}, false, false)).To(MatchError("command executor must not be nil"))
+			status, err := h.SetNvConfigParametersBatch(nvconfigPort(pciAddress), map[string]string{"PARAM": "1"}, false, false)
+			Expect(status).To(Equal(types.ApplyStatusFailed))
+			Expect(err).To(MatchError("command executor must not be nil"))
 		})
 	})
 })


### PR DESCRIPTION
## Summary

- Make `SetNvConfigParametersBatch` return `types.ApplyStatus`, derived from the DMS NVConfig action's `requires-reset` result.
- With `withDefault`, send supported requested parameters even when their next-boot values already match, allowing DMS to restore unspecified defaults while reporting a true no-op correctly.
- In `force` mode, copy `_P1` values to missing higher ports through `NUM_OF_PF` so breakout-dependent per-port values can be staged in the same batch without overwriting explicit per-port values.
- Preserve the per-port DMS apply flow and the Spectrum-X prepare-plan precondition introduced on current `main`.

## Why This Is Needed

`withDefault` can complete successfully without changing anything. Treating every successful call as an applied update incorrectly reports a reboot requirement. Propagating DMS's `requires-reset` result lets `ApplyNVConfiguration` return `NothingToDo` for that case.

Forced NVConfig apply can also need parameters for ports that are not visible until a `NUM_OF_PF`/breakout change takes effect. Expanding port-1 values to missing higher ports keeps those values in the same forced batch while preserving explicit per-port overrides.

## Validation

- `go test ./pkg/nvconfig/... ./pkg/configuration/... -count=1 -timeout 10m`
- `go build ./...`
- `make lint`
- `make test`
- `git diff --check`

The `network-operator-26.7.x` backport is #439.
