### PR TITLE
feat: expose fwctl devices in port status

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,9 +317,11 @@ status:
    partNumber: mcx632312a-hdat
    ports:
       - networkInterface: enp4s0f0np0
+        fwctlDevice: /dev/fwctl/fwctl0
         pci: "0000:04:00.0"
         rdmaInterface: mlx5_0
       - networkInterface: enp4s0f1np1
+        fwctlDevice: /dev/fwctl/fwctl1
         pci: "0000:04:00.1"
         rdmaInterface: mlx5_1
    psid: mt_0000000225

--- a/api/v1alpha1/nicdevice_types.go
+++ b/api/v1alpha1/nicdevice_types.go
@@ -62,6 +62,10 @@ type NicDeviceSpec struct {
 type NicDevicePortSpec struct {
 	// PCI is a PCI address of the port, e.g. 0000:3b:00.0
 	PCI string `json:"pci"`
+	// FwctlDevice is the fwctl character device path for this port, e.g. /dev/fwctl/fwctl0.
+	// Empty when the host does not expose a fwctl device for this PCI function.
+	// +optional
+	FwctlDevice string `json:"fwctlDevice,omitempty"`
 	// NetworkInterface is the name of the network interface for this port, e.g. eth1
 	NetworkInterface string `json:"networkInterface,omitempty"`
 	// RdmaInterface is the name of the rdma interface for this port, e.g. mlx5_1

--- a/config/crd/bases/configuration.net.nvidia.com_nicdevices.yaml
+++ b/config/crd/bases/configuration.net.nvidia.com_nicdevices.yaml
@@ -470,6 +470,11 @@ spec:
                 items:
                   description: NicDevicePortSpec describes the ports of the NIC
                   properties:
+                    fwctlDevice:
+                      description: |-
+                        FwctlDevice is the fwctl character device path for this port, e.g. /dev/fwctl/fwctl0.
+                        Empty when the host does not expose a fwctl device for this PCI function.
+                      type: string
                     networkInterface:
                       description: NetworkInterface is the name of the network interface
                         for this port, e.g. eth1

--- a/config/samples/configuration.net_v1alpha1_nicdevice.yaml
+++ b/config/samples/configuration.net_v1alpha1_nicdevice.yaml
@@ -36,9 +36,11 @@ status:
   partNumber: mcx632312a-hdat
   ports:
     - networkInterface: enp4s0f0np0
+      fwctlDevice: /dev/fwctl/fwctl0
       pci: "0000:04:00.0"
       rdmaInterface: mlx5_0
     - networkInterface: enp4s0f1np1
+      fwctlDevice: /dev/fwctl/fwctl1
       pci: "0000:04:00.1"
       rdmaInterface: mlx5_1
   psid: mt_0000000225

--- a/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicdevices.yaml
+++ b/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicdevices.yaml
@@ -470,6 +470,11 @@ spec:
                 items:
                   description: NicDevicePortSpec describes the ports of the NIC
                   properties:
+                    fwctlDevice:
+                      description: |-
+                        FwctlDevice is the fwctl character device path for this port, e.g. /dev/fwctl/fwctl0.
+                        Empty when the host does not expose a fwctl device for this PCI function.
+                      type: string
                     networkInterface:
                       description: NetworkInterface is the name of the network interface
                         for this port, e.g. eth1

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -511,6 +511,12 @@ NicDevicePortSpec describes the ports of the NIC
 <td><p>PCI is a PCI address of the port, e.g. 0000:3b:00.0</p></td>
 </tr>
 <tr>
+<td><code>fwctlDevice</code><br />
+<em>string</em></td>
+<td><em>(Optional)</em>
+<p>FwctlDevice is the fwctl character device path for this port, e.g. /dev/fwctl/fwctl0. Empty when the host does not expose a fwctl device for this PCI function.</p></td>
+</tr>
+<tr>
 <td><code>networkInterface</code><br />
 <em>string</em></td>
 <td><p>NetworkInterface is the name of the network interface for this port, e.g. eth1</p></td>
@@ -1362,4 +1368,4 @@ SpectrumXOptimizedSpec enables Spectrum-X specific optimizations
 
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-*Generated with `gen-crd-api-reference-docs` on git commit `f6d99ae`.*
+*Generated with `gen-crd-api-reference-docs` on git commit `85f5e0d`.*

--- a/docs/nic-configuration-library.md
+++ b/docs/nic-configuration-library.md
@@ -350,29 +350,29 @@ Source: `pkg/nvconfig/utils.go`
 ```go
 type NVConfigUtils interface {
     // QueryNvConfig returns default, current, and next-boot configs
-    // additionalParameter: optional specific parameter (e.g., "ESWITCH_HAIRPIN_DESCRIPTORS[0..7]")
-    QueryNvConfig(ctx context.Context, pciAddr string, additionalParameter string) (types.NvConfigQuery, error)
+    // parameters: optional specific parameters (e.g., "ESWITCH_HAIRPIN_DESCRIPTORS[0..7]")
+    QueryNvConfig(ctx context.Context, port v1alpha1.NicDevicePortSpec, parameters []string) (types.NvConfigQuery, error)
 
     // SetNvConfigParameter sets a single NV config parameter
-    SetNvConfigParameter(pciAddr string, paramName string, paramValue string) error
+    SetNvConfigParameter(port v1alpha1.NicDevicePortSpec, paramName string, paramValue string) error
 
     // SetNvConfigParametersBatch sets multiple parameters in single mlxconfig call
     // params: map of paramName → paramValue
     // withDefault: add --with_default flag
     // force: add --force flag
-    SetNvConfigParametersBatch(pciAddr string, params map[string]string, withDefault bool, force bool) error
+    SetNvConfigParametersBatch(port v1alpha1.NicDevicePortSpec, params map[string]string, withDefault bool, force bool) error
 
     // ResetNvConfig resets NIC's NV config to defaults
-    ResetNvConfig(pciAddr string) error
+    ResetNvConfig(port v1alpha1.NicDevicePortSpec) error
 
     // SetSystemConf applies a ConnectX-9 Network Bay system configuration for a single ASIC via
-    // `mlxconfig -d <pci> -y [--force] set_system_conf <conf>[<asic>]` (persistent, reboot-required)
-    SetSystemConf(ctx context.Context, pciAddr string, conf string, asic int, force bool) error
+    // `mlxconfig -d <device> -y [--force] set_system_conf <conf>[<asic>]` (persistent, reboot-required)
+    SetSystemConf(ctx context.Context, port v1alpha1.NicDevicePortSpec, conf string, asic int, force bool) error
 
-    // ValidateSystemConf runs `mlxconfig -d <pci> -y validate_system_conf <conf>[<asic>]` and returns
+    // ValidateSystemConf runs `mlxconfig -d <device> -y validate_system_conf <conf>[<asic>]` and returns
     // the overall match bit plus the names of the mismatched params (the MISMATCH rows), so callers can
     // decide which mismatches are intentional overrides rather than drift.
-    ValidateSystemConf(ctx context.Context, pciAddr string, conf string, asic int) (bool, []string, error)
+    ValidateSystemConf(ctx context.Context, port v1alpha1.NicDevicePortSpec, conf string, asic int) (bool, []string, error)
 }
 ```
 
@@ -383,14 +383,15 @@ func NewNVConfigUtils() NVConfigUtils
 
 **Batch command format:**
 ```
-mlxconfig -d <pci> --yes [--with_default] [--force] set PARAM1=VAL1 PARAM2=VAL2 ...
+mlxconfig -d <device> --yes [--with_default] [--force] set PARAM1=VAL1 PARAM2=VAL2 ...
 ```
 Parameter names are sorted for deterministic command generation.
+`<device>` is `port.FwctlDevice` when discovered, otherwise `port.PCI`.
 
 **System conf command format (ConnectX-9 Network Bay):**
 ```
-mlxconfig -d <pci> -y [--force] set_system_conf <conf>[<asic>]
-mlxconfig -d <pci> -y validate_system_conf <conf>[<asic>]
+mlxconfig -d <device> -y [--force] set_system_conf <conf>[<asic>]
+mlxconfig -d <device> -y validate_system_conf <conf>[<asic>]
 ```
 `ValidateSystemConf` parses the per-param `OK:` / `MISMATCH:` rows plus the `SKIPPED (failed to query:)` list and the trailing `Result:` line, returning the overall match bit and the mismatched param names. The configuration manager uses the mismatched names to treat MISMATCH rows for `rawNvConfig`- or Spectrum-X-owned params as intentional overrides (priority `rawNvConfig` > Spectrum-X > system_conf) rather than drift.
 
@@ -625,6 +626,7 @@ type NicDeviceStatus struct {
 ```go
 type NicDevicePortSpec struct {
     PCI              string // PCI address (e.g., "0000:3b:00.0")
+    FwctlDevice      string // fwctl character device path (e.g., "/dev/fwctl/fwctl0")
     NetworkInterface string // Network interface name (e.g., "eth1")
     RdmaInterface    string // RDMA interface name (e.g., "mlx5_1")
 }

--- a/pkg/configuration/manager.go
+++ b/pkg/configuration/manager.go
@@ -82,7 +82,8 @@ func (h configurationManager) ValidateDeviceNvSpec(ctx context.Context, device *
 		log.Log.Error(err, "failed to query nv configs", "device", device.Name)
 		return false, false, nil, err
 	}
-	firstPortConfig := nvConfigsForPorts[device.Status.Ports[0].PCI]
+	firstPort := device.Status.Ports[0]
+	firstPortConfig := nvConfigsForPorts[firstPort.PCI]
 
 	// 2. Reset-to-default takes precedence over everything else.
 	if device.Spec.Configuration.ResetToDefault {
@@ -202,12 +203,12 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 		log.Log.Error(err, "failed to query nv configs", "device", device.Name)
 		return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
 	}
-	firstPortPCIAddr := device.Status.Ports[0].PCI
-	firstPortConfig := nvConfigsForPorts[firstPortPCIAddr]
+	firstPort := device.Status.Ports[0]
+	firstPortConfig := nvConfigsForPorts[firstPort.PCI]
 
 	// 2. Reset-to-default takes precedence: reset and finish.
 	if device.Spec.Configuration.ResetToDefault {
-		return h.applyResetToDefault(device, firstPortPCIAddr, firstPortConfig)
+		return h.applyResetToDefault(device, firstPort, firstPortConfig)
 	}
 
 	// 3. Network Bay system_conf: the params that don't match the requested named profile.
@@ -255,7 +256,8 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 	//   - force=false: apply only the params visible on this PF whose value differs; params not yet
 	//     visible are skipped this round and picked up after a reboot exposes them (which sequences
 	//     breakout before postBreakout without --force).
-	for pciAddr, nvConfig := range nvConfigsForPorts {
+	for _, port := range device.Status.Ports {
+		nvConfig := nvConfigsForPorts[port.PCI]
 		batch := map[string]string{}
 		if options.Force {
 			// Copy rather than alias desiredParams: it is reused across PF iterations, and the
@@ -278,8 +280,8 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 		if len(batch) == 0 {
 			continue
 		}
-		log.Log.V(2).Info("applying nv config to device", "device", device.Name, "pci", pciAddr, "config", batch, "force", options.Force)
-		if err := h.nvConfigUtils.SetNvConfigParametersBatch(pciAddr, batch, options.WithDefault, options.Force); err != nil {
+		log.Log.V(2).Info("applying nv config to device", "device", device.Name, "pci", port.PCI, "fwctlDevice", port.FwctlDevice, "config", batch, "force", options.Force)
+		if err := h.nvConfigUtils.SetNvConfigParametersBatch(port, batch, options.WithDefault, options.Force); err != nil {
 			log.Log.Error(err, "Failed to apply nv config parameters", "device", device.Name, "params", batch)
 			return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
 		}
@@ -306,10 +308,10 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 func (h configurationManager) setSystemConf(ctx context.Context, device *v1alpha1.NicDevice, options *types.ConfigurationOptions) error {
 	conf := device.Spec.Configuration.Template.NetworkBay.Conf
 	asic := device.Status.NetworkBay.Asic
-	pci := device.Status.Ports[0].PCI
+	port := device.Status.Ports[0]
 
 	log.Log.Info("applying Network Bay system_conf", "device", device.Name, "conf", conf, "asic", asic)
-	if err := h.nvConfigUtils.SetSystemConf(ctx, pci, conf, asic, options.Force); err != nil {
+	if err := h.nvConfigUtils.SetSystemConf(ctx, port, conf, asic, options.Force); err != nil {
 		log.Log.Error(err, "failed to apply system_conf", "device", device.Name)
 		return err
 	}
@@ -317,11 +319,11 @@ func (h configurationManager) setSystemConf(ctx context.Context, device *v1alpha
 }
 
 // applyResetToDefault resets NV config to defaults, preserving BF3 operation mode
-func (h configurationManager) applyResetToDefault(device *v1alpha1.NicDevice, pciAddr string, portConfig types.NvConfigQuery) (*types.ConfigurationApplyResult, error) {
+func (h configurationManager) applyResetToDefault(device *v1alpha1.NicDevice, port v1alpha1.NicDevicePortSpec, portConfig types.NvConfigQuery) (*types.ConfigurationApplyResult, error) {
 	log.Log.Info("resetting nv config to default", "device", device.Name)
 	bf3OperationModeValue, isBF3device := portConfig.CurrentConfig[consts.BF3OperationModeParam]
 
-	err := h.nvConfigUtils.ResetNvConfig(pciAddr)
+	err := h.nvConfigUtils.ResetNvConfig(port)
 	if err != nil {
 		log.Log.Error(err, "Failed to reset nv config", "device", device.Name)
 		return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
@@ -338,7 +340,7 @@ func (h configurationManager) applyResetToDefault(device *v1alpha1.NicDevice, pc
 			mode = "NIC"
 		}
 		log.Log.Info(fmt.Sprintf("The device %s is the BlueField-3, restoring the previous mode of operation (%s mode) after configuration reset", device.Name, mode))
-		err = h.nvConfigUtils.SetNvConfigParameter(pciAddr, consts.BF3OperationModeParam, val)
+		err = h.nvConfigUtils.SetNvConfigParameter(port, consts.BF3OperationModeParam, val)
 		if err != nil {
 			log.Log.Error(err, "Failed to restore the BlueField device mode of operation", "device", device.Name, "mode", mode, "param", consts.BF3OperationModeParam, "value", val)
 			return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
@@ -569,9 +571,9 @@ func (h configurationManager) systemConfMismatchedParams(ctx context.Context, de
 
 	conf := device.Spec.Configuration.Template.NetworkBay.Conf
 	asic := device.Status.NetworkBay.Asic
-	pci := device.Status.Ports[0].PCI
+	port := device.Status.Ports[0]
 
-	matches, mismatched, err := h.nvConfigUtils.ValidateSystemConf(ctx, pci, conf, asic)
+	matches, mismatched, err := h.nvConfigUtils.ValidateSystemConf(ctx, port, conf, asic)
 	if err != nil {
 		log.Log.Error(err, "failed to validate system_conf", "device", device.Name)
 		return nil, err
@@ -588,12 +590,11 @@ func (h configurationManager) systemConfMismatchedParams(ctx context.Context, de
 func (h configurationManager) queryNvConfigs(ctx context.Context, device *v1alpha1.NicDevice) (map[string]types.NvConfigQuery, error) {
 	nvConfigs := make(map[string]types.NvConfigQuery)
 	for _, port := range device.Status.Ports {
-		pciAddr := port.PCI
-		nvConfig, err := h.nvConfigUtils.QueryNvConfig(ctx, pciAddr, nil)
+		nvConfig, err := h.nvConfigUtils.QueryNvConfig(ctx, port, nil)
 		if err != nil {
 			return nil, err
 		}
-		nvConfigs[pciAddr] = nvConfig
+		nvConfigs[port.PCI] = nvConfig
 	}
 	return nvConfigs, nil
 }

--- a/pkg/configuration/manager_test.go
+++ b/pkg/configuration/manager_test.go
@@ -34,6 +34,10 @@ import (
 const pciAddress = "0000:3b:00.0"
 const pciAddress2 = "0000:3b:00.1"
 
+func portSpec(pciAddr string) v1alpha1.NicDevicePortSpec {
+	return v1alpha1.NicDevicePortSpec{PCI: pciAddr}
+}
+
 // okSystemConf stubs a matching validate_system_conf result (no mismatched params). Spread into a
 // mock .Return(...) call: mockNV.On("ValidateSystemConf", ...).Return(okSystemConf()...).
 func okSystemConf() []interface{} {
@@ -87,7 +91,7 @@ var _ = Describe("ConfigurationManager", func() {
 			Context("when QueryNvConfig returns an error", func() {
 				It("should return false, false, and the error", func() {
 					queryErr := errors.New("failed to query nv config")
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).
 						Return(types.NewNvConfigQuery(), queryErr)
 
 					configUpdate, reboot, _, err := manager.ValidateDeviceNvSpec(ctx, device)
@@ -111,7 +115,7 @@ var _ = Describe("ConfigurationManager", func() {
 						DefaultConfig:  map[string][]string{"param1": {"default1"}},
 					}
 
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).
 						Return(nvConfig, nil)
 					mockConfigValidation.On("ValidateResetToDefault", nvConfig).
 						Return(true, false, nil)
@@ -133,7 +137,7 @@ var _ = Describe("ConfigurationManager", func() {
 					}
 					validationErr := errors.New("validation failed")
 
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).
 						Return(nvConfig, nil)
 					mockConfigValidation.On("ValidateResetToDefault", nvConfig).
 						Return(false, false, validationErr)
@@ -157,7 +161,7 @@ var _ = Describe("ConfigurationManager", func() {
 					}
 					constructErr := errors.New("failed to construct desired config")
 
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).
 						Return(nvConfig, nil)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 						Return(nil, constructErr)
@@ -182,7 +186,7 @@ var _ = Describe("ConfigurationManager", func() {
 					}
 					desiredConfig := map[string]string{"param1": "value1", "param2": "value2"}
 
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).
 						Return(nvConfig, nil)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 						Return(desiredConfig, nil)
@@ -207,7 +211,7 @@ var _ = Describe("ConfigurationManager", func() {
 					}
 					desiredConfig := map[string]string{"param1": "value1", "param2": "value2"}
 
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).
 						Return(nvConfig, nil)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 						Return(desiredConfig, nil)
@@ -232,7 +236,7 @@ var _ = Describe("ConfigurationManager", func() {
 					}
 					desiredConfig := map[string]string{"param1": "value1", "param2": "value2"}
 
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).
 						Return(nvConfig, nil)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 						Return(desiredConfig, nil)
@@ -256,7 +260,7 @@ var _ = Describe("ConfigurationManager", func() {
 					}
 					desiredConfig := map[string]string{"param1": "value1", "param2": "value2"}
 
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).
 						Return(nvConfig, nil)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 						Return(desiredConfig, nil)
@@ -281,7 +285,7 @@ var _ = Describe("ConfigurationManager", func() {
 					// param1 is hidden on this device (e.g. ADVANCED_PCI_SETTINGS off)
 					desiredConfig := map[string]string{"param1": "value1", "param2": "value2"}
 
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).
 						Return(nvConfig, nil)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 						Return(desiredConfig, nil)
@@ -305,7 +309,7 @@ var _ = Describe("ConfigurationManager", func() {
 					// param1 is unsupported; param2 needs to change
 					desiredConfig := map[string]string{"param1": "value1", "param2": "value2"}
 
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).
 						Return(nvConfig, nil)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 						Return(desiredConfig, nil)
@@ -330,7 +334,7 @@ var _ = Describe("ConfigurationManager", func() {
 					}
 					desiredConfig := map[string]string{"param1": "value1", "param2": "2"}
 
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).
 						Return(nvConfig, nil)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 						Return(desiredConfig, nil)
@@ -351,7 +355,7 @@ var _ = Describe("ConfigurationManager", func() {
 					}
 					desiredConfig := map[string]string{"param1": "VaLuE1", "param2": "valUE2"}
 
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).
 						Return(nvConfig, nil)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 						Return(desiredConfig, nil)
@@ -372,7 +376,7 @@ var _ = Describe("ConfigurationManager", func() {
 					}
 					desiredConfig := map[string]string{"param1": "value3", "param2": "val4"}
 
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).
 						Return(nvConfig, nil)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 						Return(desiredConfig, nil)
@@ -405,8 +409,8 @@ var _ = Describe("ConfigurationManager", func() {
 						DefaultConfig:  map[string][]string{},
 					}
 
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig0, nil)
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress2, []string(nil)).Return(nvConfig1, nil)
+					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(nvConfig0, nil)
+					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress2), []string(nil)).Return(nvConfig1, nil)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig0).Return(map[string]string{"TRACER_ENABLED": "1"}, nil)
 
 					configUpdate, reboot, _, err := manager.ValidateDeviceNvSpec(ctx, device)
@@ -432,8 +436,8 @@ var _ = Describe("ConfigurationManager", func() {
 						DefaultConfig:  map[string][]string{},
 					}
 
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig0, nil)
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress2, []string(nil)).Return(nvConfig1, nil)
+					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(nvConfig0, nil)
+					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress2), []string(nil)).Return(nvConfig1, nil)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig0).Return(map[string]string{"TRACER_ENABLED": "1"}, nil)
 
 					configUpdate, reboot, _, err := manager.ValidateDeviceNvSpec(ctx, device)
@@ -459,8 +463,8 @@ var _ = Describe("ConfigurationManager", func() {
 						DefaultConfig:  map[string][]string{},
 					}
 
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig0, nil)
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress2, []string(nil)).Return(nvConfig1, nil)
+					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(nvConfig0, nil)
+					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress2), []string(nil)).Return(nvConfig1, nil)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig0).Return(map[string]string{"TRACER_ENABLED": "1"}, nil)
 
 					configUpdate, reboot, _, err := manager.ValidateDeviceNvSpec(ctx, device)
@@ -522,12 +526,12 @@ var _ = Describe("ConfigurationManager", func() {
 						NextBootConfig: map[string][]string{"param1": {"value1"}},
 						DefaultConfig:  map[string][]string{"param1": {"default1"}},
 					}
-					mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+					mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).
 						Return(nvConfig, nil)
 
-					mockNV.On("ResetNvConfig", pciAddress).Return(nil)
-					mockNV.AssertNotCalled(GinkgoT(), "SetNvConfigParameter", pciAddress, consts.BF3OperationModeParam, mock.Anything)
-					mockNV.AssertNotCalled(GinkgoT(), "SetNvConfigParameter", pciAddress, consts.AdvancedPCISettingsParam, mock.Anything)
+					mockNV.On("ResetNvConfig", portSpec(pciAddress)).Return(nil)
+					mockNV.AssertNotCalled(GinkgoT(), "SetNvConfigParameter", portSpec(pciAddress), consts.BF3OperationModeParam, mock.Anything)
+					mockNV.AssertNotCalled(GinkgoT(), "SetNvConfigParameter", portSpec(pciAddress), consts.AdvancedPCISettingsParam, mock.Anything)
 
 					result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 					Expect(result.RebootRequired).To(BeTrue())
@@ -542,15 +546,15 @@ var _ = Describe("ConfigurationManager", func() {
 						NextBootConfig: map[string][]string{consts.BF3OperationModeParam: {consts.NvParamBF3DpuMode}},
 						DefaultConfig:  map[string][]string{consts.BF3OperationModeParam: {consts.NvParamBF3DpuMode}},
 					}
-					mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+					mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).
 						Return(nvConfig, nil)
 
-					mockNV.On("ResetNvConfig", pciAddress).Return(nil)
+					mockNV.On("ResetNvConfig", portSpec(pciAddress)).Return(nil)
 					mockNV.
-						On("SetNvConfigParameter", pciAddress, consts.BF3OperationModeParam, consts.NvParamBF3NicMode).
+						On("SetNvConfigParameter", portSpec(pciAddress), consts.BF3OperationModeParam, consts.NvParamBF3NicMode).
 						Return(nil)
-					mockNV.AssertNotCalled(GinkgoT(), "SetNvConfigParameter", pciAddress, consts.BF3OperationModeParam, consts.NvParamBF3DpuMode)
-					mockNV.AssertNotCalled(GinkgoT(), "SetNvConfigParameter", pciAddress, consts.AdvancedPCISettingsParam, mock.Anything)
+					mockNV.AssertNotCalled(GinkgoT(), "SetNvConfigParameter", portSpec(pciAddress), consts.BF3OperationModeParam, consts.NvParamBF3DpuMode)
+					mockNV.AssertNotCalled(GinkgoT(), "SetNvConfigParameter", portSpec(pciAddress), consts.AdvancedPCISettingsParam, mock.Anything)
 
 					result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 					Expect(result.RebootRequired).To(BeTrue())
@@ -565,11 +569,11 @@ var _ = Describe("ConfigurationManager", func() {
 						NextBootConfig: map[string][]string{"param1": {"value1"}},
 						DefaultConfig:  map[string][]string{"param1": {"default1"}},
 					}
-					mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+					mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).
 						Return(nvConfig, nil)
 
 					resetErr := errors.New("failed to reset nv config")
-					mockNV.On("ResetNvConfig", pciAddress).Return(resetErr)
+					mockNV.On("ResetNvConfig", portSpec(pciAddress)).Return(resetErr)
 
 					result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 					Expect(result.RebootRequired).To(BeFalse())
@@ -584,13 +588,13 @@ var _ = Describe("ConfigurationManager", func() {
 						NextBootConfig: map[string][]string{consts.BF3OperationModeParam: {consts.NvParamBF3DpuMode}},
 						DefaultConfig:  map[string][]string{consts.BF3OperationModeParam: {consts.NvParamBF3DpuMode}},
 					}
-					mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+					mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).
 						Return(nvConfig, nil)
 
-					mockNV.On("ResetNvConfig", pciAddress).Return(nil)
+					mockNV.On("ResetNvConfig", portSpec(pciAddress)).Return(nil)
 					setParamErr := errors.New("failed to set nv config parameter")
 					mockNV.
-						On("SetNvConfigParameter", pciAddress, consts.BF3OperationModeParam, consts.NvParamBF3NicMode).
+						On("SetNvConfigParameter", portSpec(pciAddress), consts.BF3OperationModeParam, consts.NvParamBF3NicMode).
 						Return(setParamErr)
 
 					result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
@@ -605,7 +609,7 @@ var _ = Describe("ConfigurationManager", func() {
 				Context("when QueryNvConfig returns an error", func() {
 					It("should return false and the error", func() {
 						queryErr := errors.New("failed to query nv config")
-						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(types.NewNvConfigQuery(), queryErr)
+						mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(types.NewNvConfigQuery(), queryErr)
 
 						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 						Expect(result.RebootRequired).To(BeFalse())
@@ -624,7 +628,7 @@ var _ = Describe("ConfigurationManager", func() {
 						}
 						desiredConfig := map[string]string{"param1": "value1"}
 
-						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+						mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).
 							Return(nvConfig, nil)
 						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 							Return(desiredConfig, nil)
@@ -645,11 +649,11 @@ var _ = Describe("ConfigurationManager", func() {
 						}
 						desiredConfig := map[string]string{"param1": "value2"}
 
-						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+						mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).
 							Return(nvConfig, nil)
 						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 							Return(desiredConfig, nil)
-						mockNV.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"param1": "value2"}, false, false).
+						mockNV.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"param1": "value2"}, false, false).
 							Return(nil)
 
 						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
@@ -668,7 +672,7 @@ var _ = Describe("ConfigurationManager", func() {
 						}
 						constructErr := errors.New("failed to construct desired config")
 
-						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+						mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).
 							Return(nvConfig, nil)
 						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 							Return(nil, constructErr)
@@ -689,7 +693,7 @@ var _ = Describe("ConfigurationManager", func() {
 						}
 						desiredConfig := map[string]string{"param1": "value1", "param2": "value2"}
 
-						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+						mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).
 							Return(nvConfig, nil)
 						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 							Return(desiredConfig, nil)
@@ -711,12 +715,12 @@ var _ = Describe("ConfigurationManager", func() {
 						}
 						desiredConfig := map[string]string{"param1": "value3"}
 
-						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+						mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).
 							Return(nvConfig, nil)
 						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 							Return(desiredConfig, nil)
 						setParamErr := errors.New("failed to set param1")
-						mockNV.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"param1": "value3"}, false, false).
+						mockNV.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"param1": "value3"}, false, false).
 							Return(setParamErr)
 
 						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
@@ -744,11 +748,11 @@ var _ = Describe("ConfigurationManager", func() {
 							DefaultConfig:  map[string][]string{},
 						}
 
-						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig0, nil)
-						mockNV.On("QueryNvConfig", ctx, pciAddress2, []string(nil)).Return(nvConfig1, nil)
+						mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(nvConfig0, nil)
+						mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress2), []string(nil)).Return(nvConfig1, nil)
 						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig0).Return(map[string]string{"TRACER_ENABLED": "1"}, nil)
 						// Only port2 should be updated
-						mockNV.On("SetNvConfigParametersBatch", pciAddress2, map[string]string{"TRACER_ENABLED": "1"}, false, false).Return(nil)
+						mockNV.On("SetNvConfigParametersBatch", portSpec(pciAddress2), map[string]string{"TRACER_ENABLED": "1"}, false, false).Return(nil)
 
 						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 						Expect(err).To(BeNil())
@@ -772,8 +776,8 @@ var _ = Describe("ConfigurationManager", func() {
 							DefaultConfig:  map[string][]string{},
 						}
 
-						mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig0, nil)
-						mockNV.On("QueryNvConfig", ctx, pciAddress2, []string(nil)).Return(nvConfig1, nil)
+						mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(nvConfig0, nil)
+						mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress2), []string(nil)).Return(nvConfig1, nil)
 						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig0).Return(map[string]string{"TRACER_ENABLED": "1"}, nil)
 
 						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
@@ -796,11 +800,11 @@ var _ = Describe("ConfigurationManager", func() {
 					}
 					desiredConfig := map[string]string{"param1": "newValue3", "param2": "newValue3"}
 
-					mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+					mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).
 						Return(nvConfig, nil)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 						Return(desiredConfig, nil)
-					mockNV.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"param1": "newValue3", "param2": "newValue3"}, false, false).
+					mockNV.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"param1": "newValue3", "param2": "newValue3"}, false, false).
 						Return(nil)
 
 					result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
@@ -821,7 +825,7 @@ var _ = Describe("ConfigurationManager", func() {
 					}
 					desiredConfig := map[string]string{"param1": "value1"}
 
-					mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).
+					mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).
 						Return(nvConfig, nil)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 						Return(desiredConfig, nil)
@@ -1226,7 +1230,7 @@ var _ = Describe("ConfigurationManager", func() {
 			// next-boot config — the same source the apply path uses. These tests mock the combined map
 			// directly; the merge/expansion/priority itself is covered in the configValidation suite.
 			It("requires update+reboot when a combined param mismatches next boot", func() {
-				mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(
+				mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(
 					types.NvConfigQuery{NextBootConfig: map[string][]string{"NUM_OF_PF": {"1"}}}, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(map[string]string{"NUM_OF_PF": "2"}, nil)
@@ -1239,7 +1243,7 @@ var _ = Describe("ConfigurationManager", func() {
 
 			It("requires no update when every combined param matches next boot and current", func() {
 				matched := map[string][]string{"NUM_OF_PF": {"2"}, "LINK_TYPE_P1": {"2"}}
-				mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(
+				mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(
 					types.NvConfigQuery{NextBootConfig: matched, CurrentConfig: matched}, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(map[string]string{"NUM_OF_PF": "2", "LINK_TYPE_P1": "2"}, nil)
@@ -1253,7 +1257,7 @@ var _ = Describe("ConfigurationManager", func() {
 			It("requires reboot (not update) when a param is staged for next boot but not yet current", func() {
 				// Regression for the staged-not-rebooted case: next boot already has the desired value but
 				// current does not, so we must report RebootRequired, not loop with NothingToDo.
-				mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(
+				mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(
 					types.NvConfigQuery{
 						NextBootConfig: map[string][]string{"NUM_OF_PF": {"2"}},
 						CurrentConfig:  map[string][]string{"NUM_OF_PF": {"1"}},
@@ -1268,7 +1272,7 @@ var _ = Describe("ConfigurationManager", func() {
 			})
 
 			It("returns the error when ConstructNvParamMapFromTemplate fails", func() {
-				mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(types.NvConfigQuery{}, nil)
+				mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(types.NvConfigQuery{}, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(nil, errors.New("config not found"))
 
@@ -1285,9 +1289,9 @@ var _ = Describe("ConfigurationManager", func() {
 
 				It("does not flag drift when every system_conf mismatch is covered by a combined override param", func() {
 					matched := map[string][]string{"NUM_OF_PF": {"2"}}
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(
+					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(
 						types.NvConfigQuery{NextBootConfig: matched, CurrentConfig: matched}, nil)
-					mockNVConfigUtils.On("ValidateSystemConf", ctx, pciAddress, "conf3", 0).
+					mockNVConfigUtils.On("ValidateSystemConf", ctx, portSpec(pciAddress), "conf3", 0).
 						Return(mismatchSystemConf("NUM_OF_PF")...)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 						Return(map[string]string{"NUM_OF_PF": "2"}, nil)
@@ -1300,9 +1304,9 @@ var _ = Describe("ConfigurationManager", func() {
 
 				It("flags drift when a system_conf mismatch is covered by no combined override param", func() {
 					matched := map[string][]string{"NUM_OF_PF": {"2"}}
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(
+					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(
 						types.NvConfigQuery{NextBootConfig: matched, CurrentConfig: matched}, nil)
-					mockNVConfigUtils.On("ValidateSystemConf", ctx, pciAddress, "conf3", 0).
+					mockNVConfigUtils.On("ValidateSystemConf", ctx, portSpec(pciAddress), "conf3", 0).
 						Return(mismatchSystemConf("BOARD_CONFIGURATION_MODE")...)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 						Return(map[string]string{"NUM_OF_PF": "2"}, nil)
@@ -1324,9 +1328,9 @@ var _ = Describe("ConfigurationManager", func() {
 						"MODULE_SPLIT_M0[0]": {"1"}, "MODULE_SPLIT_M0[1]": {"1"},
 						"MODULE_SPLIT_M0[2]": {"0"}, "MODULE_SPLIT_M0[3]": {"1"},
 					}
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(
+					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(
 						types.NvConfigQuery{NextBootConfig: nextBoot, CurrentConfig: nextBoot}, nil)
-					mockNVConfigUtils.On("ValidateSystemConf", ctx, pciAddress, "conf3", 0).
+					mockNVConfigUtils.On("ValidateSystemConf", ctx, portSpec(pciAddress), "conf3", 0).
 						Return(mismatchSystemConf("MODULE_SPLIT_M0[0]", "MODULE_SPLIT_M0[1]", "MODULE_SPLIT_M0[2]", "MODULE_SPLIT_M0[3]")...)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).Return(expanded, nil)
 
@@ -1345,9 +1349,9 @@ var _ = Describe("ConfigurationManager", func() {
 						"MODULE_SPLIT_M0[0]": "1", "MODULE_SPLIT_M0[1]": "1",
 						"MODULE_SPLIT_M0[2]": "1", "MODULE_SPLIT_M0[3]": "1",
 					}
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(
+					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(
 						types.NvConfigQuery{NextBootConfig: matched, CurrentConfig: matched}, nil)
-					mockNVConfigUtils.On("ValidateSystemConf", ctx, pciAddress, "conf3", 0).
+					mockNVConfigUtils.On("ValidateSystemConf", ctx, portSpec(pciAddress), "conf3", 0).
 						Return(mismatchSystemConf("MODULE_SPLIT_M0[0]", "MODULE_SPLIT_M0[1]", "MODULE_SPLIT_M0[2]", "MODULE_SPLIT_M0[3]")...)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).Return(expanded, nil)
 
@@ -1362,12 +1366,12 @@ var _ = Describe("ConfigurationManager", func() {
 
 		Describe("ApplyNVConfiguration", func() {
 			It("force=false applies the combined params present in the query that differ", func() {
-				mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(
+				mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(
 					types.NvConfigQuery{NextBootConfig: map[string][]string{"NUM_OF_PF": {"1"}, "LINK_TYPE_P1": {"2"}}}, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(map[string]string{"NUM_OF_PF": "2", "LINK_TYPE_P1": "2"}, nil)
 				// NUM_OF_PF differs (1 != 2) and is applied; LINK_TYPE_P1 already matches and is skipped.
-				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"NUM_OF_PF": "2"}, false, false).Return(nil)
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, false, false).Return(nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 				Expect(err).NotTo(HaveOccurred())
@@ -1375,10 +1379,10 @@ var _ = Describe("ConfigurationManager", func() {
 			})
 
 			It("force=true applies all combined params in a single --force batch", func() {
-				mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(types.NvConfigQuery{}, nil)
+				mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(types.NvConfigQuery{}, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(map[string]string{"NUM_OF_PF": "2", "LINK_TYPE_P1": "2"}, nil)
-				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress,
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress),
 					map[string]string{"NUM_OF_PF": "2", "LINK_TYPE_P1": "2"}, false, true).Return(nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{Force: true})
@@ -1388,25 +1392,25 @@ var _ = Describe("ConfigurationManager", func() {
 
 			It("force=true applies the batch to every PF, not just the first", func() {
 				device.Status.Ports = []v1alpha1.NicDevicePortSpec{{PCI: pciAddress}, {PCI: pciAddress2}}
-				mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(types.NvConfigQuery{}, nil)
-				mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress2, []string(nil)).Return(types.NvConfigQuery{}, nil)
+				mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(types.NvConfigQuery{}, nil)
+				mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress2), []string(nil)).Return(types.NvConfigQuery{}, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(map[string]string{"NUM_OF_PF": "2"}, nil)
-				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"NUM_OF_PF": "2"}, false, true).Return(nil)
-				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress2, map[string]string{"NUM_OF_PF": "2"}, false, true).Return(nil)
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, false, true).Return(nil)
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress2), map[string]string{"NUM_OF_PF": "2"}, false, true).Return(nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{Force: true})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.RebootRequired).To(BeTrue())
-				mockNVConfigUtils.AssertCalled(GinkgoT(), "SetNvConfigParametersBatch", pciAddress2, map[string]string{"NUM_OF_PF": "2"}, false, true)
+				mockNVConfigUtils.AssertCalled(GinkgoT(), "SetNvConfigParametersBatch", portSpec(pciAddress2), map[string]string{"NUM_OF_PF": "2"}, false, true)
 			})
 
 			It("propagates WithDefault=true to the combined batch", func() {
-				mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(
+				mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(
 					types.NvConfigQuery{NextBootConfig: map[string][]string{"NUM_OF_PF": {"1"}}}, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(map[string]string{"NUM_OF_PF": "2"}, nil)
-				mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"NUM_OF_PF": "2"}, true, false).Return(nil)
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, true, false).Return(nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{WithDefault: true})
 				Expect(err).NotTo(HaveOccurred())
@@ -1414,7 +1418,7 @@ var _ = Describe("ConfigurationManager", func() {
 			})
 
 			It("returns NothingToDo when the combined params already match", func() {
-				mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(
+				mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(
 					types.NvConfigQuery{NextBootConfig: map[string][]string{"NUM_OF_PF": {"2"}}}, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(map[string]string{"NUM_OF_PF": "2"}, nil)
@@ -1426,7 +1430,7 @@ var _ = Describe("ConfigurationManager", func() {
 			})
 
 			It("returns error when ConstructNvParamMapFromTemplate fails", func() {
-				mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(types.NvConfigQuery{}, nil)
+				mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(types.NvConfigQuery{}, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(nil, errors.New("config not found"))
 
@@ -1442,13 +1446,13 @@ var _ = Describe("ConfigurationManager", func() {
 				})
 
 				It("applies set_system_conf when the combined params do not cover a mismatch", func() {
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(types.NvConfigQuery{}, nil)
-					mockNVConfigUtils.On("ValidateSystemConf", ctx, pciAddress, "conf3", 0).
+					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(types.NvConfigQuery{}, nil)
+					mockNVConfigUtils.On("ValidateSystemConf", ctx, portSpec(pciAddress), "conf3", 0).
 						Return(mismatchSystemConf("BOARD_CONFIGURATION_MODE")...)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 						Return(map[string]string{"NUM_OF_PF": "2"}, nil)
-					mockNVConfigUtils.On("SetSystemConf", ctx, pciAddress, "conf3", 0, true).Return(nil)
-					mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"NUM_OF_PF": "2"}, false, true).Return(nil)
+					mockNVConfigUtils.On("SetSystemConf", ctx, portSpec(pciAddress), "conf3", 0, true).Return(nil)
+					mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, false, true).Return(nil)
 
 					result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{Force: true})
 					Expect(err).NotTo(HaveOccurred())
@@ -1456,12 +1460,12 @@ var _ = Describe("ConfigurationManager", func() {
 				})
 
 				It("does not apply set_system_conf when the combined params cover all mismatches", func() {
-					mockNVConfigUtils.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(types.NvConfigQuery{}, nil)
-					mockNVConfigUtils.On("ValidateSystemConf", ctx, pciAddress, "conf3", 0).
+					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(types.NvConfigQuery{}, nil)
+					mockNVConfigUtils.On("ValidateSystemConf", ctx, portSpec(pciAddress), "conf3", 0).
 						Return(mismatchSystemConf("NUM_OF_PF")...)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 						Return(map[string]string{"NUM_OF_PF": "2"}, nil)
-					mockNVConfigUtils.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"NUM_OF_PF": "2"}, false, true).Return(nil)
+					mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, false, true).Return(nil)
 					mockNVConfigUtils.AssertNotCalled(GinkgoT(), "SetSystemConf", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 
 					result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{Force: true})
@@ -1519,9 +1523,9 @@ var _ = Describe("ConfigurationManager", func() {
 			It("requires update+reboot when system_conf has an unexplained mismatch", func() {
 				// system_conf mismatched params are gathered first, then checked against the desired
 				// (template + rawNvConfig) config — empty here, so BOARD_CONFIGURATION_MODE is uncovered drift.
-				mockNV.On("ValidateSystemConf", ctx, pciAddress, "conf3", 0).
+				mockNV.On("ValidateSystemConf", ctx, portSpec(pciAddress), "conf3", 0).
 					Return(mismatchSystemConf("BOARD_CONFIGURATION_MODE")...)
-				mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig, nil)
+				mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(nvConfig, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 					Return(map[string]string{}, nil)
 
@@ -1532,9 +1536,9 @@ var _ = Describe("ConfigurationManager", func() {
 			})
 
 			It("fails closed when validate_system_conf reports a mismatch but no MISMATCH rows are parsed", func() {
-				mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig, nil)
+				mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(nvConfig, nil)
 				// Result says NOT match, but no recognized MISMATCH rows — must not look like a match.
-				mockNV.On("ValidateSystemConf", ctx, pciAddress, "conf3", 0).
+				mockNV.On("ValidateSystemConf", ctx, portSpec(pciAddress), "conf3", 0).
 					Return(false, []string(nil), nil)
 
 				_, _, _, err := manager.ValidateDeviceNvSpec(ctx, device)
@@ -1542,9 +1546,9 @@ var _ = Describe("ConfigurationManager", func() {
 			})
 
 			It("requires nothing when both regular config and system_conf match", func() {
-				mockNV.On("ValidateSystemConf", ctx, pciAddress, "conf3", 0).
+				mockNV.On("ValidateSystemConf", ctx, portSpec(pciAddress), "conf3", 0).
 					Return(okSystemConf()...)
-				mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig, nil)
+				mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(nvConfig, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 					Return(map[string]string{}, nil)
 
@@ -1563,9 +1567,9 @@ var _ = Describe("ConfigurationManager", func() {
 					NextBootConfig: map[string][]string{"NUM_OF_PF": {"8"}},
 					DefaultConfig:  map[string][]string{"NUM_OF_PF": {"1"}},
 				}
-				mockNV.On("ValidateSystemConf", ctx, pciAddress, "conf3", 0).
+				mockNV.On("ValidateSystemConf", ctx, portSpec(pciAddress), "conf3", 0).
 					Return(mismatchSystemConf("NUM_OF_PF")...)
-				mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(portConfig, nil)
+				mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(portConfig, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, portConfig).
 					Return(map[string]string{"NUM_OF_PF": "8"}, nil)
 
@@ -1580,7 +1584,7 @@ var _ = Describe("ConfigurationManager", func() {
 				// same device — otherwise it would re-stage and get wiped every reconcile. validate_system_conf
 				// must not be called; the reset validation path runs instead.
 				device.Spec.Configuration.ResetToDefault = true
-				mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig, nil)
+				mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(nvConfig, nil)
 				mockConfigValidation.On("ValidateResetToDefault", nvConfig).Return(false, false, nil)
 				mockNV.AssertNotCalled(GinkgoT(), "ValidateSystemConf", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 
@@ -1595,12 +1599,12 @@ var _ = Describe("ConfigurationManager", func() {
 			// Apply checks system_conf coverage: it stages set_system_conf only when the combined override
 			// params do not cover every mismatched profile param.
 			It("stages set_system_conf when the combined params do not cover a mismatch", func() {
-				mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig, nil)
-				mockNV.On("ValidateSystemConf", ctx, pciAddress, "conf3", 0).
+				mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(nvConfig, nil)
+				mockNV.On("ValidateSystemConf", ctx, portSpec(pciAddress), "conf3", 0).
 					Return(mismatchSystemConf("BOARD_CONFIGURATION_MODE")...)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 					Return(map[string]string{}, nil)
-				mockNV.On("SetSystemConf", ctx, pciAddress, "conf3", 0, false).Return(nil)
+				mockNV.On("SetSystemConf", ctx, portSpec(pciAddress), "conf3", 0, false).Return(nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 				Expect(err).NotTo(HaveOccurred())
@@ -1609,12 +1613,12 @@ var _ = Describe("ConfigurationManager", func() {
 			})
 
 			It("passes --force to set_system_conf when Force is set", func() {
-				mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig, nil)
-				mockNV.On("ValidateSystemConf", ctx, pciAddress, "conf3", 0).
+				mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(nvConfig, nil)
+				mockNV.On("ValidateSystemConf", ctx, portSpec(pciAddress), "conf3", 0).
 					Return(mismatchSystemConf("BOARD_CONFIGURATION_MODE")...)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 					Return(map[string]string{}, nil)
-				mockNV.On("SetSystemConf", ctx, pciAddress, "conf3", 0, true).Return(nil)
+				mockNV.On("SetSystemConf", ctx, portSpec(pciAddress), "conf3", 0, true).Return(nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{Force: true})
 				Expect(err).NotTo(HaveOccurred())
@@ -1627,14 +1631,14 @@ var _ = Describe("ConfigurationManager", func() {
 					NextBootConfig: map[string][]string{"param1": {"value1"}},
 					DefaultConfig:  map[string][]string{"param1": {"default1"}},
 				}
-				mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(portConfig, nil)
-				mockNV.On("ValidateSystemConf", ctx, pciAddress, "conf3", 0).
+				mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(portConfig, nil)
+				mockNV.On("ValidateSystemConf", ctx, portSpec(pciAddress), "conf3", 0).
 					Return(mismatchSystemConf("BOARD_CONFIGURATION_MODE")...)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, portConfig).
 					Return(map[string]string{"param1": "value2"}, nil)
-				setSystemConfCall := mockNV.On("SetSystemConf", ctx, pciAddress, "conf3", 0, false).Return(nil)
+				setSystemConfCall := mockNV.On("SetSystemConf", ctx, portSpec(pciAddress), "conf3", 0, false).Return(nil)
 				// set_system_conf is the baseline and must be staged before the override batch.
-				mockNV.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"param1": "value2"}, false, false).
+				mockNV.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"param1": "value2"}, false, false).
 					Return(nil).NotBefore(setSystemConfCall)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
@@ -1645,8 +1649,8 @@ var _ = Describe("ConfigurationManager", func() {
 			It("resets and never touches system_conf when ResetToDefault is set", func() {
 				// Guards against the reset/set_system_conf reboot loop: reset runs, set_system_conf does not.
 				device.Spec.Configuration.ResetToDefault = true
-				mockNV.On("QueryNvConfig", ctx, pciAddress, []string(nil)).Return(nvConfig, nil)
-				mockNV.On("ResetNvConfig", pciAddress).Return(nil)
+				mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(nvConfig, nil)
+				mockNV.On("ResetNvConfig", portSpec(pciAddress)).Return(nil)
 				mockNV.AssertNotCalled(GinkgoT(), "SetSystemConf", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
@@ -1710,9 +1714,9 @@ var _ = Describe("ConfigurationManager", func() {
 			// 1) system_conf valid, no overrides → nothing to do, no set_system_conf.
 			It("1: valid system_conf with no overrides converges without applying anything", func() {
 				staged := sriovStaged(nil)
-				fullFlowNV.On("QueryNvConfig", fullFlowCtx, pciAddress, []string(nil)).Return(
+				fullFlowNV.On("QueryNvConfig", fullFlowCtx, portSpec(pciAddress), []string(nil)).Return(
 					types.NvConfigQuery{NextBootConfig: staged, CurrentConfig: staged}, nil)
-				fullFlowNV.On("ValidateSystemConf", fullFlowCtx, pciAddress, "conf3", 0).Return(okSystemConf()...)
+				fullFlowNV.On("ValidateSystemConf", fullFlowCtx, portSpec(pciAddress), "conf3", 0).Return(okSystemConf()...)
 
 				updateNeeded, rebootNeeded, _, err := fullFlowManager.ValidateDeviceNvSpec(fullFlowCtx, fullFlowDevice)
 				Expect(err).NotTo(HaveOccurred())
@@ -1730,11 +1734,11 @@ var _ = Describe("ConfigurationManager", func() {
 			// 2) system_conf mismatch, no overrides → set_system_conf re-applied.
 			It("2: system_conf mismatch with no overrides re-applies set_system_conf", func() {
 				staged := sriovStaged(nil)
-				fullFlowNV.On("QueryNvConfig", fullFlowCtx, pciAddress, []string(nil)).Return(
+				fullFlowNV.On("QueryNvConfig", fullFlowCtx, portSpec(pciAddress), []string(nil)).Return(
 					types.NvConfigQuery{NextBootConfig: staged, CurrentConfig: staged}, nil)
-				fullFlowNV.On("ValidateSystemConf", fullFlowCtx, pciAddress, "conf3", 0).
+				fullFlowNV.On("ValidateSystemConf", fullFlowCtx, portSpec(pciAddress), "conf3", 0).
 					Return(mismatchSystemConf("BOARD_CONFIGURATION_MODE")...)
-				fullFlowNV.On("SetSystemConf", fullFlowCtx, pciAddress, "conf3", 0, false).Return(nil)
+				fullFlowNV.On("SetSystemConf", fullFlowCtx, portSpec(pciAddress), "conf3", 0, false).Return(nil)
 
 				updateNeeded, rebootNeeded, _, err := fullFlowManager.ValidateDeviceNvSpec(fullFlowCtx, fullFlowDevice)
 				Expect(err).NotTo(HaveOccurred())
@@ -1752,9 +1756,9 @@ var _ = Describe("ConfigurationManager", func() {
 			It("3: system_conf mismatch fully covered by an already-applied rawNvConfig override converges", func() {
 				fullFlowDevice.Spec.Configuration.Template.RawNvConfig = []v1alpha1.NvConfigParam{{Name: "NUM_OF_PF", Value: "8"}}
 				staged := sriovStaged(map[string][]string{"NUM_OF_PF": {"8"}})
-				fullFlowNV.On("QueryNvConfig", fullFlowCtx, pciAddress, []string(nil)).Return(
+				fullFlowNV.On("QueryNvConfig", fullFlowCtx, portSpec(pciAddress), []string(nil)).Return(
 					types.NvConfigQuery{NextBootConfig: staged, CurrentConfig: staged}, nil)
-				fullFlowNV.On("ValidateSystemConf", fullFlowCtx, pciAddress, "conf3", 0).
+				fullFlowNV.On("ValidateSystemConf", fullFlowCtx, portSpec(pciAddress), "conf3", 0).
 					Return(mismatchSystemConf("NUM_OF_PF")...)
 
 				updateNeeded, rebootNeeded, _, err := fullFlowManager.ValidateDeviceNvSpec(fullFlowCtx, fullFlowDevice)
@@ -1774,11 +1778,11 @@ var _ = Describe("ConfigurationManager", func() {
 			It("4: rawNvConfig covers the mismatch by name but differs in value — applies the raw param, not set_system_conf", func() {
 				fullFlowDevice.Spec.Configuration.Template.RawNvConfig = []v1alpha1.NvConfigParam{{Name: "NUM_OF_PF", Value: "8"}}
 				staged := sriovStaged(map[string][]string{"NUM_OF_PF": {"1"}})
-				fullFlowNV.On("QueryNvConfig", fullFlowCtx, pciAddress, []string(nil)).Return(
+				fullFlowNV.On("QueryNvConfig", fullFlowCtx, portSpec(pciAddress), []string(nil)).Return(
 					types.NvConfigQuery{NextBootConfig: staged, CurrentConfig: staged}, nil)
-				fullFlowNV.On("ValidateSystemConf", fullFlowCtx, pciAddress, "conf3", 0).
+				fullFlowNV.On("ValidateSystemConf", fullFlowCtx, portSpec(pciAddress), "conf3", 0).
 					Return(mismatchSystemConf("NUM_OF_PF")...)
-				fullFlowNV.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"NUM_OF_PF": "8"}, false, false).Return(nil)
+				fullFlowNV.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "8"}, false, false).Return(nil)
 
 				updateNeeded, rebootNeeded, _, err := fullFlowManager.ValidateDeviceNvSpec(fullFlowCtx, fullFlowDevice)
 				Expect(err).NotTo(HaveOccurred())
@@ -1798,9 +1802,9 @@ var _ = Describe("ConfigurationManager", func() {
 				fullFlowSpcX.On("GetBreakoutMlxConfig", fullFlowDevice).Return(map[string]string{"NUM_OF_PF": "2"}, nil)
 				fullFlowSpcX.On("GetPostBreakoutMlxConfig", fullFlowDevice).Return(nil, nil)
 				staged := sriovStaged(map[string][]string{"NUM_OF_PF": {"2"}})
-				fullFlowNV.On("QueryNvConfig", fullFlowCtx, pciAddress, []string(nil)).Return(
+				fullFlowNV.On("QueryNvConfig", fullFlowCtx, portSpec(pciAddress), []string(nil)).Return(
 					types.NvConfigQuery{NextBootConfig: staged, CurrentConfig: staged}, nil)
-				fullFlowNV.On("ValidateSystemConf", fullFlowCtx, pciAddress, "conf3", 0).
+				fullFlowNV.On("ValidateSystemConf", fullFlowCtx, portSpec(pciAddress), "conf3", 0).
 					Return(mismatchSystemConf("NUM_OF_PF")...)
 
 				updateNeeded, rebootNeeded, _, err := fullFlowManager.ValidateDeviceNvSpec(fullFlowCtx, fullFlowDevice)
@@ -1827,12 +1831,12 @@ var _ = Describe("ConfigurationManager", func() {
 				fullFlowSpcX.On("GetBreakoutMlxConfig", fullFlowDevice).Return(map[string]string{"NUM_OF_PF": "2", "LINK_TYPE_P1": "1"}, nil)
 				fullFlowSpcX.On("GetPostBreakoutMlxConfig", fullFlowDevice).Return(nil, nil)
 				staged := sriovStaged(map[string][]string{"NUM_OF_PF": {"8"}, "LINK_TYPE_P1": {"1"}})
-				fullFlowNV.On("QueryNvConfig", fullFlowCtx, pciAddress, []string(nil)).Return(
+				fullFlowNV.On("QueryNvConfig", fullFlowCtx, portSpec(pciAddress), []string(nil)).Return(
 					types.NvConfigQuery{NextBootConfig: staged, CurrentConfig: staged}, nil)
-				fullFlowNV.On("ValidateSystemConf", fullFlowCtx, pciAddress, "conf3", 0).
+				fullFlowNV.On("ValidateSystemConf", fullFlowCtx, portSpec(pciAddress), "conf3", 0).
 					Return(mismatchSystemConf("NUM_OF_PF", "LINK_TYPE_P1")...)
 				// Only LINK_TYPE_P1 differs from next boot; the raw value 2 wins over the Spectrum-X value 1.
-				fullFlowNV.On("SetNvConfigParametersBatch", pciAddress, map[string]string{"LINK_TYPE_P1": "2"}, false, false).Return(nil)
+				fullFlowNV.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"LINK_TYPE_P1": "2"}, false, false).Return(nil)
 
 				updateNeeded, rebootNeeded, _, err := fullFlowManager.ValidateDeviceNvSpec(fullFlowCtx, fullFlowDevice)
 				Expect(err).NotTo(HaveOccurred())
@@ -1864,12 +1868,12 @@ var _ = Describe("ConfigurationManager", func() {
 					"NUM_OF_PF":               {"8"},
 					"LINK_TYPE_P1":            {"1"}, // Spectrum-X value staged; raw wants 2
 				}
-				fullFlowNV.On("QueryNvConfig", fullFlowCtx, pciAddress, []string(nil)).Return(
+				fullFlowNV.On("QueryNvConfig", fullFlowCtx, portSpec(pciAddress), []string(nil)).Return(
 					types.NvConfigQuery{NextBootConfig: staged, CurrentConfig: staged}, nil)
-				fullFlowNV.On("ValidateSystemConf", fullFlowCtx, pciAddress, "conf3", 0).
+				fullFlowNV.On("ValidateSystemConf", fullFlowCtx, portSpec(pciAddress), "conf3", 0).
 					Return(mismatchSystemConf("NUM_OF_PF", "LINK_TYPE_P1")...)
 				// Raw wins on both: LINK_TYPE_P1 over Spectrum-X (1→2) and NUM_OF_VFS over template (4→16).
-				fullFlowNV.On("SetNvConfigParametersBatch", pciAddress,
+				fullFlowNV.On("SetNvConfigParametersBatch", portSpec(pciAddress),
 					map[string]string{"LINK_TYPE_P1": "2", consts.SriovNumOfVfsParam: "16"}, false, false).Return(nil)
 
 				updateNeeded, rebootNeeded, _, err := fullFlowManager.ValidateDeviceNvSpec(fullFlowCtx, fullFlowDevice)

--- a/pkg/devicediscovery/devicediscovery.go
+++ b/pkg/devicediscovery/devicediscovery.go
@@ -102,6 +102,7 @@ func (d deviceDiscovery) DiscoverNicDevices() (map[string]v1alpha1.NicDevice, er
 
 		pciKey := utils.PCIDeviceAddress(device.Address)
 		deviceStatus, ok := statuses[pciKey]
+		fwctlDevice := d.utils.GetFwctlDevice(device.Address)
 
 		if !ok {
 			firmwareVersion, psid, err := d.utils.GetFirmwareVersionAndPSID(device.Address)
@@ -118,7 +119,8 @@ func (d deviceDiscovery) DiscoverNicDevices() (map[string]v1alpha1.NicDevice, er
 
 			dpu := false
 			if isBlueField {
-				nvConfig, err := d.nvConfigUtils.QueryNvConfig(context.Background(), device.Address, []string{consts.BF3OperationModeParam})
+				port := v1alpha1.NicDevicePortSpec{PCI: device.Address, FwctlDevice: fwctlDevice}
+				nvConfig, err := d.nvConfigUtils.QueryNvConfig(context.Background(), port, []string{consts.BF3OperationModeParam})
 				if err != nil {
 					log.Log.Error(err, "Failed to get BlueField device's operation mode", "address", device.Address)
 					return nil, err
@@ -148,6 +150,7 @@ func (d deviceDiscovery) DiscoverNicDevices() (map[string]v1alpha1.NicDevice, er
 
 		deviceStatus.Ports = append(deviceStatus.Ports, v1alpha1.NicDevicePortSpec{
 			PCI:              device.Address,
+			FwctlDevice:      fwctlDevice,
 			NetworkInterface: networkInterface,
 			RdmaInterface:    rdmaInterface,
 		})

--- a/pkg/devicediscovery/devicediscovery_test.go
+++ b/pkg/devicediscovery/devicediscovery_test.go
@@ -33,12 +33,17 @@ import (
 
 var _ = Describe("DeviceDiscovery", func() {
 	var (
-		mockUtils mocks.DeviceDiscoveryUtils
-		manager   DeviceDiscovery
+		mockUtils    mocks.DeviceDiscoveryUtils
+		manager      DeviceDiscovery
+		fwctlDevices map[string]string
 	)
 
 	BeforeEach(func() {
 		mockUtils = mocks.DeviceDiscoveryUtils{}
+		fwctlDevices = map[string]string{}
+		mockUtils.On("GetFwctlDevice", mock.Anything).Return(func(pciAddr string) string {
+			return fwctlDevices[pciAddr]
+		}).Maybe()
 		manager = deviceDiscovery{utils: &mockUtils, nodeName: "test-node"}
 	})
 
@@ -630,6 +635,7 @@ var _ = Describe("DeviceDiscovery", func() {
 
 	Context("when parsing model name and SuperNIC flag", func() {
 		It("should truncate model name at first comma and set SuperNIC", func() {
+			fwctlDevices["0000:00:00.0"] = "/dev/fwctl/fwctl0"
 			mockUtils.On("GetPCIDevices").Return([]*pci.Device{
 				{
 					Address: "0000:00:00.0",
@@ -656,6 +662,8 @@ var _ = Describe("DeviceDiscovery", func() {
 			discoveredDevice := devicesByPCI["0000:00:00"]
 			Expect(discoveredDevice.Status.ModelName).To(Equal("NVIDIA ConnectX-8 C8180 HHHL SuperNIC"))
 			Expect(discoveredDevice.Status.SuperNIC).To(BeTrue())
+			Expect(discoveredDevice.Status.Ports).To(HaveLen(1))
+			Expect(discoveredDevice.Status.Ports[0].FwctlDevice).To(Equal("/dev/fwctl/fwctl0"))
 		})
 	})
 
@@ -677,7 +685,7 @@ var _ = Describe("DeviceDiscovery", func() {
 			mockUtils.On("GetRDMADeviceName", "0000:00:00.0").Return("mlx5_0")
 
 			nvConfigUtilsMock := nvmmocks.NewNVConfigUtils(GinkgoT())
-			nvConfigUtilsMock.On("QueryNvConfig", mock.Anything, "0000:00:00.0", []string{consts.BF3OperationModeParam}).Return(types.NvConfigQuery{
+			nvConfigUtilsMock.On("QueryNvConfig", mock.Anything, v1alpha1.NicDevicePortSpec{PCI: "0000:00:00.0"}, []string{consts.BF3OperationModeParam}).Return(types.NvConfigQuery{
 				CurrentConfig:  map[string][]string{consts.BF3OperationModeParam: {"enabled", consts.NvParamBF3DpuMode}},
 				NextBootConfig: map[string][]string{},
 				DefaultConfig:  map[string][]string{},

--- a/pkg/devicediscovery/mocks/DeviceDiscoveryUtils.go
+++ b/pkg/devicediscovery/mocks/DeviceDiscoveryUtils.go
@@ -67,6 +67,24 @@ func (_m *DeviceDiscoveryUtils) GetInterfaceName(pciAddr string) string {
 	return r0
 }
 
+// GetFwctlDevice provides a mock function with given fields: pciAddr
+func (_m *DeviceDiscoveryUtils) GetFwctlDevice(pciAddr string) string {
+	ret := _m.Called(pciAddr)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetFwctlDevice")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		r0 = rf(pciAddr)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
 // GetNetworkBayASIC provides a mock function for the type DeviceDiscoveryUtils
 func (_m *DeviceDiscoveryUtils) GetNetworkBayASIC(pciAddr string) (int, bool) {
 	ret := _m.Called(pciAddr)

--- a/pkg/devicediscovery/utils.go
+++ b/pkg/devicediscovery/utils.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -37,6 +38,8 @@ import (
 )
 
 const pciDevicesPath = "/sys/bus/pci/devices"
+
+const fwctlDevicesPath = "/dev/fwctl"
 
 const mlxvpdMaxAttempts = 3
 
@@ -82,6 +85,10 @@ type DeviceDiscoveryUtils interface {
 
 	// GetInterfaceName returns a network interface name for the given PCI address
 	GetInterfaceName(pciAddr string) string
+
+	// GetFwctlDevice returns a fwctl character device path for the given PCI address.
+	// Missing or unreadable sysfs state is logged and treated as no fwctl device.
+	GetFwctlDevice(pciAddr string) string
 
 	// IsSriovVF return true if the device is a SRIOV VF, false otherwise
 	IsSriovVF(pciAddr string) bool
@@ -266,6 +273,20 @@ func (d *deviceDiscoveryUtils) GetInterfaceName(pciAddr string) string {
 	return names[0]
 }
 
+// GetFwctlDevice returns a fwctl character device path for the given PCI address.
+func (d *deviceDiscoveryUtils) GetFwctlDevice(pciAddr string) string {
+	log.Log.Info("DeviceDiscoveryUtils.GetFwctlDevice()", "pciAddr", pciAddr)
+
+	fwctlDevice, err := getFwctlDeviceFromPath(pciDevicesPath, pciAddr)
+	if err != nil {
+		log.Log.V(1).Info("GetFwctlDevice(): fwctl device not found", "pciAddr", pciAddr, "error", err.Error())
+		return ""
+	}
+
+	log.Log.Info("fwctl device", "pciAddr", pciAddr, "device", fwctlDevice)
+	return fwctlDevice
+}
+
 // IsSriovVF return true if the device is a SRIOV VF, false otherwise
 func (d *deviceDiscoveryUtils) IsSriovVF(pciAddr string) bool {
 	log.Log.Info("HostUtils.IsSriovVF()", "pciAddr", pciAddr)
@@ -408,6 +429,28 @@ func getNetNamesFromPath(basePath, pciAddr string) ([]string, error) {
 	}
 
 	return names, nil
+}
+
+func getFwctlDeviceFromPath(pciDevicesBasePath, pciAddr string) (string, error) {
+	fwctlDir := filepath.Join(pciDevicesBasePath, pciAddr, "fwctl")
+	entries, err := os.ReadDir(fwctlDir)
+	if err != nil {
+		return "", fmt.Errorf("GetFwctlDevice(): failed to read fwctl directory %s: %w", fwctlDir, err)
+	}
+
+	deviceNames := make([]string, 0)
+	for _, entry := range entries {
+		name := entry.Name()
+		if strings.HasPrefix(name, "fwctl") {
+			deviceNames = append(deviceNames, name)
+		}
+	}
+	if len(deviceNames) == 0 {
+		return "", fmt.Errorf("GetFwctlDevice(): no fwctl entries under pci device %s", pciAddr)
+	}
+	sort.Strings(deviceNames)
+
+	return filepath.Join(fwctlDevicesPath, deviceNames[0]), nil
 }
 
 // NewDeviceDiscoveryUtils creates a new DeviceDiscoveryUtils instance

--- a/pkg/devicediscovery/utils_test.go
+++ b/pkg/devicediscovery/utils_test.go
@@ -310,6 +310,54 @@ var _ = Describe("HostUtils", func() {
 			Expect(vpd.ModelName).To(Equal(""))
 		})
 	})
+
+	Describe("getFwctlDeviceFromPath", func() {
+		It("returns the dev path for a discovered fwctl entry", func() {
+			root := GinkgoT().TempDir()
+			fwctlDir := filepath.Join(root, pciAddress, "fwctl")
+			Expect(os.MkdirAll(fwctlDir, 0o755)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(fwctlDir, "fwctl2"), []byte{}, 0o644)).To(Succeed())
+
+			fwctlDevice, err := getFwctlDeviceFromPath(root, pciAddress)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fwctlDevice).To(Equal("/dev/fwctl/fwctl2"))
+		})
+
+		It("returns the first fwctl entry sorted by name", func() {
+			root := GinkgoT().TempDir()
+			fwctlDir := filepath.Join(root, pciAddress, "fwctl")
+			Expect(os.MkdirAll(fwctlDir, 0o755)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(fwctlDir, "fwctl7"), []byte{}, 0o644)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(fwctlDir, "fwctl3"), []byte{}, 0o644)).To(Succeed())
+
+			fwctlDevice, err := getFwctlDeviceFromPath(root, pciAddress)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fwctlDevice).To(Equal("/dev/fwctl/fwctl3"))
+		})
+
+		It("returns an error when the fwctl directory is missing", func() {
+			root := GinkgoT().TempDir()
+
+			fwctlDevice, err := getFwctlDeviceFromPath(root, pciAddress)
+
+			Expect(err).To(HaveOccurred())
+			Expect(fwctlDevice).To(BeEmpty())
+		})
+
+		It("returns an error when the fwctl directory has no fwctl entries", func() {
+			root := GinkgoT().TempDir()
+			fwctlDir := filepath.Join(root, pciAddress, "fwctl")
+			Expect(os.MkdirAll(fwctlDir, 0o755)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(fwctlDir, "not-fwctl"), []byte{}, 0o644)).To(Succeed())
+
+			fwctlDevice, err := getFwctlDeviceFromPath(root, pciAddress)
+
+			Expect(err).To(HaveOccurred())
+			Expect(fwctlDevice).To(BeEmpty())
+		})
+	})
 	//nolint:dupl
 	Describe("GetFirmwareVersionAndPSID", func() {
 		It("should return lowercased firmware version and psid", func() {

--- a/pkg/nvconfig/mocks/NVConfigUtils.go
+++ b/pkg/nvconfig/mocks/NVConfigUtils.go
@@ -7,6 +7,7 @@ import (
 
 	mock "github.com/stretchr/testify/mock"
 
+	v1alpha1 "github.com/Mellanox/nic-configuration-operator/api/v1alpha1"
 	types "github.com/Mellanox/nic-configuration-operator/pkg/types"
 )
 
@@ -15,9 +16,9 @@ type NVConfigUtils struct {
 	mock.Mock
 }
 
-// QueryNvConfig provides a mock function with given fields: ctx, pciAddr, parameters
-func (_m *NVConfigUtils) QueryNvConfig(ctx context.Context, pciAddr string, parameters []string) (types.NvConfigQuery, error) {
-	ret := _m.Called(ctx, pciAddr, parameters)
+// QueryNvConfig provides a mock function with given fields: ctx, port, parameters
+func (_m *NVConfigUtils) QueryNvConfig(ctx context.Context, port v1alpha1.NicDevicePortSpec, parameters []string) (types.NvConfigQuery, error) {
+	ret := _m.Called(ctx, port, parameters)
 
 	if len(ret) == 0 {
 		panic("no return value specified for QueryNvConfig")
@@ -25,17 +26,17 @@ func (_m *NVConfigUtils) QueryNvConfig(ctx context.Context, pciAddr string, para
 
 	var r0 types.NvConfigQuery
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, []string) (types.NvConfigQuery, error)); ok {
-		return rf(ctx, pciAddr, parameters)
+	if rf, ok := ret.Get(0).(func(context.Context, v1alpha1.NicDevicePortSpec, []string) (types.NvConfigQuery, error)); ok {
+		return rf(ctx, port, parameters)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, []string) types.NvConfigQuery); ok {
-		r0 = rf(ctx, pciAddr, parameters)
+	if rf, ok := ret.Get(0).(func(context.Context, v1alpha1.NicDevicePortSpec, []string) types.NvConfigQuery); ok {
+		r0 = rf(ctx, port, parameters)
 	} else {
 		r0 = ret.Get(0).(types.NvConfigQuery)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, []string) error); ok {
-		r1 = rf(ctx, pciAddr, parameters)
+	if rf, ok := ret.Get(1).(func(context.Context, v1alpha1.NicDevicePortSpec, []string) error); ok {
+		r1 = rf(ctx, port, parameters)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -43,17 +44,17 @@ func (_m *NVConfigUtils) QueryNvConfig(ctx context.Context, pciAddr string, para
 	return r0, r1
 }
 
-// ResetNvConfig provides a mock function with given fields: pciAddr
-func (_m *NVConfigUtils) ResetNvConfig(pciAddr string) error {
-	ret := _m.Called(pciAddr)
+// ResetNvConfig provides a mock function with given fields: port
+func (_m *NVConfigUtils) ResetNvConfig(port v1alpha1.NicDevicePortSpec) error {
+	ret := _m.Called(port)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ResetNvConfig")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string) error); ok {
-		r0 = rf(pciAddr)
+	if rf, ok := ret.Get(0).(func(v1alpha1.NicDevicePortSpec) error); ok {
+		r0 = rf(port)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -61,17 +62,17 @@ func (_m *NVConfigUtils) ResetNvConfig(pciAddr string) error {
 	return r0
 }
 
-// SetNvConfigParameter provides a mock function with given fields: pciAddr, paramName, paramValue
-func (_m *NVConfigUtils) SetNvConfigParameter(pciAddr string, paramName string, paramValue string) error {
-	ret := _m.Called(pciAddr, paramName, paramValue)
+// SetNvConfigParameter provides a mock function with given fields: port, paramName, paramValue
+func (_m *NVConfigUtils) SetNvConfigParameter(port v1alpha1.NicDevicePortSpec, paramName string, paramValue string) error {
+	ret := _m.Called(port, paramName, paramValue)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SetNvConfigParameter")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, string) error); ok {
-		r0 = rf(pciAddr, paramName, paramValue)
+	if rf, ok := ret.Get(0).(func(v1alpha1.NicDevicePortSpec, string, string) error); ok {
+		r0 = rf(port, paramName, paramValue)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -79,17 +80,17 @@ func (_m *NVConfigUtils) SetNvConfigParameter(pciAddr string, paramName string, 
 	return r0
 }
 
-// SetNvConfigParametersBatch provides a mock function with given fields: pciAddr, params, withDefault, force
-func (_m *NVConfigUtils) SetNvConfigParametersBatch(pciAddr string, params map[string]string, withDefault bool, force bool) error {
-	ret := _m.Called(pciAddr, params, withDefault, force)
+// SetNvConfigParametersBatch provides a mock function with given fields: port, params, withDefault, force
+func (_m *NVConfigUtils) SetNvConfigParametersBatch(port v1alpha1.NicDevicePortSpec, params map[string]string, withDefault bool, force bool) error {
+	ret := _m.Called(port, params, withDefault, force)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SetNvConfigParametersBatch")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, map[string]string, bool, bool) error); ok {
-		r0 = rf(pciAddr, params, withDefault, force)
+	if rf, ok := ret.Get(0).(func(v1alpha1.NicDevicePortSpec, map[string]string, bool, bool) error); ok {
+		r0 = rf(port, params, withDefault, force)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -97,17 +98,17 @@ func (_m *NVConfigUtils) SetNvConfigParametersBatch(pciAddr string, params map[s
 	return r0
 }
 
-// SetSystemConf provides a mock function with given fields: ctx, pciAddr, conf, asic, force
-func (_m *NVConfigUtils) SetSystemConf(ctx context.Context, pciAddr string, conf string, asic int, force bool) error {
-	ret := _m.Called(ctx, pciAddr, conf, asic, force)
+// SetSystemConf provides a mock function with given fields: ctx, port, conf, asic, force
+func (_m *NVConfigUtils) SetSystemConf(ctx context.Context, port v1alpha1.NicDevicePortSpec, conf string, asic int, force bool) error {
+	ret := _m.Called(ctx, port, conf, asic, force)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SetSystemConf")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, int, bool) error); ok {
-		r0 = rf(ctx, pciAddr, conf, asic, force)
+	if rf, ok := ret.Get(0).(func(context.Context, v1alpha1.NicDevicePortSpec, string, int, bool) error); ok {
+		r0 = rf(ctx, port, conf, asic, force)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -115,9 +116,9 @@ func (_m *NVConfigUtils) SetSystemConf(ctx context.Context, pciAddr string, conf
 	return r0
 }
 
-// ValidateSystemConf provides a mock function with given fields: ctx, pciAddr, conf, asic
-func (_m *NVConfigUtils) ValidateSystemConf(ctx context.Context, pciAddr string, conf string, asic int) (bool, []string, error) {
-	ret := _m.Called(ctx, pciAddr, conf, asic)
+// ValidateSystemConf provides a mock function with given fields: ctx, port, conf, asic
+func (_m *NVConfigUtils) ValidateSystemConf(ctx context.Context, port v1alpha1.NicDevicePortSpec, conf string, asic int) (bool, []string, error) {
+	ret := _m.Called(ctx, port, conf, asic)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ValidateSystemConf")
@@ -126,25 +127,25 @@ func (_m *NVConfigUtils) ValidateSystemConf(ctx context.Context, pciAddr string,
 	var r0 bool
 	var r1 []string
 	var r2 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, int) (bool, []string, error)); ok {
-		return rf(ctx, pciAddr, conf, asic)
+	if rf, ok := ret.Get(0).(func(context.Context, v1alpha1.NicDevicePortSpec, string, int) (bool, []string, error)); ok {
+		return rf(ctx, port, conf, asic)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, int) bool); ok {
-		r0 = rf(ctx, pciAddr, conf, asic)
+	if rf, ok := ret.Get(0).(func(context.Context, v1alpha1.NicDevicePortSpec, string, int) bool); ok {
+		r0 = rf(ctx, port, conf, asic)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, int) []string); ok {
-		r1 = rf(ctx, pciAddr, conf, asic)
+	if rf, ok := ret.Get(1).(func(context.Context, v1alpha1.NicDevicePortSpec, string, int) []string); ok {
+		r1 = rf(ctx, port, conf, asic)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).([]string)
 		}
 	}
 
-	if rf, ok := ret.Get(2).(func(context.Context, string, string, int) error); ok {
-		r2 = rf(ctx, pciAddr, conf, asic)
+	if rf, ok := ret.Get(2).(func(context.Context, v1alpha1.NicDevicePortSpec, string, int) error); ok {
+		r2 = rf(ctx, port, conf, asic)
 	} else {
 		r2 = ret.Error(2)
 	}

--- a/pkg/nvconfig/utils.go
+++ b/pkg/nvconfig/utils.go
@@ -26,6 +26,7 @@ import (
 	execUtils "k8s.io/utils/exec"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/Mellanox/nic-configuration-operator/api/v1alpha1"
 	"github.com/Mellanox/nic-configuration-operator/pkg/types"
 	"github.com/Mellanox/nic-configuration-operator/pkg/utils"
 )
@@ -50,42 +51,50 @@ func parseMLXConfigValue(value string, valueInBracketsRegex *regexp.Regexp) []st
 type NVConfigUtils interface {
 	// QueryNvConfig queries nv config for a mellanox device and returns default, current and next boot configs
 	// parameters is an optional list of specific parameters to query, e.g. "ESWITCH_HAIRPIN_DESCRIPTORS[0..7]"
-	QueryNvConfig(ctx context.Context, pciAddr string, parameters []string) (types.NvConfigQuery, error)
+	QueryNvConfig(ctx context.Context, port v1alpha1.NicDevicePortSpec, parameters []string) (types.NvConfigQuery, error)
 	// SetNvConfigParameter sets a nv config parameter for a mellanox device
-	SetNvConfigParameter(pciAddr string, paramName string, paramValue string) error
+	SetNvConfigParameter(port v1alpha1.NicDevicePortSpec, paramName string, paramValue string) error
 	// SetNvConfigParametersBatch sets multiple nv config parameters for a mellanox device in a single mlxconfig call
 	// When force is true, --force is passed to mlxconfig so it accepts a batch it would otherwise refuse
 	// due to implicit parameter dependencies.
-	SetNvConfigParametersBatch(pciAddr string, params map[string]string, withDefault bool, force bool) error
+	SetNvConfigParametersBatch(port v1alpha1.NicDevicePortSpec, params map[string]string, withDefault bool, force bool) error
 	// ResetNvConfig resets NIC's nv config
-	ResetNvConfig(pciAddr string) error
+	ResetNvConfig(port v1alpha1.NicDevicePortSpec) error
 	// SetSystemConf applies a ConnectX-9 Network Bay system configuration for a single ASIC via
-	// `mlxconfig -d <pci> -y [--force] set_system_conf <conf>[<asic>]`. Persistent, reboot-required.
-	SetSystemConf(ctx context.Context, pciAddr string, conf string, asic int, force bool) error
+	// `mlxconfig -d <device> -y [--force] set_system_conf <conf>[<asic>]`. Persistent, reboot-required.
+	SetSystemConf(ctx context.Context, port v1alpha1.NicDevicePortSpec, conf string, asic int, force bool) error
 	// ValidateSystemConf reports whether the device's applied configuration matches the named system
-	// configuration for the given ASIC via `mlxconfig -d <pci> -y validate_system_conf <conf>[<asic>]`.
+	// configuration for the given ASIC via `mlxconfig -d <device> -y validate_system_conf <conf>[<asic>]`.
 	// It returns the overall match bit plus the names of the mismatched params (the MISMATCH rows), so
 	// callers that allow explicit overrides (e.g. rawNvConfig / Spectrum-X) on top of a named system conf
 	// can decide whether a reported mismatch is an intentional override or real drift requiring re-apply.
-	ValidateSystemConf(ctx context.Context, pciAddr string, conf string, asic int) (bool, []string, error)
+	ValidateSystemConf(ctx context.Context, port v1alpha1.NicDevicePortSpec, conf string, asic int) (bool, []string, error)
 }
 
 type nvConfigUtils struct {
 	execInterface execUtils.Interface
 }
 
+func resolveDevice(port v1alpha1.NicDevicePortSpec) string {
+	if port.FwctlDevice != "" {
+		log.Log.V(2).Info("using fwctl device for mlxconfig", "pciAddr", port.PCI, "fwctlDevice", port.FwctlDevice)
+		return port.FwctlDevice
+	}
+	return port.PCI
+}
+
 // queryMLXConfig runs a query on mlxconfig to parse out default, current and nextboot configurations
 // might run recursively to expand array parameters' values
-func (h *nvConfigUtils) queryMLXConfig(ctx context.Context, query types.NvConfigQuery, pciAddr string, additionalParameter string) error {
-	log.Log.Info(fmt.Sprintf("mlxconfig -d %s query %s", pciAddr, additionalParameter)) // TODO change verbosity
+func (h *nvConfigUtils) queryMLXConfig(ctx context.Context, query types.NvConfigQuery, targetDevice string, additionalParameter string) error {
+	log.Log.Info(fmt.Sprintf("mlxconfig -d %s query %s", targetDevice, additionalParameter)) // TODO change verbosity
 	valueInBracketsRegex := regexp.MustCompile(`^(.*?)\(([^)]*)\)$`)
 	spaceRe := regexp.MustCompile(`\s{2,}`)
 
 	var cmd execUtils.Cmd
 	if additionalParameter == "" {
-		cmd = h.execInterface.CommandContext(ctx, "mlxconfig", "-d", pciAddr, "-e", "query")
+		cmd = h.execInterface.CommandContext(ctx, "mlxconfig", "-d", targetDevice, "-e", "query")
 	} else {
-		cmd = h.execInterface.CommandContext(ctx, "mlxconfig", "-d", pciAddr, "-e", "query", additionalParameter)
+		cmd = h.execInterface.CommandContext(ctx, "mlxconfig", "-d", targetDevice, "-e", "query", additionalParameter)
 	}
 	output, err := utils.RunCommand(cmd)
 	if err != nil {
@@ -142,7 +151,7 @@ func (h *nvConfigUtils) queryMLXConfig(ctx context.Context, query types.NvConfig
 
 			// If the parameter value is an array, we want to extract values for all indices
 			if strings.HasPrefix(defaultVal, arrayPrefix) {
-				err = h.queryMLXConfig(ctx, query, pciAddr, paramName+strings.TrimPrefix(defaultVal, arrayPrefix))
+				err = h.queryMLXConfig(ctx, query, targetDevice, paramName+strings.TrimPrefix(defaultVal, arrayPrefix))
 				if err != nil {
 					return err
 				}
@@ -160,22 +169,23 @@ func (h *nvConfigUtils) queryMLXConfig(ctx context.Context, query types.NvConfig
 }
 
 // QueryNvConfig queries nv config for a mellanox device and returns default, current and next boot configs
-func (h *nvConfigUtils) QueryNvConfig(ctx context.Context, pciAddr string, parameters []string) (types.NvConfigQuery, error) {
-	log.Log.Info("ConfigurationUtils.QueryNvConfig()", "pciAddr", pciAddr)
+func (h *nvConfigUtils) QueryNvConfig(ctx context.Context, port v1alpha1.NicDevicePortSpec, parameters []string) (types.NvConfigQuery, error) {
+	targetDevice := resolveDevice(port)
+	log.Log.Info("ConfigurationUtils.QueryNvConfig()", "pciAddr", port.PCI, "targetDevice", targetDevice)
 
 	query := types.NewNvConfigQuery()
 
 	if len(parameters) == 0 {
-		err := h.queryMLXConfig(ctx, query, pciAddr, "")
+		err := h.queryMLXConfig(ctx, query, targetDevice, "")
 		if err != nil {
-			log.Log.Error(err, "Failed to parse mlxconfig query output", "device", pciAddr)
+			log.Log.Error(err, "Failed to parse mlxconfig query output", "device", targetDevice)
 			return query, err
 		}
 	} else {
 		for _, param := range parameters {
-			err := h.queryMLXConfig(ctx, query, pciAddr, param)
+			err := h.queryMLXConfig(ctx, query, targetDevice, param)
 			if err != nil {
-				log.Log.Error(err, "Failed to parse mlxconfig query output", "device", pciAddr, "parameter", param)
+				log.Log.Error(err, "Failed to parse mlxconfig query output", "device", targetDevice, "parameter", param)
 				return query, err
 			}
 		}
@@ -185,10 +195,11 @@ func (h *nvConfigUtils) QueryNvConfig(ctx context.Context, pciAddr string, param
 }
 
 // SetNvConfigParameter sets a nv config parameter for a mellanox device
-func (h *nvConfigUtils) SetNvConfigParameter(pciAddr string, paramName string, paramValue string) error {
-	log.Log.Info("ConfigurationUtils.SetNvConfigParameter()", "pciAddr", pciAddr, "paramName", paramName, "paramValue", paramValue)
+func (h *nvConfigUtils) SetNvConfigParameter(port v1alpha1.NicDevicePortSpec, paramName string, paramValue string) error {
+	targetDevice := resolveDevice(port)
+	log.Log.Info("ConfigurationUtils.SetNvConfigParameter()", "pciAddr", port.PCI, "targetDevice", targetDevice, "paramName", paramName, "paramValue", paramValue)
 
-	cmd := h.execInterface.Command("mlxconfig", "-d", pciAddr, "--yes", "set", paramName+"="+paramValue)
+	cmd := h.execInterface.Command("mlxconfig", "-d", targetDevice, "--yes", "set", paramName+"="+paramValue)
 	output, err := utils.RunCommand(cmd)
 	if err != nil {
 		log.Log.Error(err, "SetNvConfigParameter(): Failed to run mlxconfig", "output", string(output))
@@ -198,8 +209,9 @@ func (h *nvConfigUtils) SetNvConfigParameter(pciAddr string, paramName string, p
 }
 
 // SetNvConfigParametersBatch sets multiple nv config parameters for a mellanox device in a single mlxconfig call
-func (h *nvConfigUtils) SetNvConfigParametersBatch(pciAddr string, params map[string]string, withDefault bool, force bool) error {
-	log.Log.Info("ConfigurationUtils.SetNvConfigParametersBatch()", "pciAddr", pciAddr, "params", params, "withDefault", withDefault, "force", force)
+func (h *nvConfigUtils) SetNvConfigParametersBatch(port v1alpha1.NicDevicePortSpec, params map[string]string, withDefault bool, force bool) error {
+	targetDevice := resolveDevice(port)
+	log.Log.Info("ConfigurationUtils.SetNvConfigParametersBatch()", "pciAddr", port.PCI, "targetDevice", targetDevice, "params", params, "withDefault", withDefault, "force", force)
 
 	if len(params) == 0 {
 		return nil
@@ -217,7 +229,7 @@ func (h *nvConfigUtils) SetNvConfigParametersBatch(pciAddr string, params map[st
 		paramArgs = append(paramArgs, name+"="+params[name])
 	}
 
-	args := []string{"-d", pciAddr, "--yes"}
+	args := []string{"-d", targetDevice, "--yes"}
 	if withDefault {
 		args = append(args, "--with_default")
 	}
@@ -242,19 +254,20 @@ func systemConfToken(conf string, asic int) string {
 }
 
 // SetSystemConf applies a ConnectX-9 Network Bay system configuration for a single ASIC.
-func (h *nvConfigUtils) SetSystemConf(ctx context.Context, pciAddr string, conf string, asic int, force bool) error {
-	log.Log.Info("ConfigurationUtils.SetSystemConf()", "pciAddr", pciAddr, "conf", conf, "asic", asic, "force", force)
+func (h *nvConfigUtils) SetSystemConf(ctx context.Context, port v1alpha1.NicDevicePortSpec, conf string, asic int, force bool) error {
+	targetDevice := resolveDevice(port)
+	log.Log.Info("ConfigurationUtils.SetSystemConf()", "pciAddr", port.PCI, "targetDevice", targetDevice, "conf", conf, "asic", asic, "force", force)
 
-	args := []string{"-d", pciAddr, "-y"}
+	args := []string{"-d", targetDevice, "-y"}
 	if force {
 		args = append(args, "--force")
 	}
 	args = append(args, "set_system_conf", systemConfToken(conf, asic))
 
 	output, err := h.execInterface.CommandContext(ctx, "mlxconfig", args...).CombinedOutput()
-	log.Log.V(2).Info("command output", "command", "mlxconfig set_system_conf", "pciAddr", pciAddr, "output", string(output))
+	log.Log.V(2).Info("command output", "command", "mlxconfig set_system_conf", "pciAddr", port.PCI, "targetDevice", targetDevice, "output", string(output))
 	if err != nil {
-		log.Log.Error(err, "SetSystemConf(): Failed to run mlxconfig", "pciAddr", pciAddr)
+		log.Log.Error(err, "SetSystemConf(): Failed to run mlxconfig", "pciAddr", port.PCI, "targetDevice", targetDevice)
 		return err
 	}
 	return nil
@@ -262,12 +275,13 @@ func (h *nvConfigUtils) SetSystemConf(ctx context.Context, pciAddr string, conf 
 
 // ValidateSystemConf runs validate_system_conf and returns the overall match bit plus the names of
 // the mismatched params (the MISMATCH rows).
-func (h *nvConfigUtils) ValidateSystemConf(ctx context.Context, pciAddr string, conf string, asic int) (bool, []string, error) {
-	log.Log.Info("ConfigurationUtils.ValidateSystemConf()", "pciAddr", pciAddr, "conf", conf, "asic", asic)
+func (h *nvConfigUtils) ValidateSystemConf(ctx context.Context, port v1alpha1.NicDevicePortSpec, conf string, asic int) (bool, []string, error) {
+	targetDevice := resolveDevice(port)
+	log.Log.Info("ConfigurationUtils.ValidateSystemConf()", "pciAddr", port.PCI, "targetDevice", targetDevice, "conf", conf, "asic", asic)
 
-	args := []string{"-d", pciAddr, "-y", "validate_system_conf", systemConfToken(conf, asic)}
+	args := []string{"-d", targetDevice, "-y", "validate_system_conf", systemConfToken(conf, asic)}
 	output, err := h.execInterface.CommandContext(ctx, "mlxconfig", args...).CombinedOutput()
-	log.Log.V(2).Info("command output", "command", "mlxconfig validate_system_conf", "pciAddr", pciAddr, "output", string(output))
+	log.Log.V(2).Info("command output", "command", "mlxconfig validate_system_conf", "pciAddr", port.PCI, "targetDevice", targetDevice, "output", string(output))
 
 	// mlxconfig validate_system_conf exits non-zero (e.g. 3) when the device configuration does
 	// NOT match the system conf — that is a valid result, not a command failure. Treat the parsed
@@ -276,7 +290,7 @@ func (h *nvConfigUtils) ValidateSystemConf(ctx context.Context, pciAddr string, 
 	matches, mismatched, resultLineFound, parseErr := parseValidateSystemConf(output)
 	if parseErr != nil {
 		if err != nil {
-			log.Log.Error(err, "ValidateSystemConf(): Failed to run mlxconfig", "pciAddr", pciAddr)
+			log.Log.Error(err, "ValidateSystemConf(): Failed to run mlxconfig", "pciAddr", port.PCI, "targetDevice", targetDevice)
 			return false, nil, err
 		}
 		return false, nil, parseErr
@@ -285,11 +299,11 @@ func (h *nvConfigUtils) ValidateSystemConf(ctx context.Context, pciAddr string, 
 	// In that case the parsed rows are partial, so we must not trust a derived match bit — surface the
 	// command error instead of reporting a (possibly false) match from incomplete data.
 	if !resultLineFound && err != nil {
-		log.Log.Error(err, "ValidateSystemConf(): incomplete validate_system_conf output", "pciAddr", pciAddr)
+		log.Log.Error(err, "ValidateSystemConf(): incomplete validate_system_conf output", "pciAddr", port.PCI, "targetDevice", targetDevice)
 		return false, nil, err
 	}
 
-	log.Log.Info("ValidateSystemConf() result", "pciAddr", pciAddr, "conf", conf, "asic", asic, "matches", matches)
+	log.Log.Info("ValidateSystemConf() result", "pciAddr", port.PCI, "targetDevice", targetDevice, "conf", conf, "asic", asic, "matches", matches)
 	return matches, mismatched, nil
 }
 
@@ -366,10 +380,11 @@ func parseValidateSystemConf(output []byte) (matches bool, mismatched []string, 
 }
 
 // ResetNvConfig resets NIC's nv config
-func (h *nvConfigUtils) ResetNvConfig(pciAddr string) error {
-	log.Log.Info("ConfigurationUtils.ResetNvConfig()", "pciAddr", pciAddr)
+func (h *nvConfigUtils) ResetNvConfig(port v1alpha1.NicDevicePortSpec) error {
+	targetDevice := resolveDevice(port)
+	log.Log.Info("ConfigurationUtils.ResetNvConfig()", "pciAddr", port.PCI, "targetDevice", targetDevice)
 
-	cmd := h.execInterface.Command("mlxconfig", "-d", pciAddr, "--yes", "reset")
+	cmd := h.execInterface.Command("mlxconfig", "-d", targetDevice, "--yes", "reset")
 	output, err := utils.RunCommand(cmd)
 	if err != nil {
 		log.Log.Error(err, "ResetNvConfig(): Failed to run mlxconfig", "output", string(output))

--- a/pkg/nvconfig/utils_test.go
+++ b/pkg/nvconfig/utils_test.go
@@ -20,12 +20,17 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/Mellanox/nic-configuration-operator/api/v1alpha1"
 	"github.com/Mellanox/nic-configuration-operator/pkg/consts"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/exec"
 	execTesting "k8s.io/utils/exec/testing"
 )
+
+func nvconfigPort(pciAddr string) v1alpha1.NicDevicePortSpec {
+	return v1alpha1.NicDevicePortSpec{PCI: pciAddr}
+}
 
 var _ = Describe("NVConfigUtils", func() {
 	Describe("parseMLXConfigValue", func() {
@@ -46,6 +51,17 @@ var _ = Describe("NVConfigUtils", func() {
 			Entry("plain symbolic value", "HOST_0", []string{"HOST_0"}),
 			Entry("empty value", "", []string{""}),
 		)
+	})
+
+	Describe("resolveDevice", func() {
+		It("prefers fwctl when discovered", func() {
+			port := v1alpha1.NicDevicePortSpec{PCI: "0000:3b:00.0", FwctlDevice: "/dev/fwctl/fwctl0"}
+			Expect(resolveDevice(port)).To(Equal("/dev/fwctl/fwctl0"))
+		})
+
+		It("falls back to PCI when fwctl is empty", func() {
+			Expect(resolveDevice(nvconfigPort("0000:3b:00.0"))).To(Equal("0000:3b:00.0"))
+		})
 	})
 
 	Describe("queryMLXConfig", func() {
@@ -117,7 +133,7 @@ Configurations:                              Default         Current         Nex
 		})
 
 		It("should parse mlxconfig output correctly", func() {
-			query, err := h.QueryNvConfig(context.TODO(), pciAddress, nil)
+			query, err := h.QueryNvConfig(context.TODO(), nvconfigPort(pciAddress), nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Verify regular parameters
@@ -166,7 +182,7 @@ Device type:    ConnectX4
 
 			h.execInterface = fakeExec
 
-			query, err := h.QueryNvConfig(context.TODO(), pciAddress, nil)
+			query, err := h.QueryNvConfig(context.TODO(), nvconfigPort(pciAddress), nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(query.DefaultConfig).To(BeEmpty())
@@ -200,7 +216,7 @@ Configurations:                              Default         Current         Nex
 
 			h.execInterface = fakeExec
 
-			query, err := h.QueryNvConfig(context.TODO(), pciAddress, []string{consts.BF3OperationModeParam})
+			query, err := h.QueryNvConfig(context.TODO(), nvconfigPort(pciAddress), []string{consts.BF3OperationModeParam})
 			Expect(err).ToNot(HaveOccurred())
 
 			// Verify regular parameters
@@ -259,7 +275,7 @@ The '*' shows parameters with next value different from default/current value.
 
 			h.execInterface = fakeExec
 
-			query, err := h.QueryNvConfig(context.TODO(), pciAddress, nil)
+			query, err := h.QueryNvConfig(context.TODO(), nvconfigPort(pciAddress), nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(query.DefaultConfig).To(HaveKeyWithValue("PCI_DOWNSTREAM_PORT_OWNER[0]", []string{"device_default", "0"}))
@@ -303,7 +319,7 @@ Configurations:                                         Default                 
 
 			h.execInterface = fakeExec
 
-			query, err := h.QueryNvConfig(context.TODO(), pciAddress, []string{"MIXED_FORMAT_PARAM"})
+			query, err := h.QueryNvConfig(context.TODO(), nvconfigPort(pciAddress), []string{"MIXED_FORMAT_PARAM"})
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(query.DefaultConfig).To(HaveKeyWithValue("MIXED_FORMAT_PARAM", []string{"7"}))
@@ -338,7 +354,7 @@ Configurations:                                         Default                 
 
 			h.execInterface = fakeExec
 
-			_, err := h.QueryNvConfig(context.TODO(), pciAddress, nil)
+			_, err := h.QueryNvConfig(context.TODO(), nvconfigPort(pciAddress), nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("mlxconfig error"))
 		})
@@ -476,7 +492,22 @@ Result: Device configuration does NOT match the system configuration.
 					return cmd
 				},
 			}
-			Expect(h.SetSystemConf(context.TODO(), pciAddress, "conf3", 0, false)).To(Succeed())
+			Expect(h.SetSystemConf(context.TODO(), nvconfigPort(pciAddress), "conf3", 0, false)).To(Succeed())
+		})
+
+		It("uses fwctl device when present", func() {
+			cmd := &execTesting.FakeCmd{}
+			cmd.CombinedOutputScript = append(cmd.CombinedOutputScript, func() ([]byte, []byte, error) {
+				return []byte("ok"), nil, nil
+			})
+			fakeExec.CommandScript = []execTesting.FakeCommandAction{
+				func(name string, args ...string) exec.Cmd {
+					Expect(args).To(Equal([]string{"-d", "/dev/fwctl/fwctl2", "-y", "set_system_conf", "conf3[0]"}))
+					return cmd
+				},
+			}
+			port := v1alpha1.NicDevicePortSpec{PCI: pciAddress, FwctlDevice: "/dev/fwctl/fwctl2"}
+			Expect(h.SetSystemConf(context.TODO(), port, "conf3", 0, false)).To(Succeed())
 		})
 
 		It("builds args with --force", func() {
@@ -490,7 +521,7 @@ Result: Device configuration does NOT match the system configuration.
 					return cmd
 				},
 			}
-			Expect(h.SetSystemConf(context.TODO(), pciAddress, "conf3", 1, true)).To(Succeed())
+			Expect(h.SetSystemConf(context.TODO(), nvconfigPort(pciAddress), "conf3", 1, true)).To(Succeed())
 		})
 
 		It("returns an error when mlxconfig fails", func() {
@@ -501,7 +532,7 @@ Result: Device configuration does NOT match the system configuration.
 			fakeExec.CommandScript = []execTesting.FakeCommandAction{
 				func(name string, args ...string) exec.Cmd { return cmd },
 			}
-			Expect(h.SetSystemConf(context.TODO(), pciAddress, "conf3", 0, false)).ToNot(Succeed())
+			Expect(h.SetSystemConf(context.TODO(), nvconfigPort(pciAddress), "conf3", 0, false)).ToNot(Succeed())
 		})
 	})
 
@@ -529,7 +560,7 @@ Result: Device configuration does NOT match the system configuration.
 					return cmd
 				},
 			}
-			matches, mismatched, err := h.ValidateSystemConf(context.TODO(), pciAddress, "conf16", 0)
+			matches, mismatched, err := h.ValidateSystemConf(context.TODO(), nvconfigPort(pciAddress), "conf16", 0)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(matches).To(BeTrue())
 			Expect(mismatched).To(BeEmpty())
@@ -551,7 +582,7 @@ Result: Device configuration does NOT match the system configuration.
 			fakeExec.CommandScript = []execTesting.FakeCommandAction{
 				func(name string, args ...string) exec.Cmd { return cmd },
 			}
-			matches, mismatched, err := h.ValidateSystemConf(context.TODO(), pciAddress, "conf3", 1)
+			matches, mismatched, err := h.ValidateSystemConf(context.TODO(), nvconfigPort(pciAddress), "conf3", 1)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(matches).To(BeFalse())
 			Expect(mismatched).To(ConsistOf("LINK_TYPE_P1"))
@@ -565,7 +596,7 @@ Result: Device configuration does NOT match the system configuration.
 			fakeExec.CommandScript = []execTesting.FakeCommandAction{
 				func(name string, args ...string) exec.Cmd { return cmd },
 			}
-			_, _, err := h.ValidateSystemConf(context.TODO(), pciAddress, "conf3", 0)
+			_, _, err := h.ValidateSystemConf(context.TODO(), nvconfigPort(pciAddress), "conf3", 0)
 			Expect(err).To(HaveOccurred())
 		})
 	})
@@ -594,7 +625,7 @@ Result: Device configuration does NOT match the system configuration.
 					return cmd
 				},
 			}
-			Expect(h.SetNvConfigParametersBatch(pciAddress, map[string]string{"PARAM": "1"}, false, true)).To(Succeed())
+			Expect(h.SetNvConfigParametersBatch(nvconfigPort(pciAddress), map[string]string{"PARAM": "1"}, false, true)).To(Succeed())
 		})
 
 		It("omits --force when force is false", func() {
@@ -608,7 +639,22 @@ Result: Device configuration does NOT match the system configuration.
 					return cmd
 				},
 			}
-			Expect(h.SetNvConfigParametersBatch(pciAddress, map[string]string{"PARAM": "1"}, false, false)).To(Succeed())
+			Expect(h.SetNvConfigParametersBatch(nvconfigPort(pciAddress), map[string]string{"PARAM": "1"}, false, false)).To(Succeed())
+		})
+
+		It("uses fwctl device when present", func() {
+			cmd := &execTesting.FakeCmd{}
+			cmd.OutputScript = append(cmd.OutputScript, func() ([]byte, []byte, error) {
+				return []byte("ok"), nil, nil
+			})
+			fakeExec.CommandScript = []execTesting.FakeCommandAction{
+				func(name string, args ...string) exec.Cmd {
+					Expect(args).To(Equal([]string{"-d", "/dev/fwctl/fwctl3", "--yes", "set", "PARAM=1"}))
+					return cmd
+				},
+			}
+			port := v1alpha1.NicDevicePortSpec{PCI: pciAddress, FwctlDevice: "/dev/fwctl/fwctl3"}
+			Expect(h.SetNvConfigParametersBatch(port, map[string]string{"PARAM": "1"}, false, false)).To(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
## What
- Add `status.ports[].fwctlDevice` to `NicDevice` and populate it during device discovery from `/sys/bus/pci/devices/<pci>/fwctl`.
- Treat missing or unreadable fwctl sysfs state as optional: log it and continue discovery without failing.
- Change `pkg/nvconfig` APIs to take `v1alpha1.NicDevicePortSpec` and resolve mlxconfig targets to `port.FwctlDevice` when available, falling back to `port.PCI`.
- Update README, API reference, library docs, CRDs, sample, mocks, and tests.

## Why
`fwctl` exposes a stable character-device target for supported NIC operations. Surfacing it in device status lets the configuration manager prefer `/dev/fwctl/fwctl<N>` for `mlxconfig` query/set/reset/system_conf flows while keeping PCI-address behavior for hosts that do not expose fwctl.

## Verification
- `GOCACHE=/private/tmp/codex-go-cache go build ./...`
- `GOCACHE=/private/tmp/codex-go-cache go test ./pkg/devicediscovery/... ./pkg/nvconfig/... ./pkg/configuration/... -v`
- `GOCACHE=/private/tmp/codex-go-cache make test` passed once with envtest assets; a later rerun hit an unrelated controller envtest timing failure in `Should stop configuration update on one device if firmware update failed for another one`, then `KUBEBUILDER_ASSETS=... GOCACHE=/private/tmp/codex-go-cache go test ./internal/controller -count=1` passed.
- `GOCACHE=/private/tmp/codex-go-cache GOLANGCI_LINT_CACHE=/private/tmp/codex-golangci-cache make lint`
- `GOCACHE=/private/tmp/codex-go-cache make generate-api-docs`
- `git diff --check`
