### PR TITLE
perf: batch DMS get parameter queries

### DIFF
--- a/docs/nic-configuration-library.md
+++ b/docs/nic-configuration-library.md
@@ -271,6 +271,12 @@ dmsc -a <address> <authParams...> --target 0000:08:00.0 set --update "path:::typ
 - `--tls-key <path>` — client TLS private key
 - `--skip-verify` — skip server certificate verification
 
+#### Batch GetParameters
+
+`GetParameters` expands interface and priority parameters, then groups the resulting paths by concrete interface. Each interface is queried with one `dmsc get` command containing multiple `--path` flags; paths without an interface filter use a separate global batch. Parameters marked `hwplbFirstPortOnly` are added only to the first interface batch.
+
+The response parser matches each returned `Path` to its request, reads the value through DMS's selector-free `values` key, and stores it under the request's original parameter path. This removes generated interface and priority selectors while preserving configured selectors such as `slot[id=0]` and `param[id=11]`. Values returned for the same parameter within a batch or across interface batches must match.
+
 #### Batch SetParameters
 
 `SetParameters` collects all update entries via `collectSetUpdates()` (expanding interface/port/priority combinations into individual `path:::type:::value` strings using `formatSetUpdate()`), then passes them to a single `dmsc set` command with multiple `--update` flags and `--timeout 5m`:
@@ -704,7 +710,7 @@ All external commands use `cmd.CombinedOutput()` (not `cmd.Output()`) and log un
 ### Batch Operations
 
 - **mlxconfig**: `SetNvConfigParametersBatch()` applies multiple params in single `mlxconfig set` call
-- **DMS**: `SetParameters()` sends all `--update` entries in single `dmsc set` command with `--timeout 5m`
+- **DMS**: `GetParameters()` batches `--path` entries per concrete interface (with a separate global batch), and `SetParameters()` sends all `--update` entries in a single `dmsc set` command with `--timeout 5m`
 - **IgnoreError**: per-parameter flag; in batch mode, errors are suppressed only if ALL params have `IgnoreError=true`
 
 ### Channel-Based Notifications

--- a/pkg/dms/client.go
+++ b/pkg/dms/client.go
@@ -78,6 +78,29 @@ type dmsClient struct {
 	execInterface execUtils.Interface
 }
 
+type getPathRequest struct {
+	paramPath  string
+	queryPath  string
+	lookupPath string
+}
+
+type getPathRequestBatch struct {
+	key      string
+	requests []getPathRequest
+}
+
+type dmsGetCommandResult struct {
+	Source    string         `json:"source"`
+	Timestamp int64          `json:"timestamp"`
+	Time      string         `json:"time"`
+	Updates   []dmsGetUpdate `json:"updates"`
+}
+
+type dmsGetUpdate struct {
+	Path   string            `json:"Path"`
+	Values map[string]string `json:"values"`
+}
+
 func (i *dmsClient) deviceSnapshot() v1alpha1.NicDeviceStatus {
 	i.deviceMutex.RLock()
 	defer i.deviceMutex.RUnlock()
@@ -90,7 +113,6 @@ func (i *dmsClient) deviceSnapshot() v1alpha1.NicDeviceStatus {
 // filters: {"interface": "name=enp3s0f0np0"}
 // Returns: /interfaces/interface[name=enp3s0f0np0]/nvidia/qos/config/trust-mode
 func injectFilterRules(path string, filters map[string]string) string {
-	log.Log.V(2).Info("injectFilterRules", "path", path, "filters", filters)
 	pathParts := strings.Split(path, "/")
 	for i, part := range pathParts {
 		if filter, exists := filters[part]; exists {
@@ -98,18 +120,15 @@ func injectFilterRules(path string, filters map[string]string) string {
 		}
 	}
 	result := strings.Join(pathParts, "/")
-	log.Log.V(2).Info("injectFilterRules result", "original", path, "filtered", result)
 	return result
 }
 
 // interfaceNameFilter returns a filter map for DMS path filtering based on interface name
 func interfaceNameFilter(interfaceName string) map[string]string {
-	log.Log.V(2).Info("interfaceNameFilter", "interfaceName", interfaceName)
 	return map[string]string{"interface": fmt.Sprintf("name=%s", interfaceName)}
 }
 
 func priorityIdFilter(priorityId int) map[string]string {
-	log.Log.V(2).Info("priorityIdFilter", "priorityId", priorityId)
 	return map[string]string{"priority": fmt.Sprintf("id=%d", priorityId)}
 }
 
@@ -151,59 +170,143 @@ func stripSquareBracketClauses(s string) string {
 	return builder.String()
 }
 
+func normalizeDMSPath(path string) string {
+	return strings.TrimPrefix(path, "/")
+}
+
+func newGetPathRequest(path string, filterRules map[string]string) getPathRequest {
+	return getPathRequest{
+		paramPath:  path,
+		queryPath:  injectFilterRules(path, filterRules),
+		lookupPath: stripSquareBracketClauses(normalizeDMSPath(path)),
+	}
+}
+
+func getPathRequestBatchKey(filterRules map[string]string) string {
+	if interfaceFilter, ok := filterRules[Interface]; ok {
+		return Interface + "[" + interfaceFilter + "]"
+	}
+	return "global"
+}
+
 func (i *dmsClient) RunGetPathCommand(path string, filterRules map[string]string) (string, error) {
 	device := i.deviceSnapshot()
 	log.Log.V(2).Info("dmsClient.RunGetPathCommand()", "path", path, "filterRules", filterRules, "device", device.SerialNumber)
 
-	queryPath := injectFilterRules(path, filterRules)
+	request := newGetPathRequest(path, filterRules)
+	values, err := i.RunGetPathCommands(getPathRequestBatch{key: getPathRequestBatchKey(filterRules), requests: []getPathRequest{request}})
+	if err != nil {
+		return "", err
+	}
+
+	value, ok := values[request.paramPath]
+	if !ok {
+		return "", fmt.Errorf("value not found for path %s", request.paramPath)
+	}
+	log.Log.V(2).Info("RunGetPathCommand successful", "device", device.SerialNumber, "path", path, "value", value)
+	return value, nil
+}
+
+func (i *dmsClient) RunGetPathCommands(batch getPathRequestBatch) (map[string]string, error) {
+	device := i.deviceSnapshot()
+	requests := batch.requests
+	if len(requests) == 0 {
+		return map[string]string{}, nil
+	}
+
+	batchKey := batch.key
+	log.Log.V(2).Info("dmsClient.RunGetPathCommands()", "requestCount", len(requests), "batchKey", batchKey, "device", device.SerialNumber)
 
 	args := append([]string{dmsClientPath, "-a", i.bindAddress}, i.authParams...)
-	args = append(args, "--target", i.targetPCI, "--timeout", dmsClientTimeout, "get", "--path", queryPath)
-	log.Log.V(2).Info("dmsClient.RunGetPathCommand()", "args", strings.Join(args, " "))
+	args = append(args, "--target", i.targetPCI, "--timeout", dmsClientTimeout, "get")
+	for _, request := range requests {
+		args = append(args, "--path", request.queryPath)
+	}
+	log.Log.V(2).Info("dmsClient.RunGetPathCommands()", "batchKey", batchKey, "args", strings.Join(args, " "))
 
 	command := i.execInterface.Command(args[0], args[1:]...)
 
 	log.Log.V(2).Info("Executing command", "device", device.SerialNumber, "command", strings.Join(args, " "))
-	output, err := command.Output()
+	output, err := command.CombinedOutput()
+	log.Log.V(2).Info("dmsClient.RunGetPathCommands() raw DMS output", "device", device.SerialNumber, "batchKey", batchKey, "output", string(output))
 	if err != nil {
-		log.Log.V(2).Error(err, "Command execution failed", "device", device.SerialNumber, "path", path)
-		return "", fmt.Errorf("failed to run get path command: %v", err)
+		log.Log.V(2).Error(err, "Command execution failed", "device", device.SerialNumber)
+		return nil, fmt.Errorf("failed to run get path command: %v, output: %s", err, string(output))
 	}
 	log.Log.V(2).Info("Command execution successful", "device", device.SerialNumber, "outputSize", len(output))
 
-	var result []struct {
-		Source    string `json:"source"`
-		Timestamp int64  `json:"timestamp"`
-		Time      string `json:"time"`
-		Updates   []struct {
-			Path   string            `json:"Path"`
-			Values map[string]string `json:"values"`
-		} `json:"updates"`
+	values, err := parseGetPathCommandOutput(output, requests)
+	if err != nil {
+		log.Log.V(2).Error(err, "Failed to parse get path command output", "device", device.SerialNumber)
+		return nil, err
 	}
 
+	return values, nil
+}
+
+func parseGetPathCommandOutput(output []byte, requests []getPathRequest) (map[string]string, error) {
+	var result []dmsGetCommandResult
 	if err := json.Unmarshal(output, &result); err != nil {
-		log.Log.V(2).Error(err, "Failed to unmarshal command output", "device", device.SerialNumber)
-		return "", fmt.Errorf("failed to unmarshal command output: %v", err)
+		return nil, fmt.Errorf("failed to unmarshal command output: %v", err)
 	}
 
-	log.Log.V(2).Info("dmsClient.RunGetPathCommand()", "json result", result)
+	log.Log.V(2).Info("parseGetPathCommandOutput()", "json result", result)
 
-	if len(result) == 0 || len(result[0].Updates) == 0 {
-		log.Log.V(2).Info("No updates found in command output", "device", device.SerialNumber)
-		return "", fmt.Errorf("no updates found in command output")
+	var updates []dmsGetUpdate
+	for _, item := range result {
+		updates = append(updates, item.Updates...)
+	}
+	if len(updates) == 0 {
+		return nil, fmt.Errorf("no updates found in command output")
 	}
 
-	// we have to remove the leading "/" from the path, because DMS returns the path without it
-	// Remove all "[... ]" blocks from the path for lookup to match the values map keys
-	lookupPath := stripSquareBracketClauses(strings.TrimPrefix(path, "/"))
-	value, ok := result[0].Updates[0].Values[lookupPath]
-	if !ok {
-		log.Log.V(2).Info("Value not found for path", "device", device.SerialNumber, "path", path)
-		return "", fmt.Errorf("value not found for path %s", path)
+	updatesByPath := make(map[string]dmsGetUpdate, len(updates))
+	for _, update := range updates {
+		updatePath := normalizeDMSPath(update.Path)
+		existing, found := updatesByPath[updatePath]
+		if !found {
+			updatesByPath[updatePath] = update
+			continue
+		}
+
+		values := make(map[string]string, len(existing.Values)+len(update.Values))
+		for key, value := range existing.Values {
+			values[key] = value
+		}
+		for key, value := range update.Values {
+			if existingValue, exists := values[key]; exists && existingValue != value {
+				return nil, fmt.Errorf("conflicting value found for path %s", update.Path)
+			}
+			values[key] = value
+		}
+		existing.Values = values
+		updatesByPath[updatePath] = existing
 	}
 
-	log.Log.V(2).Info("RunGetPathCommand successful", "device", device.SerialNumber, "path", path, "value", value)
-	return value, nil
+	values := make(map[string]string, len(requests))
+	for _, request := range requests {
+		update, ok := updatesByPath[normalizeDMSPath(request.queryPath)]
+		if !ok {
+			return nil, fmt.Errorf("no update found for path %s", request.queryPath)
+		}
+		value, ok := update.Values[request.lookupPath]
+		if !ok {
+			updateLookupPath := stripSquareBracketClauses(normalizeDMSPath(update.Path))
+			value, ok = update.Values[updateLookupPath]
+		}
+		if !ok {
+			return nil, fmt.Errorf("value not found for path %s", request.paramPath)
+		}
+
+		path := request.paramPath
+		currentValue, found := values[path]
+		if found && currentValue != value {
+			return nil, types.ValuesDoNotMatchError(types.ConfigurationParameter{Name: request.paramPath, DMSPath: path}, value)
+		}
+		values[path] = value
+	}
+
+	return values, nil
 }
 
 // formatSetUpdate builds a "path:::type:::value" update entry, applying filter rules to the path.
@@ -377,34 +480,60 @@ func (i *dmsClient) InstallBFB(ctx context.Context, version string, bfbPath stri
 	return nil
 }
 
-func (i *dmsClient) getCompareReplaceValue(param *types.ConfigurationParameter, filterRules map[string]string, value *string) error {
-	device := i.deviceSnapshot()
-	result, err := i.RunGetPathCommand(param.DMSPath, filterRules)
-	if err != nil {
-		log.Log.V(2).Error(err, "Failed to get parameter", "device", device.SerialNumber, "param", param)
-		return fmt.Errorf("failed to get parameter: %v", err)
-	}
-
-	if *value != "" && result != *value {
-		err = types.ValuesDoNotMatchError(*param, result)
-		log.Log.V(2).Error(err, "Failed to get parameter", "device", device.SerialNumber, "param", param)
-		return err
-	}
-
-	*value = result
-	return nil
-
-}
-
 func (i *dmsClient) GetParameters(params []types.ConfigurationParameter) (map[string]string, error) {
 	device := i.deviceSnapshot()
 	log.Log.V(2).Info("dmsClient.GetParameters()", "params", params, "device", device.SerialNumber)
 
 	values := make(map[string]string)
+	paramByPath := make(map[string]types.ConfigurationParameter, len(params))
+	for _, param := range params {
+		paramByPath[param.DMSPath] = param
+	}
+
+	batches := collectGetPathRequestBatches(device, params)
+	for _, batch := range batches {
+		requestValues, err := i.RunGetPathCommands(batch)
+		if err != nil {
+			log.Log.V(2).Error(err, "Failed to get parameters", "device", device.SerialNumber, "batchKey", batch.key)
+			if types.IsValuesDoNotMatchError(err) {
+				return nil, err
+			}
+			return nil, fmt.Errorf("failed to get parameter: %v", err)
+		}
+
+		for path, result := range requestValues {
+			param, ok := paramByPath[path]
+			if !ok {
+				return nil, fmt.Errorf("unexpected value found for path %s", path)
+			}
+			value, found := values[path]
+			if found && result != value {
+				err := types.ValuesDoNotMatchError(param, result)
+				log.Log.V(2).Error(err, "Failed to get parameter", "device", device.SerialNumber, "param", param)
+				return nil, err
+			}
+			values[path] = result
+		}
+	}
+
+	return values, nil
+}
+
+func collectGetPathRequestBatches(device v1alpha1.NicDeviceStatus, params []types.ConfigurationParameter) []getPathRequestBatch {
+	batches := []getPathRequestBatch{}
+	batchIndexes := make(map[string]int)
+	appendRequest := func(batchKey string, request getPathRequest) {
+		batchIndex, found := batchIndexes[batchKey]
+		if !found {
+			batchIndex = len(batches)
+			batchIndexes[batchKey] = batchIndex
+			batches = append(batches, getPathRequestBatch{key: batchKey})
+		}
+		batches[batchIndex].requests = append(batches[batchIndex].requests, request)
+	}
 
 	for _, param := range params {
 		paramPathParts := strings.Split(param.DMSPath, "/")
-		value := ""
 
 		if slices.Contains(paramPathParts, Interface) {
 			ports := device.Ports
@@ -413,36 +542,22 @@ func (i *dmsClient) GetParameters(params []types.ConfigurationParameter) (map[st
 			}
 			for _, port := range ports {
 				filterRules := interfaceNameFilter(port.NetworkInterface)
+				batchKey := getPathRequestBatchKey(filterRules)
 
 				if slices.Contains(paramPathParts, Priority) {
 					for id := 0; id < 8; id++ {
-						filterRules := mergeFilterRules(filterRules, priorityIdFilter(id))
-
-						err := i.getCompareReplaceValue(&param, filterRules, &value)
-						if err != nil {
-							return nil, err
-						}
+						fr := mergeFilterRules(filterRules, priorityIdFilter(id))
+						appendRequest(batchKey, newGetPathRequest(param.DMSPath, fr))
 					}
 				} else {
-					err := i.getCompareReplaceValue(&param, filterRules, &value)
-					if err != nil {
-						return nil, err
-					}
+					appendRequest(batchKey, newGetPathRequest(param.DMSPath, filterRules))
 				}
 			}
-
 		} else {
-			var err error
-			value, err = i.RunGetPathCommand(param.DMSPath, nil)
-			if err != nil {
-				log.Log.V(2).Error(err, "Failed to get parameter", "device", device.SerialNumber, "param", param)
-				return nil, fmt.Errorf("failed to get parameter: %v", err)
-			}
+			appendRequest(getPathRequestBatchKey(nil), newGetPathRequest(param.DMSPath, nil))
 		}
-
-		values[param.DMSPath] = value
 	}
-	return values, nil
+	return batches
 }
 
 // collectSetUpdates expands all parameters into individual "path:::type:::value" update entries,

--- a/pkg/dms/client_test.go
+++ b/pkg/dms/client_test.go
@@ -89,6 +89,16 @@ func createToSSetPath(netInterface string, value int) string {
 // makeGetOutput returns JSON output for RunGetPathCommand
 // displayPath is the Path field value; valueKeyPath is the key expected by DMS client (original unfiltered path)
 func makeGetOutput(displayPath, valueKeyPath, value string) []byte {
+	return makeBatchedGetOutput(getOutputUpdate{displayPath: displayPath, valueKeyPath: valueKeyPath, value: value})
+}
+
+type getOutputUpdate struct {
+	displayPath  string
+	valueKeyPath string
+	value        string
+}
+
+func makeBatchedGetOutput(updates ...getOutputUpdate) []byte {
 	t := []struct {
 		Source    string `json:"source"`
 		Timestamp int64  `json:"timestamp"`
@@ -102,13 +112,16 @@ func makeGetOutput(displayPath, valueKeyPath, value string) []byte {
 			Source:    "test",
 			Timestamp: 0,
 			Time:      "",
-			Updates: []struct {
-				Path   string            `json:"Path"`
-				Values map[string]string `json:"values"`
-			}{
-				{Path: displayPath, Values: map[string]string{valueKeyPath[1:]: value}},
-			},
 		},
+	}
+	for _, update := range updates {
+		t[0].Updates = append(t[0].Updates, struct {
+			Path   string            `json:"Path"`
+			Values map[string]string `json:"values"`
+		}{
+			Path:   update.displayPath,
+			Values: map[string]string{strings.TrimPrefix(update.valueKeyPath, "/"): update.value},
+		})
 	}
 	b, _ := json.Marshal(t)
 	return b
@@ -355,14 +368,418 @@ var _ = Describe("DMSClient", func() {
 		})
 	})
 
+	Describe("RunGetPathCommands", func() {
+		It("returns values keyed by original parameter paths", func() {
+			paramPath := "/interfaces/interface/nvidia/cc/config/priority/rp_enabled"
+			requests := []getPathRequest{
+				newGetPathRequest(paramPath, mergeFilterRules(interfaceNameFilter(testNetworkInterface), priorityIdFilter(0))),
+				newGetPathRequest(paramPath, mergeFilterRules(interfaceNameFilter(testNetworkInterface), priorityIdFilter(1))),
+			}
+			fakeExec.CommandScript = []execTesting.FakeCommandAction{
+				func(cmd string, args ...string) exec.Cmd {
+					return createFakeCmd(makeBatchedGetOutput(
+						getOutputUpdate{displayPath: requests[0].queryPath, valueKeyPath: paramPath, value: "true"},
+						getOutputUpdate{displayPath: requests[1].queryPath, valueKeyPath: paramPath, value: "true"},
+					), nil)
+				},
+			}
+
+			values, err := client.RunGetPathCommands(getPathRequestBatch{
+				key:      getPathRequestBatchKey(interfaceNameFilter(testNetworkInterface)),
+				requests: requests,
+			})
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(values).To(Equal(map[string]string{
+				paramPath: "true",
+			}))
+		})
+
+		It("returns a values-do-not-match error for conflicting values of one parameter", func() {
+			paramPath := "/interfaces/interface/nvidia/cc/config/priority/rp_enabled"
+			requests := []getPathRequest{
+				newGetPathRequest(paramPath, mergeFilterRules(interfaceNameFilter(testNetworkInterface), priorityIdFilter(0))),
+				newGetPathRequest(paramPath, mergeFilterRules(interfaceNameFilter(testNetworkInterface), priorityIdFilter(1))),
+			}
+			fakeExec.CommandScript = []execTesting.FakeCommandAction{
+				func(cmd string, args ...string) exec.Cmd {
+					return createFakeCmd(makeBatchedGetOutput(
+						getOutputUpdate{displayPath: requests[0].queryPath, valueKeyPath: paramPath, value: "true"},
+						getOutputUpdate{displayPath: requests[1].queryPath, valueKeyPath: paramPath, value: "false"},
+					), nil)
+				},
+			}
+
+			_, err := client.RunGetPathCommands(getPathRequestBatch{
+				key:      getPathRequestBatchKey(interfaceNameFilter(testNetworkInterface)),
+				requests: requests,
+			})
+
+			Expect(err).To(HaveOccurred())
+			Expect(types.IsValuesDoNotMatchError(err)).To(BeTrue())
+		})
+	})
+
+	Describe("parseGetPathCommandOutput", func() {
+		It("maps multiple parameter values from a single batched command output", func() {
+			requests := []getPathRequest{
+				newGetPathRequest(QoSTrustModePath, interfaceNameFilter(testNetworkInterface)),
+				newGetPathRequest(QoSPFCPath, interfaceNameFilter(testNetworkInterface)),
+				newGetPathRequest(ToSPath, interfaceNameFilter(testNetworkInterface)),
+			}
+			output := makeBatchedGetOutput(
+				getOutputUpdate{displayPath: createTrustModePath(testNetworkInterface), valueKeyPath: QoSTrustModePath, value: "dscp"},
+				getOutputUpdate{displayPath: createPFCPath(testNetworkInterface), valueKeyPath: QoSPFCPath, value: "00001000"},
+				getOutputUpdate{displayPath: createToSPath(testNetworkInterface), valueKeyPath: ToSPath, value: "96"},
+			)
+
+			values, err := parseGetPathCommandOutput(output, requests)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(values).To(Equal(map[string]string{
+				QoSTrustModePath: "dscp",
+				QoSPFCPath:       "00001000",
+				ToSPath:          "96",
+			}))
+		})
+
+		It("matches batched output by returned path when updates are out of request order", func() {
+			requests := []getPathRequest{
+				newGetPathRequest(QoSTrustModePath, interfaceNameFilter(testNetworkInterface)),
+				newGetPathRequest(QoSPFCPath, interfaceNameFilter(testNetworkInterface)),
+				newGetPathRequest(ToSPath, interfaceNameFilter(testNetworkInterface)),
+			}
+			output := makeBatchedGetOutput(
+				getOutputUpdate{displayPath: createToSPath(testNetworkInterface), valueKeyPath: ToSPath, value: "96"},
+				getOutputUpdate{displayPath: createPFCPath(testNetworkInterface), valueKeyPath: QoSPFCPath, value: "00001000"},
+				getOutputUpdate{displayPath: createTrustModePath(testNetworkInterface), valueKeyPath: QoSTrustModePath, value: "dscp"},
+			)
+
+			values, err := parseGetPathCommandOutput(output, requests)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(values).To(Equal(map[string]string{
+				QoSTrustModePath: "dscp",
+				QoSPFCPath:       "00001000",
+				ToSPath:          "96",
+			}))
+		})
+
+		It("parses a raw batched dmsc output with many parameter values", func() {
+			requests := []getPathRequest{
+				newGetPathRequest("/interfaces/interface/nvidia/qos/config/trust-mode", interfaceNameFilter(testNetworkInterface)),
+				newGetPathRequest("/interfaces/interface/nvidia/qos/config/pfc", interfaceNameFilter(testNetworkInterface)),
+				newGetPathRequest("/interfaces/interface/nvidia/roce/config/cc-per-plane", interfaceNameFilter(testNetworkInterface)),
+				newGetPathRequest("/interfaces/interface/nvidia/roce/config/adaptive-retransmission", interfaceNameFilter(testNetworkInterface)),
+				newGetPathRequest("/interfaces/interface/nvidia/roce/config/tx-window", interfaceNameFilter(testNetworkInterface)),
+				newGetPathRequest("/interfaces/interface/nvidia/roce/config/slow-restart", interfaceNameFilter(testNetworkInterface)),
+				newGetPathRequest("/interfaces/interface/nvidia/roce/config/adaptive-routing-force", interfaceNameFilter(testNetworkInterface)),
+				newGetPathRequest("/interfaces/interface/nvidia/cc/config/priority/rp_enabled", mergeFilterRules(interfaceNameFilter(testNetworkInterface), priorityIdFilter(0))),
+				newGetPathRequest("/interfaces/interface/nvidia/cc/config/priority/rp_enabled", mergeFilterRules(interfaceNameFilter(testNetworkInterface), priorityIdFilter(1))),
+				newGetPathRequest("/interfaces/interface/nvidia/cc/config/priority/np_enabled", mergeFilterRules(interfaceNameFilter(testNetworkInterface), priorityIdFilter(0))),
+				newGetPathRequest("/interfaces/interface/nvidia/cc/config/priority/np_enabled", mergeFilterRules(interfaceNameFilter(testNetworkInterface), priorityIdFilter(1))),
+				newGetPathRequest("/interfaces/interface/nvidia/cc/slot[id=0]/config/enabled", interfaceNameFilter(testNetworkInterface)),
+				newGetPathRequest("/interfaces/interface/nvidia/cc/slot[id=0]/config/counter_enable", interfaceNameFilter(testNetworkInterface)),
+				newGetPathRequest("/interfaces/interface/nvidia/cc/slot[id=15]/config/enabled", interfaceNameFilter(testNetworkInterface)),
+				newGetPathRequest("/interfaces/interface/ethernet/nvidia/config/inter-packet-gap", interfaceNameFilter(testNetworkInterface)),
+			}
+			rawOutput := []byte(`[
+  {
+    "source": "dmsc",
+    "timestamp": 1783591000,
+    "time": "2026-07-09T11:16:40Z",
+    "updates": [
+      {
+        "Path": "/interfaces/interface[name=enp3s0f0np0]/nvidia/qos/config/trust-mode",
+        "values": {
+          "interfaces/interface/nvidia/qos/config/trust-mode": "dscp"
+        }
+      },
+      {
+        "Path": "/interfaces/interface[name=enp3s0f0np0]/nvidia/qos/config/pfc",
+        "values": {
+          "interfaces/interface/nvidia/qos/config/pfc": "00001000"
+        }
+      },
+      {
+        "Path": "/interfaces/interface[name=enp3s0f0np0]/nvidia/roce/config/cc-per-plane",
+        "values": {
+          "interfaces/interface/nvidia/roce/config/cc-per-plane": "true"
+        }
+      },
+      {
+        "Path": "/interfaces/interface[name=enp3s0f0np0]/nvidia/roce/config/adaptive-retransmission",
+        "values": {
+          "interfaces/interface/nvidia/roce/config/adaptive-retransmission": "true"
+        }
+      },
+      {
+        "Path": "/interfaces/interface[name=enp3s0f0np0]/nvidia/roce/config/tx-window",
+        "values": {
+          "interfaces/interface/nvidia/roce/config/tx-window": "64"
+        }
+      },
+      {
+        "Path": "/interfaces/interface[name=enp3s0f0np0]/nvidia/roce/config/slow-restart",
+        "values": {
+          "interfaces/interface/nvidia/roce/config/slow-restart": "false"
+        }
+      },
+      {
+        "Path": "/interfaces/interface[name=enp3s0f0np0]/nvidia/roce/config/adaptive-routing-force",
+        "values": {
+          "interfaces/interface/nvidia/roce/config/adaptive-routing-force": "true"
+        }
+      },
+      {
+        "Path": "/interfaces/interface[name=enp3s0f0np0]/nvidia/cc/config/priority[id=0]/rp_enabled",
+        "values": {
+          "interfaces/interface/nvidia/cc/config/priority/rp_enabled": "true"
+        }
+      },
+	      {
+	        "Path": "/interfaces/interface[name=enp3s0f0np0]/nvidia/cc/config/priority[id=1]/rp_enabled",
+	        "values": {
+	          "interfaces/interface/nvidia/cc/config/priority/rp_enabled": "true"
+	        }
+	      },
+      {
+        "Path": "/interfaces/interface[name=enp3s0f0np0]/nvidia/cc/config/priority[id=0]/np_enabled",
+        "values": {
+          "interfaces/interface/nvidia/cc/config/priority/np_enabled": "true"
+        }
+      },
+      {
+        "Path": "/interfaces/interface[name=enp3s0f0np0]/nvidia/cc/config/priority[id=1]/np_enabled",
+        "values": {
+          "interfaces/interface/nvidia/cc/config/priority/np_enabled": "true"
+        }
+      },
+      {
+        "Path": "/interfaces/interface[name=enp3s0f0np0]/nvidia/cc/slot[id=0]/config/enabled",
+        "values": {
+          "interfaces/interface/nvidia/cc/slot/config/enabled": "true"
+        }
+      },
+      {
+        "Path": "/interfaces/interface[name=enp3s0f0np0]/nvidia/cc/slot[id=0]/config/counter_enable",
+        "values": {
+          "interfaces/interface/nvidia/cc/slot/config/counter_enable": "true"
+        }
+      },
+      {
+        "Path": "/interfaces/interface[name=enp3s0f0np0]/nvidia/cc/slot[id=15]/config/enabled",
+        "values": {
+          "interfaces/interface/nvidia/cc/slot/config/enabled": "false"
+        }
+      },
+      {
+        "Path": "/interfaces/interface[name=enp3s0f0np0]/ethernet/nvidia/config/inter-packet-gap",
+        "values": {
+          "interfaces/interface/ethernet/nvidia/config/inter-packet-gap": "12"
+        }
+      }
+    ]
+  }
+]`)
+
+			values, err := parseGetPathCommandOutput(rawOutput, requests)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(values).To(Equal(map[string]string{
+				"/interfaces/interface/nvidia/qos/config/trust-mode":               "dscp",
+				"/interfaces/interface/nvidia/qos/config/pfc":                      "00001000",
+				"/interfaces/interface/nvidia/roce/config/cc-per-plane":            "true",
+				"/interfaces/interface/nvidia/roce/config/adaptive-retransmission": "true",
+				"/interfaces/interface/nvidia/roce/config/tx-window":               "64",
+				"/interfaces/interface/nvidia/roce/config/slow-restart":            "false",
+				"/interfaces/interface/nvidia/roce/config/adaptive-routing-force":  "true",
+				"/interfaces/interface/nvidia/cc/config/priority/rp_enabled":       "true",
+				"/interfaces/interface/nvidia/cc/config/priority/np_enabled":       "true",
+				"/interfaces/interface/nvidia/cc/slot[id=0]/config/enabled":        "true",
+				"/interfaces/interface/nvidia/cc/slot[id=0]/config/counter_enable": "true",
+				"/interfaces/interface/nvidia/cc/slot[id=15]/config/enabled":       "false",
+				"/interfaces/interface/ethernet/nvidia/config/inter-packet-gap":    "12",
+			}))
+		})
+
+		It("parses repeated paths from multiple batched result objects", func() {
+			requests := []getPathRequest{
+				newGetPathRequest("/interfaces/interface/nvidia/roce/config/tx-window", interfaceNameFilter("eth_p0_r0")),
+				newGetPathRequest("/interfaces/interface/nvidia/roce/config/slow-restart", interfaceNameFilter("eth_p0_r0")),
+				newGetPathRequest("/interfaces/interface/nvidia/roce/config/tx-window", interfaceNameFilter("eth_p1_r0")),
+				newGetPathRequest("/interfaces/interface/nvidia/roce/config/slow-restart", interfaceNameFilter("eth_p1_r0")),
+			}
+			rawOutput := []byte(`[
+  {
+    "source": "localhost:9339",
+    "timestamp": 1783591180747365539,
+    "time": "2026-07-09T09:59:40.747365539Z",
+    "target": "0000:c9:00.1",
+    "updates": [
+      {
+        "Path": "interfaces/interface[name=eth_p0_r0]/nvidia/roce/config/tx-window",
+        "values": {
+          "interfaces/interface/nvidia/roce/config/tx-window": "false"
+        }
+      }
+    ]
+  },
+  {
+    "source": "localhost:9339",
+    "timestamp": 1783591180873488751,
+    "time": "2026-07-09T09:59:40.873488751Z",
+    "target": "0000:c9:00.1",
+    "updates": [
+      {
+        "Path": "interfaces/interface[name=eth_p0_r0]/nvidia/roce/config/slow-restart",
+        "values": {
+          "interfaces/interface/nvidia/roce/config/slow-restart": "true"
+        }
+      }
+    ]
+  },
+  {
+    "source": "localhost:9339",
+    "timestamp": 1783591180975087880,
+    "time": "2026-07-09T09:59:40.97508788Z",
+    "target": "0000:c9:00.1",
+    "updates": [
+      {
+        "Path": "interfaces/interface[name=eth_p1_r0]/nvidia/roce/config/tx-window",
+        "values": {
+          "interfaces/interface/nvidia/roce/config/tx-window": "false"
+        }
+      }
+    ]
+  },
+  {
+    "source": "localhost:9339",
+    "timestamp": 1783591181073981538,
+    "time": "2026-07-09T09:59:41.073981538Z",
+    "target": "0000:c9:00.1",
+    "updates": [
+      {
+        "Path": "interfaces/interface[name=eth_p1_r0]/nvidia/roce/config/slow-restart",
+        "values": {
+          "interfaces/interface/nvidia/roce/config/slow-restart": "true"
+        }
+      }
+    ]
+  },
+  {
+    "source": "localhost:9339",
+    "timestamp": 1783591181173245802,
+    "time": "2026-07-09T09:59:41.173245802Z",
+    "target": "0000:c9:00.1",
+    "updates": [
+      {
+        "Path": "interfaces/interface[name=eth_p0_r0]/nvidia/roce/config/tx-window",
+        "values": {
+          "interfaces/interface/nvidia/roce/config/tx-window": "false"
+        }
+      }
+    ]
+  },
+  {
+    "source": "localhost:9339",
+    "timestamp": 1783591181271181677,
+    "time": "2026-07-09T09:59:41.271181677Z",
+    "target": "0000:c9:00.1",
+    "updates": [
+      {
+        "Path": "interfaces/interface[name=eth_p0_r0]/nvidia/roce/config/slow-restart",
+        "values": {
+          "interfaces/interface/nvidia/roce/config/slow-restart": "true"
+        }
+      }
+    ]
+  },
+  {
+    "source": "localhost:9339",
+    "timestamp": 1783591181369848140,
+    "time": "2026-07-09T09:59:41.36984814Z",
+    "target": "0000:c9:00.1",
+    "updates": [
+      {
+        "Path": "interfaces/interface[name=eth_p1_r0]/nvidia/roce/config/tx-window",
+        "values": {
+          "interfaces/interface/nvidia/roce/config/tx-window": "false"
+        }
+      }
+    ]
+  },
+  {
+    "source": "localhost:9339",
+    "timestamp": 1783591181469246758,
+    "time": "2026-07-09T09:59:41.469246758Z",
+    "target": "0000:c9:00.1",
+    "updates": [
+      {
+        "Path": "interfaces/interface[name=eth_p1_r0]/nvidia/roce/config/slow-restart",
+        "values": {
+          "interfaces/interface/nvidia/roce/config/slow-restart": "true"
+        }
+      }
+    ]
+  }
+]`)
+
+			values, err := parseGetPathCommandOutput(rawOutput, requests)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(values).To(Equal(map[string]string{
+				"/interfaces/interface/nvidia/roce/config/tx-window":    "false",
+				"/interfaces/interface/nvidia/roce/config/slow-restart": "true",
+			}))
+		})
+
+		It("returns a values-do-not-match error for conflicting values of one parameter", func() {
+			paramPath := "/interfaces/interface/nvidia/roce/config/tx-window"
+			requests := []getPathRequest{
+				newGetPathRequest(paramPath, interfaceNameFilter("eth_p0_r0")),
+				newGetPathRequest(paramPath, interfaceNameFilter("eth_p1_r0")),
+			}
+			output := makeBatchedGetOutput(
+				getOutputUpdate{displayPath: requests[0].queryPath, valueKeyPath: paramPath, value: "false"},
+				getOutputUpdate{displayPath: requests[1].queryPath, valueKeyPath: paramPath, value: "true"},
+			)
+
+			_, err := parseGetPathCommandOutput(output, requests)
+
+			Expect(err).To(HaveOccurred())
+			Expect(types.IsValuesDoNotMatchError(err)).To(BeTrue())
+		})
+
+		It("returns error when repeated paths have conflicting values", func() {
+			requests := []getPathRequest{
+				newGetPathRequest(QoSTrustModePath, interfaceNameFilter(testNetworkInterface)),
+			}
+			output := makeBatchedGetOutput(
+				getOutputUpdate{displayPath: createTrustModePath(testNetworkInterface), valueKeyPath: QoSTrustModePath, value: "dscp"},
+				getOutputUpdate{displayPath: createTrustModePath(testNetworkInterface), valueKeyPath: QoSTrustModePath, value: "pfc"},
+			)
+
+			_, err := parseGetPathCommandOutput(output, requests)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("conflicting value found for path /interfaces/interface[name=enp3s0f0np0]/nvidia/qos/config/trust-mode"))
+		})
+	})
+
 	Describe("GetParameters", func() {
+		collectPathPayloads := func(args []string) []string {
+			var payloads []string
+			for i, arg := range args {
+				if arg == "--path" && i+1 < len(args) {
+					payloads = append(payloads, args[i+1])
+				}
+			}
+			return payloads
+		}
+
 		It("returns value for simple path", func() {
 			param := types.ConfigurationParameter{DMSPath: "/nvidia/mode/config/mode"}
 			fakeExec.CommandScript = []execTesting.FakeCommandAction{
 				func(cmd string, args ...string) exec.Cmd {
 					verifyTargetFlag(args)
-					path := args[len(args)-1]
-					Expect(path).To(Equal(param.DMSPath))
+					paths := collectPathPayloads(args)
+					Expect(paths).To(Equal([]string{param.DMSPath}))
 					return createFakeCmd(makeGetOutput(param.DMSPath, param.DMSPath, "NIC"), nil)
 				},
 			}
@@ -372,20 +789,16 @@ var _ = Describe("DMSClient", func() {
 			Expect(vals[param.DMSPath]).To(Equal("NIC"))
 		})
 
-		It("returns value for interface path with final unfiltered get", func() {
+		It("returns value for interface path in a batched command", func() {
 			param := types.ConfigurationParameter{DMSPath: "/interfaces/interface/nvidia/qos/config/trust-mode"}
 
 			filtered := createTrustModePath(testNetworkInterface)
 			fakeExec.CommandScript = []execTesting.FakeCommandAction{
-				// filtered get per port
 				func(cmd string, args ...string) exec.Cmd {
 					verifyTargetFlag(args)
+					paths := collectPathPayloads(args)
+					Expect(paths).To(Equal([]string{filtered}))
 					return createFakeCmd(makeGetOutput(filtered, param.DMSPath, "dscp"), nil)
-				},
-				// final unfiltered get
-				func(cmd string, args ...string) exec.Cmd {
-					verifyTargetFlag(args)
-					return createFakeCmd(makeGetOutput(param.DMSPath, param.DMSPath, "dscp"), nil)
 				},
 			}
 
@@ -394,16 +807,180 @@ var _ = Describe("DMSClient", func() {
 			Expect(vals[param.DMSPath]).To(Equal("dscp"))
 		})
 
-		It("fails on mismatch across priorities", func() {
-			param := types.ConfigurationParameter{DMSPath: "/interfaces/interface/nvidia/cc/config/priority/np_enabled"}
-			filtered := "/interfaces/interface[name=" + testNetworkInterface + "]/nvidia/cc/config/priority/np_enabled"
+		It("fails on mismatch across interfaces of the same device", func() {
+			const secondNetworkInterface = "enp3s0f1np1"
+			param := types.ConfigurationParameter{DMSPath: "/interfaces/interface/nvidia/qos/config/trust-mode"}
+			multiPortClient := &dmsClient{
+				device: v1alpha1.NicDeviceStatus{
+					SerialNumber: "test-serial",
+					Ports: []v1alpha1.NicDevicePortSpec{
+						{PCI: testPCI, NetworkInterface: testNetworkInterface},
+						{PCI: "0000:00:00.1", NetworkInterface: secondNetworkInterface},
+					},
+				},
+				targetPCI:     testPCI,
+				bindAddress:   ":9339",
+				authParams:    []string{"--insecure"},
+				execInterface: fakeExec,
+			}
+			expectedPaths := []string{
+				createTrustModePath(testNetworkInterface),
+				createTrustModePath(secondNetworkInterface),
+			}
 
 			fakeExec.CommandScript = []execTesting.FakeCommandAction{
 				func(cmd string, args ...string) exec.Cmd {
-					return createFakeCmd(makeGetOutput(filtered, param.DMSPath, "1"), nil)
+					verifyTargetFlag(args)
+					paths := collectPathPayloads(args)
+					Expect(paths).To(Equal([]string{expectedPaths[0]}))
+					return createFakeCmd(makeBatchedGetOutput(
+						getOutputUpdate{displayPath: expectedPaths[0], valueKeyPath: param.DMSPath, value: "dscp"},
+					), nil)
 				},
 				func(cmd string, args ...string) exec.Cmd {
-					return createFakeCmd(makeGetOutput(filtered, param.DMSPath, "0"), nil)
+					verifyTargetFlag(args)
+					paths := collectPathPayloads(args)
+					Expect(paths).To(Equal([]string{expectedPaths[1]}))
+					return createFakeCmd(makeBatchedGetOutput(
+						getOutputUpdate{displayPath: expectedPaths[1], valueKeyPath: param.DMSPath, value: "pfc"},
+					), nil)
+				},
+			}
+
+			_, err := multiPortClient.GetParameters([]types.ConfigurationParameter{param})
+			Expect(err).To(HaveOccurred())
+			Expect(types.IsValuesDoNotMatchError(err)).To(BeTrue())
+		})
+
+		It("returns value when per-interface batches agree across device ports", func() {
+			const secondNetworkInterface = "enp3s0f1np1"
+			param := types.ConfigurationParameter{DMSPath: "/interfaces/interface/nvidia/qos/config/trust-mode"}
+			multiPortClient := &dmsClient{
+				device: v1alpha1.NicDeviceStatus{
+					SerialNumber: "test-serial",
+					Ports: []v1alpha1.NicDevicePortSpec{
+						{PCI: testPCI, NetworkInterface: testNetworkInterface},
+						{PCI: "0000:00:00.1", NetworkInterface: secondNetworkInterface},
+					},
+				},
+				targetPCI:     testPCI,
+				bindAddress:   ":9339",
+				authParams:    []string{"--insecure"},
+				execInterface: fakeExec,
+			}
+			expectedPaths := []string{
+				createTrustModePath(testNetworkInterface),
+				createTrustModePath(secondNetworkInterface),
+			}
+
+			fakeExec.CommandScript = []execTesting.FakeCommandAction{
+				func(cmd string, args ...string) exec.Cmd {
+					verifyTargetFlag(args)
+					paths := collectPathPayloads(args)
+					Expect(paths).To(Equal([]string{expectedPaths[0]}))
+					return createFakeCmd(makeBatchedGetOutput(
+						getOutputUpdate{displayPath: expectedPaths[0], valueKeyPath: param.DMSPath, value: "dscp"},
+					), nil)
+				},
+				func(cmd string, args ...string) exec.Cmd {
+					verifyTargetFlag(args)
+					paths := collectPathPayloads(args)
+					Expect(paths).To(Equal([]string{expectedPaths[1]}))
+					return createFakeCmd(makeBatchedGetOutput(
+						getOutputUpdate{displayPath: expectedPaths[1], valueKeyPath: param.DMSPath, value: "dscp"},
+					), nil)
+				},
+			}
+
+			vals, err := multiPortClient.GetParameters([]types.ConfigurationParameter{param})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vals[param.DMSPath]).To(Equal("dscp"))
+		})
+
+		It("fails on mismatch when the first interface value is empty", func() {
+			const secondNetworkInterface = "enp3s0f1np1"
+			param := types.ConfigurationParameter{
+				Name:    "trust-mode",
+				DMSPath: "/interfaces/interface/nvidia/qos/config/trust-mode",
+			}
+			multiPortClient := &dmsClient{
+				device: v1alpha1.NicDeviceStatus{
+					SerialNumber: "test-serial",
+					Ports: []v1alpha1.NicDevicePortSpec{
+						{PCI: testPCI, NetworkInterface: testNetworkInterface},
+						{PCI: "0000:00:00.1", NetworkInterface: secondNetworkInterface},
+					},
+				},
+				targetPCI:     testPCI,
+				bindAddress:   ":9339",
+				authParams:    []string{"--insecure"},
+				execInterface: fakeExec,
+			}
+			firstPath := createTrustModePath(testNetworkInterface)
+			secondPath := createTrustModePath(secondNetworkInterface)
+			fakeExec.CommandScript = []execTesting.FakeCommandAction{
+				func(cmd string, args ...string) exec.Cmd {
+					return createFakeCmd(makeGetOutput(firstPath, param.DMSPath, ""), nil)
+				},
+				func(cmd string, args ...string) exec.Cmd {
+					return createFakeCmd(makeGetOutput(secondPath, param.DMSPath, "dscp"), nil)
+				},
+			}
+
+			_, err := multiPortClient.GetParameters([]types.ConfigurationParameter{param})
+
+			Expect(err).To(HaveOccurred())
+			Expect(types.IsValuesDoNotMatchError(err)).To(BeTrue())
+		})
+
+		It("keeps configured slot and param filters as distinct result keys", func() {
+			params := []types.ConfigurationParameter{
+				{Name: "param-0", DMSPath: "/interfaces/interface/nvidia/cc/slot[id=0]/param[id=0]/config/value"},
+				{Name: "param-11", DMSPath: "/interfaces/interface/nvidia/cc/slot[id=0]/param[id=11]/config/value"},
+			}
+			queryPaths := []string{
+				injectFilterRules(params[0].DMSPath, interfaceNameFilter(testNetworkInterface)),
+				injectFilterRules(params[1].DMSPath, interfaceNameFilter(testNetworkInterface)),
+			}
+			valuePath := "/interfaces/interface/nvidia/cc/slot/param/config/value"
+			fakeExec.CommandScript = []execTesting.FakeCommandAction{
+				func(cmd string, args ...string) exec.Cmd {
+					return createFakeCmd(makeBatchedGetOutput(
+						getOutputUpdate{displayPath: queryPaths[0], valueKeyPath: valuePath, value: "1"},
+						getOutputUpdate{displayPath: queryPaths[1], valueKeyPath: valuePath, value: "2"},
+					), nil)
+				},
+			}
+
+			values, err := client.GetParameters(params)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(values).To(Equal(map[string]string{
+				params[0].DMSPath: "1",
+				params[1].DMSPath: "2",
+			}))
+		})
+
+		It("fails on mismatch across priorities", func() {
+			param := types.ConfigurationParameter{DMSPath: "/interfaces/interface/nvidia/cc/config/priority/np_enabled"}
+			updates := make([]getOutputUpdate, 0, 8)
+			for id := 0; id < 8; id++ {
+				value := "1"
+				if id == 4 {
+					value = "0"
+				}
+				updates = append(updates, getOutputUpdate{
+					displayPath:  fmt.Sprintf("/interfaces/interface[name=%s]/nvidia/cc/config/priority[id=%d]/np_enabled", testNetworkInterface, id),
+					valueKeyPath: param.DMSPath,
+					value:        value,
+				})
+			}
+
+			fakeExec.CommandScript = []execTesting.FakeCommandAction{
+				func(cmd string, args ...string) exec.Cmd {
+					paths := collectPathPayloads(args)
+					Expect(paths).To(HaveLen(8))
+					return createFakeCmd(makeBatchedGetOutput(updates...), nil)
 				},
 			}
 
@@ -419,28 +996,113 @@ var _ = Describe("DMSClient", func() {
 				expectedFiltered = append(expectedFiltered, fmt.Sprintf("/interfaces/interface[name=%s]/nvidia/cc/config/priority[id=%d]/np_enabled", testNetworkInterface, id))
 			}
 
-			fakeExec.CommandScript = []execTesting.FakeCommandAction{}
-			// eight filtered gets
-			for i := 0; i < 8; i++ {
-				path := expectedFiltered[i]
-				fakeExec.CommandScript = append(fakeExec.CommandScript, func(cmd string, args ...string) exec.Cmd {
+			fakeExec.CommandScript = []execTesting.FakeCommandAction{
+				func(cmd string, args ...string) exec.Cmd {
 					verifyTargetFlag(args)
-					reqPath := args[len(args)-1]
-					Expect(reqPath).To(Equal(path))
-					return createFakeCmd(makeGetOutput(path, param.DMSPath, "1"), nil)
-				})
+					paths := collectPathPayloads(args)
+					Expect(paths).To(Equal(expectedFiltered))
+					updates := make([]getOutputUpdate, 0, len(expectedFiltered))
+					for _, path := range expectedFiltered {
+						updates = append(updates, getOutputUpdate{displayPath: path, valueKeyPath: param.DMSPath, value: "1"})
+					}
+					return createFakeCmd(makeBatchedGetOutput(updates...), nil)
+				},
 			}
-			// final unfiltered get
-			fakeExec.CommandScript = append(fakeExec.CommandScript, func(cmd string, args ...string) exec.Cmd {
-				verifyTargetFlag(args)
-				reqPath := args[len(args)-1]
-				Expect(reqPath).To(Equal(param.DMSPath))
-				return createFakeCmd(makeGetOutput(param.DMSPath, param.DMSPath, "1"), nil)
-			})
 
 			vals, err := client.GetParameters([]types.ConfigurationParameter{param})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(vals[param.DMSPath]).To(Equal("1"))
+		})
+
+		It("batches get paths by concrete interface", func() {
+			params := []types.ConfigurationParameter{
+				{DMSPath: "/nvidia/mode/config/mode"},
+				{DMSPath: "/interfaces/interface/nvidia/qos/config/trust-mode"},
+				{DMSPath: "/interfaces/interface/nvidia/cc/config/priority/np_enabled"},
+			}
+
+			expectedInterfacePaths := []string{createTrustModePath(testNetworkInterface)}
+			for id := 0; id < 8; id++ {
+				expectedInterfacePaths = append(expectedInterfacePaths, fmt.Sprintf("/interfaces/interface[name=%s]/nvidia/cc/config/priority[id=%d]/np_enabled", testNetworkInterface, id))
+			}
+
+			fakeExec.CommandScript = []execTesting.FakeCommandAction{
+				func(cmd string, args ...string) exec.Cmd {
+					verifyTargetFlag(args)
+					paths := collectPathPayloads(args)
+					Expect(paths).To(Equal([]string{"/nvidia/mode/config/mode"}))
+
+					updates := []getOutputUpdate{
+						{displayPath: params[0].DMSPath, valueKeyPath: params[0].DMSPath, value: "NIC"},
+					}
+					return createFakeCmd(makeBatchedGetOutput(updates...), nil)
+				},
+				func(cmd string, args ...string) exec.Cmd {
+					verifyTargetFlag(args)
+					paths := collectPathPayloads(args)
+					Expect(paths).To(Equal(expectedInterfacePaths))
+
+					updates := make([]getOutputUpdate, 0, len(expectedInterfacePaths))
+					updates = append(updates, getOutputUpdate{
+						displayPath:  expectedInterfacePaths[0],
+						valueKeyPath: params[1].DMSPath,
+						value:        "dscp",
+					})
+					for _, path := range expectedInterfacePaths[1:] {
+						updates = append(updates, getOutputUpdate{displayPath: path, valueKeyPath: params[2].DMSPath, value: "1"})
+					}
+					return createFakeCmd(makeBatchedGetOutput(updates...), nil)
+				},
+			}
+
+			vals, err := client.GetParameters(params)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vals[params[0].DMSPath]).To(Equal("NIC"))
+			Expect(vals[params[1].DMSPath]).To(Equal("dscp"))
+			Expect(vals[params[2].DMSPath]).To(Equal("1"))
+		})
+
+		It("returns error when batched output does not include matching Path values", func() {
+			param := types.ConfigurationParameter{DMSPath: "/interfaces/interface/nvidia/cc/config/priority/np_enabled"}
+
+			fakeExec.CommandScript = []execTesting.FakeCommandAction{
+				func(cmd string, args ...string) exec.Cmd {
+					paths := collectPathPayloads(args)
+					Expect(paths).To(HaveLen(8))
+					return createFakeCmd(makeBatchedGetOutput(getOutputUpdate{displayPath: param.DMSPath, valueKeyPath: param.DMSPath, value: "1"}), nil)
+				},
+			}
+
+			_, err := client.GetParameters([]types.ConfigurationParameter{param})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no update found for path /interfaces/interface[name=enp3s0f0np0]/nvidia/cc/config/priority[id=0]/np_enabled"))
+		})
+
+		It("returns a descriptive error when batched output is missing a requested value", func() {
+			param := types.ConfigurationParameter{DMSPath: "/nvidia/mode/config/mode"}
+			fakeExec.CommandScript = []execTesting.FakeCommandAction{
+				func(cmd string, args ...string) exec.Cmd {
+					output := makeBatchedGetOutput(getOutputUpdate{displayPath: param.DMSPath, valueKeyPath: "/some/other/path", value: "NIC"})
+					return createFakeCmd(output, nil)
+				},
+			}
+
+			_, err := client.GetParameters([]types.ConfigurationParameter{param})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("value not found for path /nvidia/mode/config/mode"))
+		})
+
+		It("returns a descriptive error when batched get command fails", func() {
+			param := types.ConfigurationParameter{DMSPath: "/nvidia/mode/config/mode"}
+			fakeExec.CommandScript = []execTesting.FakeCommandAction{
+				func(cmd string, args ...string) exec.Cmd {
+					return createFakeCmd([]byte("boom"), errors.New("command failed"))
+				},
+			}
+
+			_, err := client.GetParameters([]types.ConfigurationParameter{param})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to run get path command"))
 		})
 	})
 
@@ -663,15 +1325,28 @@ var _ = Describe("DMSClient", func() {
 				HwplbFirstPortOnly: true,
 			}
 
-			// 8 priority queries for first port only
-			for i := 0; i < 8; i++ {
-				expectedPath := fmt.Sprintf("/interfaces/interface[name=%s]/nvidia/cc/config/priority[id=%d]/rp_enabled", testNetworkInterface, i)
-				fakeExec.CommandScript = append(fakeExec.CommandScript, func(cmd string, args ...string) exec.Cmd {
-					reqPath := args[len(args)-1]
-					Expect(reqPath).To(Equal(expectedPath))
-					Expect(reqPath).NotTo(ContainSubstring(secondNetworkInterface))
-					return createFakeCmd(makeGetOutput(expectedPath, param.DMSPath, "1"), nil)
-				})
+			expectedPaths := make([]string, 0, 8)
+			for id := 0; id < 8; id++ {
+				expectedPaths = append(expectedPaths, fmt.Sprintf("/interfaces/interface[name=%s]/nvidia/cc/config/priority[id=%d]/rp_enabled", testNetworkInterface, id))
+			}
+			fakeExec.CommandScript = []execTesting.FakeCommandAction{
+				func(cmd string, args ...string) exec.Cmd {
+					paths := make([]string, 0, len(expectedPaths))
+					for i, arg := range args {
+						if arg == "--path" && i+1 < len(args) {
+							paths = append(paths, args[i+1])
+						}
+					}
+					Expect(paths).To(Equal(expectedPaths))
+					for _, path := range paths {
+						Expect(path).NotTo(ContainSubstring(secondNetworkInterface))
+					}
+					updates := make([]getOutputUpdate, 0, len(expectedPaths))
+					for _, path := range expectedPaths {
+						updates = append(updates, getOutputUpdate{displayPath: path, valueKeyPath: param.DMSPath, value: "1"})
+					}
+					return createFakeCmd(makeBatchedGetOutput(updates...), nil)
+				},
 			}
 
 			vals, err := multiPortClient.GetParameters([]types.ConfigurationParameter{param})


### PR DESCRIPTION
## Summary

- Batch `DMSClient.GetParameters` reads by concrete interface: each interface uses one `dmsc get` command with repeated `--path` arguments, while paths without an interface filter use a separate global batch.
- Preserve existing interface, priority, and `HwplbFirstPortOnly` expansion without batching multiple interfaces into the same DMS command.
- Parse batched output by the returned `Path`, independent of response order. DMS's selector-free `values` key is used only to read the value; results remain keyed by the original configured DMS path so selectors such as `slot[id=0]` and `param[id=11]` are preserved.
- Detect differing values for the same parameter within one batch and across interface batches, including when the first value is empty.
- Capture combined stdout/stderr and log raw DMS output at debug level.
- Document the batching behavior and add regression coverage for raw multi-result output, repeated updates, ordering, static selectors, per-interface routing, priorities, HWPLB first-port handling, and error paths.

## Validation

- `go test ./pkg/dms -v -count=1 -timeout 2m -run TestDMS --ginkgo.focus='DMSClient'`
- `go test ./pkg/spectrumx/... -count=1 -timeout 5m`
- `go test ./pkg/configuration/... -count=1 -timeout 5m`
- `go vet ./pkg/dms/...`
- `go build ./...`
- `./bin/golangci-lint-v2.11.4 run`
- `git diff --check upstream/main...HEAD`

## Test Image

- `harbor.mellanox.com/cloud-orchestration-dev/nic-configuration-operator-daemon:batch-dms-get-parameters` (`linux/amd64`)
