### PR TITLE
chore: adding mlxfwreset '--skip_vm_check' flag,

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,3 +403,6 @@ The NIC Configuration Daemon itself relies on the `network.nvidia.com/operator.m
 Feature flags can be enabled via environment variables in the helm chart or NVIDIA Network Operator's NicClusterPolicy.
 Supported flags:
 * `FW_RESET_AFTER_CONFIG_UPDATE`=`true`: explicitely reset the NIC's Firmware before the reboot and after updating its non-volatile configuration. Might be required on DGX servers where configuration update is not successfully applied after the warm reboot.
+
+* `SKIP_VM_CHECK`=`true`: pass `--skip_vm_check` to `mlxfwreset` resetting NIC firmware while running on VMs.
+

--- a/deployment/nic-configuration-operator-chart/values.yaml
+++ b/deployment/nic-configuration-operator-chart/values.yaml
@@ -55,6 +55,9 @@ configDaemon:
     # -- feature gate to enable FW reset after nv config update
     # - name: FW_RESET_AFTER_CONFIG_UPDATE
     #   value: "true"
+    # -- skip VM check when resetting NIC firmware via mlxfwreset
+    # - name: SKIP_VM_CHECK
+    #   value: "true"
   # -- node selector for the config daemon
   nodeSelector:
     network.nvidia.com/operator.mofed.wait: "false"

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -178,6 +178,7 @@ const (
 	LabelValueFalse               = "false"
 
 	FEATURE_GATE_FW_RESET_AFTER_CONFIG_UPDATE = "FW_RESET_AFTER_CONFIG_UPDATE"
+	SKIP_VM_CHECK                             = "SKIP_VM_CHECK"
 
 	MultiplaneModeNone     = "none"
 	MultiplaneModeSwplb    = "swplb"

--- a/pkg/firmware/utils.go
+++ b/pkg/firmware/utils.go
@@ -444,7 +444,11 @@ func (u *utils) BurnNicFirmware(ctx context.Context, pciAddress, fwPath string) 
 func (u *utils) ResetNicFirmware(ctx context.Context, pciAddress string) error {
 	log.Log.V(2).Info("FirmwareUtils.ResetNicFirmware()", "pciAddress", pciAddress)
 
-	cmd := u.execInterface.CommandContext(ctx, "mlxfwreset", "--device", pciAddress, "reset", "--yes")
+	args := []string{"--device", pciAddress, "reset", "--yes"}
+	if os.Getenv(consts.SKIP_VM_CHECK) == consts.LabelValueTrue {
+		args = append(args, "--skip_vm_check")
+	}
+	cmd := u.execInterface.CommandContext(ctx, "mlxfwreset", args...)
 	output, err := cmd.CombinedOutput()
 	log.Log.V(2).Info("ResetNicFirmware(): command output", "output", string(output))
 	if err != nil {

--- a/pkg/firmware/utils_test.go
+++ b/pkg/firmware/utils_test.go
@@ -19,6 +19,7 @@ package firmware
 import (
 	"archive/zip"
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -920,6 +921,96 @@ var _ = Describe("utils", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("creating destination file"))
 			})
+		})
+	})
+
+	Describe("ResetNicFirmware", func() {
+		const pciAddress = "0000:03:00.0"
+
+		AfterEach(func() {
+			os.Unsetenv(consts.SKIP_VM_CHECK)
+		})
+
+		It("should not pass --skip_vm_check when SKIP_VM_CHECK is unset", func() {
+			fakeExec := &execTesting.FakeExec{}
+
+			fakeCmd := &execTesting.FakeCmd{}
+			fakeCmd.CombinedOutputScript = append(fakeCmd.CombinedOutputScript, func() ([]byte, []byte, error) {
+				return []byte("reset successful"), nil, nil
+			})
+
+			fakeExec.CommandScript = append(fakeExec.CommandScript, func(cmd string, args ...string) exec.Cmd {
+				Expect(cmd).To(Equal("mlxfwreset"))
+				Expect(args).To(Equal([]string{"--device", pciAddress, "reset", "--yes"}))
+				return fakeCmd
+			})
+
+			testedUtils := &utils{execInterface: fakeExec}
+
+			err := testedUtils.ResetNicFirmware(context.Background(), pciAddress)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should pass --skip_vm_check when SKIP_VM_CHECK is true", func() {
+			os.Setenv(consts.SKIP_VM_CHECK, consts.LabelValueTrue)
+
+			fakeExec := &execTesting.FakeExec{}
+
+			fakeCmd := &execTesting.FakeCmd{}
+			fakeCmd.CombinedOutputScript = append(fakeCmd.CombinedOutputScript, func() ([]byte, []byte, error) {
+				return []byte("reset successful"), nil, nil
+			})
+
+			fakeExec.CommandScript = append(fakeExec.CommandScript, func(cmd string, args ...string) exec.Cmd {
+				Expect(cmd).To(Equal("mlxfwreset"))
+				Expect(args).To(Equal([]string{"--device", pciAddress, "reset", "--yes", "--skip_vm_check"}))
+				return fakeCmd
+			})
+
+			testedUtils := &utils{execInterface: fakeExec}
+
+			err := testedUtils.ResetNicFirmware(context.Background(), pciAddress)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should not pass --skip_vm_check when SKIP_VM_CHECK is not true", func() {
+			os.Setenv(consts.SKIP_VM_CHECK, consts.LabelValueFalse)
+
+			fakeExec := &execTesting.FakeExec{}
+
+			fakeCmd := &execTesting.FakeCmd{}
+			fakeCmd.CombinedOutputScript = append(fakeCmd.CombinedOutputScript, func() ([]byte, []byte, error) {
+				return []byte("reset successful"), nil, nil
+			})
+
+			fakeExec.CommandScript = append(fakeExec.CommandScript, func(cmd string, args ...string) exec.Cmd {
+				Expect(cmd).To(Equal("mlxfwreset"))
+				Expect(args).To(Equal([]string{"--device", pciAddress, "reset", "--yes"}))
+				return fakeCmd
+			})
+
+			testedUtils := &utils{execInterface: fakeExec}
+
+			err := testedUtils.ResetNicFirmware(context.Background(), pciAddress)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return an error when mlxfwreset fails", func() {
+			fakeExec := &execTesting.FakeExec{}
+
+			fakeCmd := &execTesting.FakeCmd{}
+			fakeCmd.CombinedOutputScript = append(fakeCmd.CombinedOutputScript, func() ([]byte, []byte, error) {
+				return []byte("reset failed"), nil, fmt.Errorf("mlxfwreset failed")
+			})
+
+			fakeExec.CommandScript = append(fakeExec.CommandScript, func(cmd string, args ...string) exec.Cmd {
+				return fakeCmd
+			})
+
+			testedUtils := &utils{execInterface: fakeExec}
+
+			err := testedUtils.ResetNicFirmware(context.Background(), pciAddress)
+			Expect(err).To(HaveOccurred())
 		})
 	})
 


### PR DESCRIPTION
Adding `--skip_vm_check` flag to mlxfwreset command is essential when working with simx NICs over virtual-machines. User will need to set `SKIP_VM_CHECK=true` in order to propagate this flag in nic-configuration-daemon 