### PR TITLE
Skip device on discovery errors when enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,3 +406,4 @@ Supported flags:
 
 * `SKIP_VM_CHECK`=`true`: pass `--skip_vm_check` to `mlxfwreset` resetting NIC firmware while running on VMs.
 
+* `SKIP_DEVICE_ON_DISCOVERY_ERROR`=`true`: skip a physical NIC during device discovery when firmware/PSID lookup or BlueField operation-mode lookup fails. When unset, these errors fail discovery so the daemon retries. Existing `NicDevice` CRs are preserved for skipped devices to avoid delete/recreate churn during transient per-device discovery failures.

--- a/deployment/nic-configuration-operator-chart/values.yaml
+++ b/deployment/nic-configuration-operator-chart/values.yaml
@@ -58,6 +58,9 @@ configDaemon:
     # -- skip VM check when resetting NIC firmware via mlxfwreset
     # - name: SKIP_VM_CHECK
     #   value: "true"
+    # -- skip a physical NIC when per-device discovery details cannot be read
+    # - name: SKIP_DEVICE_ON_DISCOVERY_ERROR
+    #   value: "true"
   # -- node selector for the config daemon
   nodeSelector:
     network.nvidia.com/operator.mofed.wait: "false"

--- a/internal/controller/devicediscovery_controller.go
+++ b/internal/controller/devicediscovery_controller.go
@@ -120,6 +120,10 @@ func (d *DeviceDiscoveryController) reconcile(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	skippedDevices := map[string]error{}
+	if skippedDeviceReporter, ok := d.deviceDiscovery.(devicediscovery.SkippedDeviceReporter); ok {
+		skippedDevices = skippedDeviceReporter.SkippedDevices()
+	}
 
 	list := &v1alpha1.NicDeviceList{}
 
@@ -149,6 +153,10 @@ func (d *DeviceDiscoveryController) reconcile(ctx context.Context) error {
 		observedDevice, exists := observedDevices[pciKey]
 
 		if !exists {
+			if skippedErr, skipped := skippedDevices[pciKey]; skipped {
+				log.Log.Info("device discovery was skipped, preserving existing NicDevice CR", "device", nicDeviceCR.Name, "pciKey", pciKey, "error", skippedErr)
+				continue
+			}
 			log.Log.V(2).Info("device doesn't exist on the node anymore, deleting", "device", nicDeviceCR.Name)
 			// Need to delete this CR, it doesn't represent the observedDevice on host anymore
 			err = d.Delete(ctx, &nicDeviceCR)

--- a/internal/controller/devicediscovery_controller_test.go
+++ b/internal/controller/devicediscovery_controller_test.go
@@ -17,6 +17,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -192,6 +193,29 @@ var _ = Describe("DeviceDiscoveryController", func() {
 				}, timeout).Should(Equal(0))
 			})
 
+			It("should preserve CRs for devices skipped during discovery", func() {
+				deviceRegistry.deviceDiscovery = &skippedDeviceDiscovery{
+					devices: map[string]v1alpha1.NicDevice{},
+					skipped: map[string]error{
+						pciDevKey: errors.New("firmware error"),
+					},
+				}
+
+				startManager(mgr, ctx, &wg)
+
+				Eventually(func() (string, error) {
+					device := &v1alpha1.NicDevice{}
+					err := k8sClient.Get(ctx, client.ObjectKey{
+						Name:      deviceName,
+						Namespace: namespaceName,
+					}, device)
+					if err != nil {
+						return "", err
+					}
+					return device.Status.SerialNumber, nil
+				}, timeout).Should(Equal(serialNumber))
+			})
+
 			It("should create new CRs for new devices", func() {
 				newPciDevKey := "0000:81:00"
 				newSerial := "new-serial-num"
@@ -235,3 +259,16 @@ var _ = Describe("DeviceDiscoveryController", func() {
 		})
 	})
 })
+
+type skippedDeviceDiscovery struct {
+	devices map[string]v1alpha1.NicDevice
+	skipped map[string]error
+}
+
+func (d *skippedDeviceDiscovery) DiscoverNicDevices() (map[string]v1alpha1.NicDevice, error) {
+	return d.devices, nil
+}
+
+func (d *skippedDeviceDiscovery) SkippedDevices() map[string]error {
+	return d.skipped
+}

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -179,6 +179,7 @@ const (
 
 	FEATURE_GATE_FW_RESET_AFTER_CONFIG_UPDATE = "FW_RESET_AFTER_CONFIG_UPDATE"
 	SKIP_VM_CHECK                             = "SKIP_VM_CHECK"
+	SKIP_DEVICE_ON_DISCOVERY_ERROR            = "SKIP_DEVICE_ON_DISCOVERY_ERROR"
 
 	MultiplaneModeNone     = "none"
 	MultiplaneModeSwplb    = "swplb"

--- a/pkg/devicediscovery/devicediscovery.go
+++ b/pkg/devicediscovery/devicediscovery.go
@@ -16,10 +16,10 @@ limitations under the License.
 package devicediscovery
 
 import (
+	"context"
+	"os"
 	"strconv"
 	"strings"
-
-	"context"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -35,9 +35,15 @@ type DeviceDiscovery interface {
 	DiscoverNicDevices() (map[string]v1alpha1.NicDevice, error)
 }
 
+type SkippedDeviceReporter interface {
+	// SkippedDevices returns physical PCI device keys skipped during the last discovery pass.
+	SkippedDevices() map[string]error
+}
+
 type deviceDiscovery struct {
-	utils         DeviceDiscoveryUtils
-	nvConfigUtils nvconfig.NVConfigUtils
+	utils          DeviceDiscoveryUtils
+	nvConfigUtils  nvconfig.NVConfigUtils
+	skippedDevices map[string]error
 
 	nodeName string
 }
@@ -47,8 +53,9 @@ type deviceDiscovery struct {
 // the same Domain:Bus:Device are ports of the same physical NIC and are merged into one NicDevice. Keying
 // by PCI device address (rather than serial number) is required on systems where multiple cards share a
 // flashed VPD image (e.g. embedded NICs on HGX B300).
-func (d deviceDiscovery) DiscoverNicDevices() (map[string]v1alpha1.NicDevice, error) {
+func (d *deviceDiscovery) DiscoverNicDevices() (map[string]v1alpha1.NicDevice, error) {
 	log.Log.Info("ConfigurationManager.DiscoverNicDevices()")
+	d.skippedDevices = map[string]error{}
 
 	pciDevices, err := d.utils.GetPCIDevices()
 	if err != nil {
@@ -57,6 +64,7 @@ func (d deviceDiscovery) DiscoverNicDevices() (map[string]v1alpha1.NicDevice, er
 	}
 
 	statuses := make(map[string]v1alpha1.NicDeviceStatus)
+	skipDeviceOnDiscoveryError := os.Getenv(consts.SKIP_DEVICE_ON_DISCOVERY_ERROR) == consts.LabelValueTrue
 
 	for _, device := range pciDevices {
 		if device.Vendor.ID != consts.MellanoxVendor {
@@ -79,11 +87,18 @@ func (d deviceDiscovery) DiscoverNicDevices() (map[string]v1alpha1.NicDevice, er
 			continue
 		}
 
+		pciKey := utils.PCIDeviceAddress(device.Address)
+		if _, skipped := d.skippedDevices[pciKey]; skipped {
+			log.Log.Info("Physical device already skipped during this discovery pass, skipping port", "pciKey", pciKey, "address", device.Address)
+			continue
+		}
+
 		log.Log.Info("Found Mellanox device", "address", device.Address, "type", device.Product.Name)
 
 		vpd, err := d.utils.GetVPD(device.Address)
 		if err != nil {
 			log.Log.Error(err, "Failed to get device's part and serial numbers, skipping", "address", device.Address)
+			d.skipPhysicalDevice(statuses, pciKey, err)
 			continue
 		}
 
@@ -100,7 +115,6 @@ func (d deviceDiscovery) DiscoverNicDevices() (map[string]v1alpha1.NicDevice, er
 			continue
 		}
 
-		pciKey := utils.PCIDeviceAddress(device.Address)
 		deviceStatus, ok := statuses[pciKey]
 		fwctlDevice := d.utils.GetFwctlDevice(device.Address)
 
@@ -108,6 +122,10 @@ func (d deviceDiscovery) DiscoverNicDevices() (map[string]v1alpha1.NicDevice, er
 			firmwareVersion, psid, err := d.utils.GetFirmwareVersionAndPSID(device.Address)
 			if err != nil {
 				log.Log.Error(err, "Failed to get device's firmware and PSID", "address", device.Address)
+				if skipDeviceOnDiscoveryError {
+					d.skipPhysicalDevice(statuses, pciKey, err)
+					continue
+				}
 				return nil, err
 			}
 
@@ -123,6 +141,10 @@ func (d deviceDiscovery) DiscoverNicDevices() (map[string]v1alpha1.NicDevice, er
 				nvConfig, err := d.nvConfigUtils.QueryNvConfig(context.Background(), port, []string{consts.BF3OperationModeParam})
 				if err != nil {
 					log.Log.Error(err, "Failed to get BlueField device's operation mode", "address", device.Address)
+					if skipDeviceOnDiscoveryError {
+						d.skipPhysicalDevice(statuses, pciKey, err)
+						continue
+					}
 					return nil, err
 				}
 				// For a field ENABLED(0) or DISABLED(1), the second parameter is the 0/1 value
@@ -181,6 +203,19 @@ func (d deviceDiscovery) DiscoverNicDevices() (map[string]v1alpha1.NicDevice, er
 	log.Log.V(2).Info("Found devices", "devices", devices)
 
 	return devices, nil
+}
+
+func (d *deviceDiscovery) skipPhysicalDevice(statuses map[string]v1alpha1.NicDeviceStatus, pciKey string, err error) {
+	d.skippedDevices[pciKey] = err
+	delete(statuses, pciKey)
+}
+
+func (d *deviceDiscovery) SkippedDevices() map[string]error {
+	skippedDevices := make(map[string]error, len(d.skippedDevices))
+	for pciKey, err := range d.skippedDevices {
+		skippedDevices[pciKey] = err
+	}
+	return skippedDevices
 }
 
 // pairNetworkBayDevices resolves PeerPCI for ConnectX-9 Network Bay siblings. The two ASICs of a

--- a/pkg/devicediscovery/devicediscovery_test.go
+++ b/pkg/devicediscovery/devicediscovery_test.go
@@ -17,6 +17,7 @@ package devicediscovery
 
 import (
 	"errors"
+	"os"
 
 	"github.com/jaypipes/ghw/pkg/pci"
 	"github.com/jaypipes/pcidb"
@@ -34,17 +35,18 @@ import (
 var _ = Describe("DeviceDiscovery", func() {
 	var (
 		mockUtils    mocks.DeviceDiscoveryUtils
-		manager      DeviceDiscovery
+		manager      *deviceDiscovery
 		fwctlDevices map[string]string
 	)
 
 	BeforeEach(func() {
+		Expect(os.Unsetenv(consts.SKIP_DEVICE_ON_DISCOVERY_ERROR)).To(Succeed())
 		mockUtils = mocks.DeviceDiscoveryUtils{}
 		fwctlDevices = map[string]string{}
 		mockUtils.On("GetFwctlDevice", mock.Anything).Return(func(pciAddr string) string {
 			return fwctlDevices[pciAddr]
 		}).Maybe()
-		manager = deviceDiscovery{utils: &mockUtils, nodeName: "test-node"}
+		manager = &deviceDiscovery{utils: &mockUtils, nodeName: "test-node"}
 	})
 
 	Describe("NewDeviceDiscovery", func() {
@@ -160,6 +162,21 @@ var _ = Describe("DeviceDiscovery", func() {
 				devices, err := manager.DiscoverNicDevices()
 				Expect(err).To(HaveOccurred())
 				Expect(devices).To(BeNil())
+				mockUtils.AssertExpectations(GinkgoT())
+			})
+
+			It("should skip devices if GetFirmwareVersionAndPSID fails and SKIP_DEVICE_ON_DISCOVERY_ERROR is true", func() {
+				Expect(os.Setenv(consts.SKIP_DEVICE_ON_DISCOVERY_ERROR, consts.LabelValueTrue)).To(Succeed())
+				mockUtils.On("IsSriovVF", "0000:00:00.0").Return(false)
+				mockUtils.On("GetVPD", "0000:00:00.0").
+					Return(&types.VPD{PartNumber: "part-number", SerialNumber: "serial-number", ModelName: ""}, nil)
+				mockUtils.On("GetFirmwareVersionAndPSID", "0000:00:00.0").
+					Return("", "", errors.New("firmware error"))
+
+				devices, err := manager.DiscoverNicDevices()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(devices).To(BeEmpty())
+				Expect(manager.SkippedDevices()).To(HaveKey("0000:00:00"))
 				mockUtils.AssertExpectations(GinkgoT())
 			})
 
@@ -313,6 +330,35 @@ var _ = Describe("DeviceDiscovery", func() {
 			mockUtils.AssertExpectations(GinkgoT())
 		})
 
+		It("should skip only a faulty device if GetFirmwareVersionAndPSID fails and SKIP_DEVICE_ON_DISCOVERY_ERROR is true", func() {
+			Expect(os.Setenv(consts.SKIP_DEVICE_ON_DISCOVERY_ERROR, consts.LabelValueTrue)).To(Succeed())
+			mockUtils.On("IsSriovVF", "0000:00:00.0").
+				Return(false)
+			mockUtils.On("GetVPD", "0000:00:00.0").
+				Return(&types.VPD{PartNumber: "part-number", SerialNumber: "serial-number", ModelName: ""}, nil)
+			mockUtils.On("GetFirmwareVersionAndPSID", "0000:00:00.0").
+				Return("fw-version", "psid", nil)
+			mockUtils.On("GetInterfaceName", "0000:00:00.0").
+				Return("eth0")
+			mockUtils.On("GetRDMADeviceName", "0000:00:00.0").
+				Return("mlx5_0")
+
+			mockUtils.On("IsSriovVF", "0000:01:00.0").
+				Return(false)
+			mockUtils.On("GetVPD", "0000:01:00.0").
+				Return(&types.VPD{PartNumber: "part-number", SerialNumber: "serial-number-2", ModelName: ""}, nil)
+			mockUtils.On("GetFirmwareVersionAndPSID", "0000:01:00.0").
+				Return("", "", errors.New("firmware error"))
+
+			devices, err := manager.DiscoverNicDevices()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(devices).To(HaveLen(1))
+			Expect(devices).To(HaveKey("0000:00:00"))
+			Expect(devices).NotTo(HaveKey("0000:01:00"))
+			Expect(manager.SkippedDevices()).To(HaveKey("0000:01:00"))
+			mockUtils.AssertExpectations(GinkgoT())
+		})
+
 		It("should discover and return devices successfully", func() {
 			mockUtils.On("IsSriovVF", "0000:00:00.0").
 				Return(false)
@@ -384,6 +430,7 @@ var _ = Describe("DeviceDiscovery", func() {
 
 			mockUtils.AssertExpectations(GinkgoT())
 		})
+
 	})
 
 	Context("when discovering ConnectX-9 Network Bay (orchid) devices", func() {
@@ -521,6 +568,44 @@ var _ = Describe("DeviceDiscovery", func() {
 
 			mockUtils.AssertExpectations(GinkgoT())
 		})
+
+		It("should skip the whole physical device when discovery fails after one port was added", func() {
+			Expect(os.Setenv(consts.SKIP_DEVICE_ON_DISCOVERY_ERROR, consts.LabelValueTrue)).To(Succeed())
+			mockUtils.On("GetPCIDevices").Return([]*pci.Device{
+				{
+					Address: "0000:00:00.0",
+					Vendor:  &pcidb.Vendor{ID: consts.MellanoxVendor},
+					Product: &pcidb.Product{ID: "test-id", Name: "Mellanox Device"},
+					Class:   &pcidb.Class{ID: "02"},
+				},
+				{
+					Address: "0000:00:00.1",
+					Vendor:  &pcidb.Vendor{ID: consts.MellanoxVendor},
+					Product: &pcidb.Product{ID: "test-id", Name: "Mellanox Device"},
+					Class:   &pcidb.Class{ID: "02"},
+				},
+			}, nil)
+
+			mockUtils.On("IsSriovVF", "0000:00:00.0").Return(false)
+			mockUtils.On("GetVPD", "0000:00:00.0").
+				Return(&types.VPD{PartNumber: "part-number", SerialNumber: "serial-number", ModelName: ""}, nil)
+			mockUtils.On("GetFirmwareVersionAndPSID", "0000:00:00.0").
+				Return("fw-version", "psid", nil)
+			mockUtils.On("GetInterfaceName", "0000:00:00.0").
+				Return("eth0")
+			mockUtils.On("GetRDMADeviceName", "0000:00:00.0").
+				Return("mlx5_0")
+
+			mockUtils.On("IsSriovVF", "0000:00:00.1").Return(false)
+			mockUtils.On("GetVPD", "0000:00:00.1").
+				Return(nil, errors.New("vpd error"))
+
+			devices, err := manager.DiscoverNicDevices()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(devices).To(BeEmpty())
+			Expect(manager.SkippedDevices()).To(HaveKey("0000:00:00"))
+			mockUtils.AssertExpectations(GinkgoT())
+		})
 	})
 
 	Context("when multiple NICs share the same flashed serial number (HGX B300)", func() {
@@ -654,7 +739,7 @@ var _ = Describe("DeviceDiscovery", func() {
 			mockUtils.On("GetInterfaceName", "0000:00:00.0").Return("eth0")
 			mockUtils.On("GetRDMADeviceName", "0000:00:00.0").Return("mlx5_0")
 
-			manager := deviceDiscovery{utils: &mockUtils, nvConfigUtils: nvmmocks.NewNVConfigUtils(GinkgoT()), nodeName: "test-node"}
+			manager := &deviceDiscovery{utils: &mockUtils, nvConfigUtils: nvmmocks.NewNVConfigUtils(GinkgoT()), nodeName: "test-node"}
 
 			devicesByPCI, err := manager.DiscoverNicDevices()
 			Expect(err).NotTo(HaveOccurred())
@@ -691,7 +776,7 @@ var _ = Describe("DeviceDiscovery", func() {
 				DefaultConfig:  map[string][]string{},
 			}, nil)
 
-			manager := deviceDiscovery{utils: &mockUtils, nvConfigUtils: nvConfigUtilsMock, nodeName: "test-node"}
+			manager := &deviceDiscovery{utils: &mockUtils, nvConfigUtils: nvConfigUtilsMock, nodeName: "test-node"}
 
 			devicesByPCI, err := manager.DiscoverNicDevices()
 			Expect(err).NotTo(HaveOccurred())
@@ -715,6 +800,58 @@ var _ = Describe("DeviceDiscovery", func() {
 			devices, err := manager.DiscoverNicDevices()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(devices).To(HaveLen(0))
+			mockUtils.AssertExpectations(GinkgoT())
+		})
+
+		It("should return an error when querying operation mode fails by default", func() {
+			mockUtils.On("GetPCIDevices").Return([]*pci.Device{
+				{
+					Address: "0000:00:00.0",
+					Vendor:  &pcidb.Vendor{ID: consts.MellanoxVendor},
+					Product: &pcidb.Product{ID: consts.BlueField3DeviceID, Name: "BlueField-3"},
+					Class:   &pcidb.Class{ID: "02"},
+				},
+			}, nil)
+			mockUtils.On("IsSriovVF", "0000:00:00.0").Return(false)
+			mockUtils.On("GetVPD", "0000:00:00.0").Return(&types.VPD{PartNumber: "part-number", SerialNumber: "serial-number", ModelName: "BlueField-3"}, nil)
+			mockUtils.On("IsZeroTrust", "0000:00:00.0").Return(false, nil)
+			mockUtils.On("GetFirmwareVersionAndPSID", "0000:00:00.0").Return("fw-version", "psid", nil)
+
+			nvConfigUtilsMock := nvmmocks.NewNVConfigUtils(GinkgoT())
+			nvConfigUtilsMock.On("QueryNvConfig", mock.Anything, v1alpha1.NicDevicePortSpec{PCI: "0000:00:00.0"}, []string{consts.BF3OperationModeParam}).Return(types.NvConfigQuery{}, errors.New("operation mode error"))
+
+			manager := &deviceDiscovery{utils: &mockUtils, nvConfigUtils: nvConfigUtilsMock, nodeName: "test-node"}
+
+			devices, err := manager.DiscoverNicDevices()
+			Expect(err).To(HaveOccurred())
+			Expect(devices).To(BeNil())
+			mockUtils.AssertExpectations(GinkgoT())
+		})
+
+		It("should skip the device when querying operation mode fails and SKIP_DEVICE_ON_DISCOVERY_ERROR is true", func() {
+			Expect(os.Setenv(consts.SKIP_DEVICE_ON_DISCOVERY_ERROR, consts.LabelValueTrue)).To(Succeed())
+			mockUtils.On("GetPCIDevices").Return([]*pci.Device{
+				{
+					Address: "0000:00:00.0",
+					Vendor:  &pcidb.Vendor{ID: consts.MellanoxVendor},
+					Product: &pcidb.Product{ID: consts.BlueField3DeviceID, Name: "BlueField-3"},
+					Class:   &pcidb.Class{ID: "02"},
+				},
+			}, nil)
+			mockUtils.On("IsSriovVF", "0000:00:00.0").Return(false)
+			mockUtils.On("GetVPD", "0000:00:00.0").Return(&types.VPD{PartNumber: "part-number", SerialNumber: "serial-number", ModelName: "BlueField-3"}, nil)
+			mockUtils.On("IsZeroTrust", "0000:00:00.0").Return(false, nil)
+			mockUtils.On("GetFirmwareVersionAndPSID", "0000:00:00.0").Return("fw-version", "psid", nil)
+
+			nvConfigUtilsMock := nvmmocks.NewNVConfigUtils(GinkgoT())
+			nvConfigUtilsMock.On("QueryNvConfig", mock.Anything, v1alpha1.NicDevicePortSpec{PCI: "0000:00:00.0"}, []string{consts.BF3OperationModeParam}).Return(types.NvConfigQuery{}, errors.New("operation mode error"))
+
+			manager := &deviceDiscovery{utils: &mockUtils, nvConfigUtils: nvConfigUtilsMock, nodeName: "test-node"}
+
+			devices, err := manager.DiscoverNicDevices()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(devices).To(BeEmpty())
+			Expect(manager.SkippedDevices()).To(HaveKey("0000:00:00"))
 			mockUtils.AssertExpectations(GinkgoT())
 		})
 	})


### PR DESCRIPTION
## Summary
- add SKIP_DEVICE_ON_DISCOVERY_ERROR support for per-device discovery failures
- skip the affected physical NIC when firmware/PSID lookup or BlueField operation-mode lookup fails and the env var is true
- preserve existing NicDevice CRs for skipped physical PCI keys to avoid transient delete/recreate churn
- document the feature flag in README and chart values

## Testing
- GOCACHE=/private/tmp/nco-skip-discovery-go-cache go test ./pkg/devicediscovery/... -v
- GOCACHE=/private/tmp/nco-skip-discovery-go-cache go test ./internal/controller -v --ginkgo.focus='DeviceDiscoveryController'
- GOCACHE=/private/tmp/nco-skip-discovery-go-cache go build ./...
- GOCACHE=/private/tmp/nco-skip-discovery-go-cache GOLANGCI_LINT_CACHE=/private/tmp/nco-skip-discovery-golangci-cache make lint