### PR TITLE
Backport skip device on discovery errors to 26.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,3 +358,5 @@ The NIC Configuration Daemon itself relies on the `network.nvidia.com/operator.m
 Feature flags can be enabled via environment variables in the helm chart or NVIDIA Network Operator's NicClusterPolicy.
 Supported flags:
 * `FW_RESET_AFTER_CONFIG_UPDATE`=`true`: explicitely reset the NIC's Firmware before the reboot and after updating its non-volatile configuration. Might be required on DGX servers where configuration update is not successfully applied after the warm reboot.
+
+* `SKIP_DEVICE_ON_DISCOVERY_ERROR`=`true`: skip a physical NIC during device discovery when firmware/PSID lookup or BlueField operation-mode lookup fails. When unset, these errors fail discovery so the daemon retries. Existing `NicDevice` CRs are preserved for skipped devices to avoid delete/recreate churn during transient per-device discovery failures.

--- a/deployment/nic-configuration-operator-chart/values.yaml
+++ b/deployment/nic-configuration-operator-chart/values.yaml
@@ -55,6 +55,9 @@ configDaemon:
     # -- feature gate to enable FW reset after nv config update
     # - name: FW_RESET_AFTER_CONFIG_UPDATE
     #   value: "true"
+    # -- skip a physical NIC when per-device discovery details cannot be read
+    # - name: SKIP_DEVICE_ON_DISCOVERY_ERROR
+    #   value: "true"
   # -- node selector for the config daemon
   nodeSelector:
     network.nvidia.com/operator.mofed.wait: "false"

--- a/internal/controller/devicediscovery_controller.go
+++ b/internal/controller/devicediscovery_controller.go
@@ -120,6 +120,10 @@ func (d *DeviceDiscoveryController) reconcile(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	skippedDevices := map[string]error{}
+	if skippedDeviceReporter, ok := d.deviceDiscovery.(devicediscovery.SkippedDeviceReporter); ok {
+		skippedDevices = skippedDeviceReporter.SkippedDevices()
+	}
 
 	list := &v1alpha1.NicDeviceList{}
 
@@ -149,6 +153,10 @@ func (d *DeviceDiscoveryController) reconcile(ctx context.Context) error {
 		observedDevice, exists := observedDevices[pciKey]
 
 		if !exists {
+			if skippedErr, skipped := skippedDevices[pciKey]; skipped {
+				log.Log.Info("device discovery was skipped, preserving existing NicDevice CR", "device", nicDeviceCR.Name, "pciKey", pciKey, "error", skippedErr)
+				continue
+			}
 			log.Log.V(2).Info("device doesn't exist on the node anymore, deleting", "device", nicDeviceCR.Name)
 			// Need to delete this CR, it doesn't represent the observedDevice on host anymore
 			err = d.Delete(ctx, &nicDeviceCR)

--- a/internal/controller/devicediscovery_controller_test.go
+++ b/internal/controller/devicediscovery_controller_test.go
@@ -17,6 +17,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -192,6 +193,29 @@ var _ = Describe("DeviceDiscoveryController", func() {
 				}, timeout).Should(Equal(0))
 			})
 
+			It("should preserve CRs for devices skipped during discovery", func() {
+				deviceRegistry.deviceDiscovery = &skippedDeviceDiscovery{
+					devices: map[string]v1alpha1.NicDevice{},
+					skipped: map[string]error{
+						pciDevKey: errors.New("firmware error"),
+					},
+				}
+
+				startManager(mgr, ctx, &wg)
+
+				Eventually(func() (string, error) {
+					device := &v1alpha1.NicDevice{}
+					err := k8sClient.Get(ctx, client.ObjectKey{
+						Name:      deviceName,
+						Namespace: namespaceName,
+					}, device)
+					if err != nil {
+						return "", err
+					}
+					return device.Status.SerialNumber, nil
+				}, timeout).Should(Equal(serialNumber))
+			})
+
 			It("should create new CRs for new devices", func() {
 				newPciDevKey := "0000:81:00"
 				newSerial := "new-serial-num"
@@ -235,3 +259,16 @@ var _ = Describe("DeviceDiscoveryController", func() {
 		})
 	})
 })
+
+type skippedDeviceDiscovery struct {
+	devices map[string]v1alpha1.NicDevice
+	skipped map[string]error
+}
+
+func (d *skippedDeviceDiscovery) DiscoverNicDevices() (map[string]v1alpha1.NicDevice, error) {
+	return d.devices, nil
+}
+
+func (d *skippedDeviceDiscovery) SkippedDevices() map[string]error {
+	return d.skipped
+}

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -164,6 +164,7 @@ const (
 	LabelValueFalse               = "false"
 
 	FEATURE_GATE_FW_RESET_AFTER_CONFIG_UPDATE = "FW_RESET_AFTER_CONFIG_UPDATE"
+	SKIP_DEVICE_ON_DISCOVERY_ERROR            = "SKIP_DEVICE_ON_DISCOVERY_ERROR"
 
 	MultiplaneModeNone     = "none"
 	MultiplaneModeSwplb    = "swplb"

--- a/pkg/devicediscovery/devicediscovery.go
+++ b/pkg/devicediscovery/devicediscovery.go
@@ -16,10 +16,10 @@ limitations under the License.
 package devicediscovery
 
 import (
+	"context"
+	"os"
 	"strconv"
 	"strings"
-
-	"context"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -35,9 +35,15 @@ type DeviceDiscovery interface {
 	DiscoverNicDevices() (map[string]v1alpha1.NicDevice, error)
 }
 
+type SkippedDeviceReporter interface {
+	// SkippedDevices returns physical PCI device keys skipped during the last discovery pass.
+	SkippedDevices() map[string]error
+}
+
 type deviceDiscovery struct {
-	utils         DeviceDiscoveryUtils
-	nvConfigUtils nvconfig.NVConfigUtils
+	utils          DeviceDiscoveryUtils
+	nvConfigUtils  nvconfig.NVConfigUtils
+	skippedDevices map[string]error
 
 	nodeName string
 }
@@ -47,8 +53,9 @@ type deviceDiscovery struct {
 // the same Domain:Bus:Device are ports of the same physical NIC and are merged into one NicDevice. Keying
 // by PCI device address (rather than serial number) is required on systems where multiple cards share a
 // flashed VPD image (e.g. embedded NICs on HGX B300).
-func (d deviceDiscovery) DiscoverNicDevices() (map[string]v1alpha1.NicDevice, error) {
+func (d *deviceDiscovery) DiscoverNicDevices() (map[string]v1alpha1.NicDevice, error) {
 	log.Log.Info("ConfigurationManager.DiscoverNicDevices()")
+	d.skippedDevices = map[string]error{}
 
 	pciDevices, err := d.utils.GetPCIDevices()
 	if err != nil {
@@ -57,6 +64,7 @@ func (d deviceDiscovery) DiscoverNicDevices() (map[string]v1alpha1.NicDevice, er
 	}
 
 	statuses := make(map[string]v1alpha1.NicDeviceStatus)
+	skipDeviceOnDiscoveryError := os.Getenv(consts.SKIP_DEVICE_ON_DISCOVERY_ERROR) == consts.LabelValueTrue
 
 	for _, device := range pciDevices {
 		if device.Vendor.ID != consts.MellanoxVendor {
@@ -79,11 +87,20 @@ func (d deviceDiscovery) DiscoverNicDevices() (map[string]v1alpha1.NicDevice, er
 			continue
 		}
 
+		pciKey := utils.PCIDeviceAddress(device.Address)
+		if _, skipped := d.skippedDevices[pciKey]; skipped {
+			log.Log.Info("Physical device already skipped during this discovery pass, skipping port", "pciKey", pciKey, "address", device.Address)
+			continue
+		}
+
 		log.Log.Info("Found Mellanox device", "address", device.Address, "type", device.Product.Name)
 
 		vpd, err := d.utils.GetVPD(device.Address)
 		if err != nil {
 			log.Log.Error(err, "Failed to get device's part and serial numbers, skipping", "address", device.Address)
+			if skipDeviceOnDiscoveryError {
+				d.skipPhysicalDevice(statuses, pciKey, err)
+			}
 			continue
 		}
 
@@ -100,13 +117,16 @@ func (d deviceDiscovery) DiscoverNicDevices() (map[string]v1alpha1.NicDevice, er
 			continue
 		}
 
-		pciKey := utils.PCIDeviceAddress(device.Address)
 		deviceStatus, ok := statuses[pciKey]
 
 		if !ok {
 			firmwareVersion, psid, err := d.utils.GetFirmwareVersionAndPSID(device.Address)
 			if err != nil {
 				log.Log.Error(err, "Failed to get device's firmware and PSID", "address", device.Address)
+				if skipDeviceOnDiscoveryError {
+					d.skipPhysicalDevice(statuses, pciKey, err)
+					continue
+				}
 				return nil, err
 			}
 
@@ -121,6 +141,10 @@ func (d deviceDiscovery) DiscoverNicDevices() (map[string]v1alpha1.NicDevice, er
 				nvConfig, err := d.nvConfigUtils.QueryNvConfig(context.Background(), device.Address, []string{consts.BF3OperationModeParam})
 				if err != nil {
 					log.Log.Error(err, "Failed to get BlueField device's operation mode", "address", device.Address)
+					if skipDeviceOnDiscoveryError {
+						d.skipPhysicalDevice(statuses, pciKey, err)
+						continue
+					}
 					return nil, err
 				}
 				// For a field ENABLED(0) or DISABLED(1), the second parameter is the 0/1 value
@@ -165,6 +189,19 @@ func (d deviceDiscovery) DiscoverNicDevices() (map[string]v1alpha1.NicDevice, er
 	log.Log.V(2).Info("Found devices", "devices", devices)
 
 	return devices, nil
+}
+
+func (d *deviceDiscovery) skipPhysicalDevice(statuses map[string]v1alpha1.NicDeviceStatus, pciKey string, err error) {
+	d.skippedDevices[pciKey] = err
+	delete(statuses, pciKey)
+}
+
+func (d *deviceDiscovery) SkippedDevices() map[string]error {
+	skippedDevices := make(map[string]error, len(d.skippedDevices))
+	for pciKey, err := range d.skippedDevices {
+		skippedDevices[pciKey] = err
+	}
+	return skippedDevices
 }
 
 func NewDeviceDiscovery(nodeName string, nvConfigUtils nvconfig.NVConfigUtils) DeviceDiscovery {

--- a/pkg/devicediscovery/devicediscovery_test.go
+++ b/pkg/devicediscovery/devicediscovery_test.go
@@ -17,6 +17,7 @@ package devicediscovery
 
 import (
 	"errors"
+	"os"
 
 	"github.com/jaypipes/ghw/pkg/pci"
 	"github.com/jaypipes/pcidb"
@@ -34,12 +35,13 @@ import (
 var _ = Describe("DeviceDiscovery", func() {
 	var (
 		mockUtils mocks.DeviceDiscoveryUtils
-		manager   DeviceDiscovery
+		manager   *deviceDiscovery
 	)
 
 	BeforeEach(func() {
+		Expect(os.Unsetenv(consts.SKIP_DEVICE_ON_DISCOVERY_ERROR)).To(Succeed())
 		mockUtils = mocks.DeviceDiscoveryUtils{}
-		manager = deviceDiscovery{utils: &mockUtils, nodeName: "test-node"}
+		manager = &deviceDiscovery{utils: &mockUtils, nodeName: "test-node"}
 	})
 
 	Describe("NewDeviceDiscovery", func() {
@@ -142,6 +144,20 @@ var _ = Describe("DeviceDiscovery", func() {
 				devices, err := manager.DiscoverNicDevices()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(devices).To(BeEmpty())
+				Expect(manager.SkippedDevices()).To(BeEmpty())
+				mockUtils.AssertExpectations(GinkgoT())
+			})
+
+			It("should report skipped device if GetPartAndSerialNumber fails and SKIP_DEVICE_ON_DISCOVERY_ERROR is true", func() {
+				Expect(os.Setenv(consts.SKIP_DEVICE_ON_DISCOVERY_ERROR, consts.LabelValueTrue)).To(Succeed())
+				mockUtils.On("IsSriovVF", "0000:00:00.0").Return(false)
+				mockUtils.On("GetVPD", "0000:00:00.0").
+					Return(nil, errors.New("serial number error"))
+
+				devices, err := manager.DiscoverNicDevices()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(devices).To(BeEmpty())
+				Expect(manager.SkippedDevices()).To(HaveKey("0000:00:00"))
 				mockUtils.AssertExpectations(GinkgoT())
 			})
 
@@ -155,6 +171,21 @@ var _ = Describe("DeviceDiscovery", func() {
 				devices, err := manager.DiscoverNicDevices()
 				Expect(err).To(HaveOccurred())
 				Expect(devices).To(BeNil())
+				mockUtils.AssertExpectations(GinkgoT())
+			})
+
+			It("should skip devices if GetFirmwareVersionAndPSID fails and SKIP_DEVICE_ON_DISCOVERY_ERROR is true", func() {
+				Expect(os.Setenv(consts.SKIP_DEVICE_ON_DISCOVERY_ERROR, consts.LabelValueTrue)).To(Succeed())
+				mockUtils.On("IsSriovVF", "0000:00:00.0").Return(false)
+				mockUtils.On("GetVPD", "0000:00:00.0").
+					Return(&types.VPD{PartNumber: "part-number", SerialNumber: "serial-number", ModelName: ""}, nil)
+				mockUtils.On("GetFirmwareVersionAndPSID", "0000:00:00.0").
+					Return("", "", errors.New("firmware error"))
+
+				devices, err := manager.DiscoverNicDevices()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(devices).To(BeEmpty())
+				Expect(manager.SkippedDevices()).To(HaveKey("0000:00:00"))
 				mockUtils.AssertExpectations(GinkgoT())
 			})
 
@@ -308,6 +339,35 @@ var _ = Describe("DeviceDiscovery", func() {
 			mockUtils.AssertExpectations(GinkgoT())
 		})
 
+		It("should skip only a faulty device if GetFirmwareVersionAndPSID fails and SKIP_DEVICE_ON_DISCOVERY_ERROR is true", func() {
+			Expect(os.Setenv(consts.SKIP_DEVICE_ON_DISCOVERY_ERROR, consts.LabelValueTrue)).To(Succeed())
+			mockUtils.On("IsSriovVF", "0000:00:00.0").
+				Return(false)
+			mockUtils.On("GetVPD", "0000:00:00.0").
+				Return(&types.VPD{PartNumber: "part-number", SerialNumber: "serial-number", ModelName: ""}, nil)
+			mockUtils.On("GetFirmwareVersionAndPSID", "0000:00:00.0").
+				Return("fw-version", "psid", nil)
+			mockUtils.On("GetInterfaceName", "0000:00:00.0").
+				Return("eth0")
+			mockUtils.On("GetRDMADeviceName", "0000:00:00.0").
+				Return("mlx5_0")
+
+			mockUtils.On("IsSriovVF", "0000:01:00.0").
+				Return(false)
+			mockUtils.On("GetVPD", "0000:01:00.0").
+				Return(&types.VPD{PartNumber: "part-number", SerialNumber: "serial-number-2", ModelName: ""}, nil)
+			mockUtils.On("GetFirmwareVersionAndPSID", "0000:01:00.0").
+				Return("", "", errors.New("firmware error"))
+
+			devices, err := manager.DiscoverNicDevices()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(devices).To(HaveLen(1))
+			Expect(devices).To(HaveKey("0000:00:00"))
+			Expect(devices).NotTo(HaveKey("0000:01:00"))
+			Expect(manager.SkippedDevices()).To(HaveKey("0000:01:00"))
+			mockUtils.AssertExpectations(GinkgoT())
+		})
+
 		It("should discover and return devices successfully", func() {
 			mockUtils.On("IsSriovVF", "0000:00:00.0").
 				Return(false)
@@ -379,6 +439,7 @@ var _ = Describe("DeviceDiscovery", func() {
 
 			mockUtils.AssertExpectations(GinkgoT())
 		})
+
 	})
 
 	Context("when discovering two ports of a single NIC", func() {
@@ -451,6 +512,44 @@ var _ = Describe("DeviceDiscovery", func() {
 			Expect(devices["0000:00:00"].Status).To(Equal(expectedDeviceStatus))
 			_ = sameSerialNumber // kept for readability of mock setup above
 
+			mockUtils.AssertExpectations(GinkgoT())
+		})
+
+		It("should skip the whole physical device when discovery fails after one port was added", func() {
+			Expect(os.Setenv(consts.SKIP_DEVICE_ON_DISCOVERY_ERROR, consts.LabelValueTrue)).To(Succeed())
+			mockUtils.On("GetPCIDevices").Return([]*pci.Device{
+				{
+					Address: "0000:00:00.0",
+					Vendor:  &pcidb.Vendor{ID: consts.MellanoxVendor},
+					Product: &pcidb.Product{ID: "test-id", Name: "Mellanox Device"},
+					Class:   &pcidb.Class{ID: "02"},
+				},
+				{
+					Address: "0000:00:00.1",
+					Vendor:  &pcidb.Vendor{ID: consts.MellanoxVendor},
+					Product: &pcidb.Product{ID: "test-id", Name: "Mellanox Device"},
+					Class:   &pcidb.Class{ID: "02"},
+				},
+			}, nil)
+
+			mockUtils.On("IsSriovVF", "0000:00:00.0").Return(false)
+			mockUtils.On("GetVPD", "0000:00:00.0").
+				Return(&types.VPD{PartNumber: "part-number", SerialNumber: "serial-number", ModelName: ""}, nil)
+			mockUtils.On("GetFirmwareVersionAndPSID", "0000:00:00.0").
+				Return("fw-version", "psid", nil)
+			mockUtils.On("GetInterfaceName", "0000:00:00.0").
+				Return("eth0")
+			mockUtils.On("GetRDMADeviceName", "0000:00:00.0").
+				Return("mlx5_0")
+
+			mockUtils.On("IsSriovVF", "0000:00:00.1").Return(false)
+			mockUtils.On("GetVPD", "0000:00:00.1").
+				Return(nil, errors.New("vpd error"))
+
+			devices, err := manager.DiscoverNicDevices()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(devices).To(BeEmpty())
+			Expect(manager.SkippedDevices()).To(HaveKey("0000:00:00"))
 			mockUtils.AssertExpectations(GinkgoT())
 		})
 	})
@@ -585,7 +684,7 @@ var _ = Describe("DeviceDiscovery", func() {
 			mockUtils.On("GetInterfaceName", "0000:00:00.0").Return("eth0")
 			mockUtils.On("GetRDMADeviceName", "0000:00:00.0").Return("mlx5_0")
 
-			manager := deviceDiscovery{utils: &mockUtils, nvConfigUtils: nvmmocks.NewNVConfigUtils(GinkgoT()), nodeName: "test-node"}
+			manager := &deviceDiscovery{utils: &mockUtils, nvConfigUtils: nvmmocks.NewNVConfigUtils(GinkgoT()), nodeName: "test-node"}
 
 			devicesByPCI, err := manager.DiscoverNicDevices()
 			Expect(err).NotTo(HaveOccurred())
@@ -620,7 +719,7 @@ var _ = Describe("DeviceDiscovery", func() {
 				DefaultConfig:  map[string][]string{},
 			}, nil)
 
-			manager := deviceDiscovery{utils: &mockUtils, nvConfigUtils: nvConfigUtilsMock, nodeName: "test-node"}
+			manager := &deviceDiscovery{utils: &mockUtils, nvConfigUtils: nvConfigUtilsMock, nodeName: "test-node"}
 
 			devicesByPCI, err := manager.DiscoverNicDevices()
 			Expect(err).NotTo(HaveOccurred())
@@ -644,6 +743,58 @@ var _ = Describe("DeviceDiscovery", func() {
 			devices, err := manager.DiscoverNicDevices()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(devices).To(HaveLen(0))
+			mockUtils.AssertExpectations(GinkgoT())
+		})
+
+		It("should return an error when querying operation mode fails by default", func() {
+			mockUtils.On("GetPCIDevices").Return([]*pci.Device{
+				{
+					Address: "0000:00:00.0",
+					Vendor:  &pcidb.Vendor{ID: consts.MellanoxVendor},
+					Product: &pcidb.Product{ID: consts.BlueField3DeviceID, Name: "BlueField-3"},
+					Class:   &pcidb.Class{ID: "02"},
+				},
+			}, nil)
+			mockUtils.On("IsSriovVF", "0000:00:00.0").Return(false)
+			mockUtils.On("GetVPD", "0000:00:00.0").Return(&types.VPD{PartNumber: "part-number", SerialNumber: "serial-number", ModelName: "BlueField-3"}, nil)
+			mockUtils.On("IsZeroTrust", "0000:00:00.0").Return(false, nil)
+			mockUtils.On("GetFirmwareVersionAndPSID", "0000:00:00.0").Return("fw-version", "psid", nil)
+
+			nvConfigUtilsMock := nvmmocks.NewNVConfigUtils(GinkgoT())
+			nvConfigUtilsMock.On("QueryNvConfig", mock.Anything, "0000:00:00.0", []string{consts.BF3OperationModeParam}).Return(types.NvConfigQuery{}, errors.New("operation mode error"))
+
+			manager := &deviceDiscovery{utils: &mockUtils, nvConfigUtils: nvConfigUtilsMock, nodeName: "test-node"}
+
+			devices, err := manager.DiscoverNicDevices()
+			Expect(err).To(HaveOccurred())
+			Expect(devices).To(BeNil())
+			mockUtils.AssertExpectations(GinkgoT())
+		})
+
+		It("should skip the device when querying operation mode fails and SKIP_DEVICE_ON_DISCOVERY_ERROR is true", func() {
+			Expect(os.Setenv(consts.SKIP_DEVICE_ON_DISCOVERY_ERROR, consts.LabelValueTrue)).To(Succeed())
+			mockUtils.On("GetPCIDevices").Return([]*pci.Device{
+				{
+					Address: "0000:00:00.0",
+					Vendor:  &pcidb.Vendor{ID: consts.MellanoxVendor},
+					Product: &pcidb.Product{ID: consts.BlueField3DeviceID, Name: "BlueField-3"},
+					Class:   &pcidb.Class{ID: "02"},
+				},
+			}, nil)
+			mockUtils.On("IsSriovVF", "0000:00:00.0").Return(false)
+			mockUtils.On("GetVPD", "0000:00:00.0").Return(&types.VPD{PartNumber: "part-number", SerialNumber: "serial-number", ModelName: "BlueField-3"}, nil)
+			mockUtils.On("IsZeroTrust", "0000:00:00.0").Return(false, nil)
+			mockUtils.On("GetFirmwareVersionAndPSID", "0000:00:00.0").Return("fw-version", "psid", nil)
+
+			nvConfigUtilsMock := nvmmocks.NewNVConfigUtils(GinkgoT())
+			nvConfigUtilsMock.On("QueryNvConfig", mock.Anything, "0000:00:00.0", []string{consts.BF3OperationModeParam}).Return(types.NvConfigQuery{}, errors.New("operation mode error"))
+
+			manager := &deviceDiscovery{utils: &mockUtils, nvConfigUtils: nvConfigUtilsMock, nodeName: "test-node"}
+
+			devices, err := manager.DiscoverNicDevices()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(devices).To(BeEmpty())
+			Expect(manager.SkippedDevices()).To(HaveKey("0000:00:00"))
 			mockUtils.AssertExpectations(GinkgoT())
 		})
 	})


### PR DESCRIPTION
## Summary
- Backport #407 to `network-operator-26.4.x` with `git cherry-pick -x`
- Add `SKIP_DEVICE_ON_DISCOVERY_ERROR=true` handling for per-device firmware/PSID and BlueField operation-mode discovery failures
- Preserve existing `NicDevice` CRs when a physical device was skipped during discovery

## Verification
- `go test ./pkg/devicediscovery/... -v`
- `go test -c ./internal/controller -o /tmp/nco-controller-tests-backport.test`
- `go build ./...`

`go test ./internal/controller/... -v` could not run locally because envtest binaries are missing at `../../bin/k8s/1.31.0-darwin-arm64/etcd`.
