### PR TITLE
Support mlxreg Spectrum-X runtime parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,17 @@ data:
           value: "example-value"
           valueType: string
           dmsPath: "<dms-path-for-runtime-parameter>"
+      adaptiveRouting:
+        - name: Example mlxreg runtime parameter
+          value: "0x00000001"
+          mlxreg:
+            register: ROCE_ACCL
+            field: "<mlxreg-field-to-check>"
+            setFields:
+              - name: "<mlxreg-field-to-set>"
+                value: "0x1"
+              - name: "<mlxreg-field-select-to-set>"
+                value: "0x1"
 ```
 
 Reference the profile from a `NicConfigurationTemplate` by using the ConfigMap name as the Spectrum-X version:

--- a/docs/examples/spectrum-x/example-spectrum-x-profile-configmap.yaml
+++ b/docs/examples/spectrum-x/example-spectrum-x-profile-configmap.yaml
@@ -56,6 +56,16 @@ data:
           value: true
           valueType: bool
           dmsPath: "<dms-path-for-runtime-parameter>"
+        - name: Example mlxreg runtime parameter
+          value: "0x00000001"
+          mlxreg:
+            register: ROCE_ACCL
+            field: "<mlxreg-field-to-check>"
+            setFields:
+              - name: "<mlxreg-field-to-set>"
+                value: "0x1"
+              - name: "<mlxreg-field-select-to-set>"
+                value: "0x1"
       congestionControl:
         - name: Example congestion control parameter
           value: 1

--- a/docs/nic-configuration-library.md
+++ b/docs/nic-configuration-library.md
@@ -466,24 +466,37 @@ type VPD struct {
 
 #### ConfigurationParameter
 
-Used by DMS client and Spectrum-X config. Loaded from YAML files in `bindata/spectrum-x/`.
+Used by DMS client and Spectrum-X profile ConfigMaps.
 
 ```go
 type ConfigurationParameter struct {
-    Name             string // Human-readable name
-    MlxConfig        string // mlxconfig parameter name (e.g., "LINK_TYPE_P1")
-    Value            string // Value to set
-    ValueType        string // DMS value type: "string", "bool", "int"
-    DMSPath          string // DMS path (e.g., "/interfaces/interface/nvidia/qos/config/trust-mode")
-    AlternativeValue string // Alternative value representation
-    DeviceId         string // Device ID filter (e.g., "1023", "a2dc")
-    Breakout         int    // Plane count filter (1, 2, 4)
-    Multiplane       string // Multiplane mode filter (none, swplb, hwplb, uniplane)
-    IgnoreError      bool   // Suppress errors for this parameter in batch operations
+    Name               string           // Human-readable name
+    MlxConfig          string           // mlxconfig parameter name (e.g., "LINK_TYPE_P1")
+    Value              string           // DMS set value or expected mlxreg get value
+    ValueType          string           // DMS value type: "string", "bool", "int"
+    DMSPath            string           // DMS path (e.g., "/interfaces/interface/nvidia/qos/config/trust-mode")
+    MlxReg             *MlxRegParameter // Optional mlxreg runtime parameter
+    AlternativeValue   string           // Alternative value representation accepted during checks
+    DeviceId           string           // Device ID filter (e.g., "1023", "a2dc")
+    Breakout           int              // Plane count filter (1, 2, 4)
+    Multiplane         string           // Multiplane mode filter (none, swplb, hwplb, uniplane)
+    IgnoreError        bool             // Suppress errors for this parameter in batch operations
+    HwplbFirstPortOnly bool             // Limit DMS interface expansion to the first port in hwplb
+}
+
+type MlxRegParameter struct {
+    Register  string        // mlxreg register name, e.g., "ROCE_ACCL"
+    Field     string        // Field read by mlxreg --get and compared with Value
+    SetFields []MlxRegField // Fields rendered into mlxreg --set NAME=VALUE,...
+}
+
+type MlxRegField struct {
+    Name  string
+    Value string
 }
 ```
 
-A parameter with `MlxConfig` set is applied via `nvconfig.SetNvConfigParametersBatch()`; a parameter with `DMSPath` set is applied via `dms.DMSClient.SetParameters()`.
+A parameter with `MlxConfig` set is applied via `nvconfig.SetNvConfigParametersBatch()`. Runtime profile parameters with `DMSPath` set are applied via `dms.DMSClient.SetParameters()`. Runtime profile parameters with `MlxReg` set are applied with `mlxreg`; they preserve profile order and split surrounding DMS parameters into separate batches.
 
 #### Spectrum-X Config Types
 

--- a/pkg/spectrumx/spectrumx.go
+++ b/pkg/spectrumx/spectrumx.go
@@ -18,6 +18,7 @@ package spectrumx
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -39,14 +40,6 @@ var cnpDscpSysfsPathTemplate = "/sys/class/net/%s/ecn/roce_np/cnp_dscp"
 
 // cnpDscpExpectedValue is the expected value for CNP DSCP
 const cnpDscpExpectedValue = "48"
-
-// mlxreg constants for CC Probe MP mode workaround.
-// Workaround: CC Probe MP mode is not configurable via DMS, so we use mlxreg instead.
-// Remove this workaround once the parameter is added to DMS.
-const ccProbeMPModeRegName = "ROCE_ACCL"
-const ccProbeMPModeFieldName = "cc_probe_mp_mode"
-const ccProbeMPModeFieldSet = "cc_probe_mp_mode=0x1,cc_probe_mp_mode_field_select=0x1"
-const ccProbeMPModeExpectedValue = "0x00000001"
 
 // mlxregBinary is the path to the mlxreg binary. This is a var to allow substitution in tests.
 var mlxregBinary = "/usr/bin/mlxreg"
@@ -258,71 +251,163 @@ func writeCnpDscp(device *v1alpha1.NicDevice) error {
 	return nil
 }
 
-// checkCCProbeMPMode checks if CC Probe MP mode is set on all PFs via mlxreg.
-// Workaround: CC Probe MP mode is not configurable via DMS, so we use mlxreg instead.
-// Remove this workaround once the parameter is added to DMS.
-func (m *spectrumXConfigManager) checkCCProbeMPMode(device *v1alpha1.NicDevice) (bool, error) {
-	log.Log.V(2).Info("SpectrumXConfigManager.checkCCProbeMPMode()", "device", device.Name)
+func isMlxRegParam(param types.ConfigurationParameter) bool {
+	return param.MlxReg != nil
+}
 
+func validateMlxRegParam(param types.ConfigurationParameter) error {
+	if param.MlxReg == nil {
+		return fmt.Errorf("mlxreg parameter %q is missing mlxreg config", param.Name)
+	}
+	if param.DMSPath != "" {
+		return fmt.Errorf("mlxreg parameter %q cannot define both dmsPath and mlxreg", param.Name)
+	}
+	if param.Value == "" {
+		return fmt.Errorf("mlxreg parameter %q is missing value", param.Name)
+	}
+	if param.MlxReg.Register == "" {
+		return fmt.Errorf("mlxreg parameter %q is missing register", param.Name)
+	}
+	if param.MlxReg.Field == "" {
+		return fmt.Errorf("mlxreg parameter %q is missing field", param.Name)
+	}
+	if len(param.MlxReg.SetFields) == 0 {
+		return fmt.Errorf("mlxreg parameter %q has no setFields", param.Name)
+	}
+	for _, field := range param.MlxReg.SetFields {
+		if field.Name == "" {
+			return fmt.Errorf("mlxreg parameter %q has a setField without name", param.Name)
+		}
+		if field.Value == "" {
+			return fmt.Errorf("mlxreg parameter %q has a setField without value", param.Name)
+		}
+	}
+	return nil
+}
+
+func parseMlxRegFieldValue(output []byte, field string) (string, bool) {
+	for _, line := range strings.Split(string(output), "\n") {
+		parts := strings.SplitN(line, "|", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		if strings.TrimSpace(parts[0]) == field {
+			return strings.TrimSpace(parts[1]), true
+		}
+	}
+	return "", false
+}
+
+func commandLine(binary string, args []string) string {
+	return strings.Join(append([]string{binary}, args...), " ")
+}
+
+func equalMlxRegValue(expected, actual string) bool {
+	expected = strings.TrimSpace(expected)
+	actual = strings.TrimSpace(actual)
+	if actual == expected {
+		return true
+	}
+
+	expectedValue, err := strconv.ParseUint(expected, 0, 64)
+	if err != nil {
+		return false
+	}
+	actualValue, err := strconv.ParseUint(actual, 0, 64)
+	if err != nil {
+		return false
+	}
+	return actualValue == expectedValue
+}
+
+func expectedMlxRegValue(param types.ConfigurationParameter, actual string) bool {
+	return equalMlxRegValue(param.Value, actual) || (param.AlternativeValue != "" && equalMlxRegValue(param.AlternativeValue, actual))
+}
+
+func mlxRegSetValue(param types.ConfigurationParameter) string {
+	fields := make([]string, 0, len(param.MlxReg.SetFields))
+	for _, field := range param.MlxReg.SetFields {
+		fields = append(fields, fmt.Sprintf("%s=%s", field.Name, field.Value))
+	}
+	return strings.Join(fields, ",")
+}
+
+func (m *spectrumXConfigManager) checkMlxRegParamApplied(device *v1alpha1.NicDevice, param types.ConfigurationParameter) (bool, error) {
+	if err := validateMlxRegParam(param); err != nil {
+		return false, err
+	}
+
+	log.Log.V(2).Info("SpectrumXConfigManager.checkMlxRegParamApplied()", "device", device.Name, "param", param.Name)
 	for _, port := range device.Status.Ports {
-		cmd := m.execInterface.Command(mlxregBinary, "-d", port.PCI,
-			"--reg_name", ccProbeMPModeRegName, "--get")
+		args := []string{"-d", port.PCI, "--reg_name", param.MlxReg.Register, "--get"}
+		command := commandLine(mlxregBinary, args)
+		log.Log.V(2).Info("checkMlxRegParamApplied(): running mlxreg get",
+			"device", device.Name, "pci", port.PCI, "param", param.Name, "field", param.MlxReg.Field,
+			"expected", param.Value, "alternativeExpected", param.AlternativeValue, "command", command)
+
+		cmd := m.execInterface.Command(mlxregBinary, args...)
 		output, err := cmd.CombinedOutput()
 		if err != nil {
-			log.Log.Error(err, "checkCCProbeMPMode(): failed to run mlxreg get", "device", device.Name, "pci", port.PCI)
-			return false, fmt.Errorf("failed to check CC Probe MP mode via mlxreg for PF %s: %w", port.PCI, err)
+			log.Log.Error(err, "checkMlxRegParamApplied(): failed to run mlxreg get",
+				"device", device.Name, "pci", port.PCI, "param", param.Name, "command", command, "output", string(output))
+			return false, fmt.Errorf("failed to check mlxreg parameter %q for PF %s: %w", param.Name, port.PCI, err)
 		}
-		// Parse the mlxreg table output to find the cc_probe_mp_mode field and its value.
-		// Output format: "cc_probe_mp_mode                               | 0x00000001"
-		// We need to avoid checking cc_probe_mp_mode_field_select as it can have a different value.
-		found := false
-		for _, line := range strings.Split(string(output), "\n") {
-			if strings.Contains(line, ccProbeMPModeFieldName) && !strings.Contains(line, "field_select") {
-				found = true
-				if !strings.Contains(line, ccProbeMPModeExpectedValue) {
-					log.Log.V(2).Info("checkCCProbeMPMode(): cc_probe_mp_mode not set on PF",
-						"device", device.Name, "pci", port.PCI, "line", strings.TrimSpace(line))
-					return false, nil
-				}
-				break
-			}
-		}
+
+		value, found := parseMlxRegFieldValue(output, param.MlxReg.Field)
+		matches := found && expectedMlxRegValue(param, value)
+		log.Log.V(2).Info("checkMlxRegParamApplied(): got mlxreg value",
+			"device", device.Name, "pci", port.PCI, "param", param.Name, "register", param.MlxReg.Register,
+			"field", param.MlxReg.Field, "expected", param.Value, "alternativeExpected", param.AlternativeValue,
+			"actual", value, "found", found, "matches", matches, "command", command, "output", string(output))
 		if !found {
-			log.Log.V(2).Info("checkCCProbeMPMode(): cc_probe_mp_mode field not found in mlxreg output",
-				"device", device.Name, "pci", port.PCI)
+			log.Log.V(2).Info("checkMlxRegParamApplied(): field not found in mlxreg output",
+				"device", device.Name, "pci", port.PCI, "param", param.Name, "field", param.MlxReg.Field,
+				"command", command, "output", string(output))
+			return false, nil
+		}
+		if !matches {
+			log.Log.V(2).Info("checkMlxRegParamApplied(): mlxreg parameter not applied",
+				"device", device.Name, "pci", port.PCI, "param", param.Name, "expected", param.Value,
+				"alternativeExpected", param.AlternativeValue, "actual", value, "command", command)
 			return false, nil
 		}
 	}
-
-	log.Log.V(2).Info("checkCCProbeMPMode(): cc_probe_mp_mode is set on all PFs", "device", device.Name)
 	return true, nil
 }
 
-// setCCProbeMPMode sets CC Probe MP mode on all PFs via mlxreg.
-// Workaround: CC Probe MP mode is not configurable via DMS, so we use mlxreg instead.
-// Remove this workaround once the parameter is added to DMS.
-func (m *spectrumXConfigManager) setCCProbeMPMode(device *v1alpha1.NicDevice) error {
-	log.Log.V(2).Info("SpectrumXConfigManager.setCCProbeMPMode()", "device", device.Name)
+func (m *spectrumXConfigManager) setMlxRegParam(device *v1alpha1.NicDevice, param types.ConfigurationParameter) error {
+	if err := validateMlxRegParam(param); err != nil {
+		return err
+	}
+	setValue := mlxRegSetValue(param)
 
+	log.Log.V(2).Info("SpectrumXConfigManager.setMlxRegParam()", "device", device.Name, "param", param.Name)
 	for _, port := range device.Status.Ports {
-		cmd := m.execInterface.Command(mlxregBinary, "-d", port.PCI,
-			"--reg_name", ccProbeMPModeRegName, "--set", ccProbeMPModeFieldSet, "--yes")
+		args := []string{"-d", port.PCI, "--reg_name", param.MlxReg.Register, "--set", setValue, "--yes"}
+		command := commandLine(mlxregBinary, args)
+		log.Log.V(2).Info("setMlxRegParam(): running mlxreg set",
+			"device", device.Name, "pci", port.PCI, "param", param.Name, "register", param.MlxReg.Register,
+			"setValue", setValue, "command", command)
+
+		cmd := m.execInterface.Command(mlxregBinary, args...)
 		output, err := cmd.CombinedOutput()
 		if err != nil {
-			log.Log.Error(err, "setCCProbeMPMode(): failed to run mlxreg set",
-				"device", device.Name, "pci", port.PCI, "output", string(output))
-			return fmt.Errorf("failed to set CC Probe MP mode via mlxreg for PF %s: %w", port.PCI, err)
+			log.Log.Error(err, "setMlxRegParam(): failed to run mlxreg set",
+				"device", device.Name, "pci", port.PCI, "param", param.Name, "command", command, "output", string(output))
+			return fmt.Errorf("failed to set mlxreg parameter %q for PF %s: %w", param.Name, port.PCI, err)
 		}
-		log.Log.V(2).Info("setCCProbeMPMode(): successfully set cc_probe_mp_mode on PF",
-			"device", device.Name, "pci", port.PCI)
+		log.Log.V(2).Info("setMlxRegParam(): successfully set mlxreg parameter on PF",
+			"device", device.Name, "pci", port.PCI, "param", param.Name, "command", command, "output", string(output))
 	}
-
 	return nil
 }
 
 // checkDmsParamsApplied checks if the given DMS parameters are applied to the device
 func checkDmsParamsApplied(device *v1alpha1.NicDevice, params []types.ConfigurationParameter, dmsClient dms.DMSClient) (bool, error) {
 	log.Log.Info("SpectrumXConfigManager.checkDmsParamsApplied()", "device", device.Name)
+	if len(params) == 0 {
+		return true, nil
+	}
 
 	values, err := dmsClient.GetParameters(params)
 	if err != nil {
@@ -336,13 +421,77 @@ func checkDmsParamsApplied(device *v1alpha1.NicDevice, params []types.Configurat
 	log.Log.V(2).Info("SpectrumXConfigManager.checkDmsParamsApplied(): got the following values", "device", device.Name, "values", values)
 
 	for _, param := range params {
-		if values[param.DMSPath] != param.Value && values[param.DMSPath] != param.AlternativeValue {
+		actual, found := values[param.DMSPath]
+		matches := found && (actual == param.Value || (param.AlternativeValue != "" && actual == param.AlternativeValue))
+		log.Log.V(2).Info("SpectrumXConfigManager.checkDmsParamsApplied(): compared parameter",
+			"device", device.Name, "param", param.Name, "path", param.DMSPath, "expected", param.Value,
+			"alternativeExpected", param.AlternativeValue, "actual", actual, "found", found, "matches", matches)
+		if !matches {
 			log.Log.V(2).Info("SpectrumXConfigManager.checkDmsParamsApplied(): parameter not applied", "device", device.Name, "param", param)
 			return false, nil
 		}
 	}
 
 	return true, nil
+}
+
+func (m *spectrumXConfigManager) checkRuntimeParamsApplied(device *v1alpha1.NicDevice, params []types.ConfigurationParameter, dmsClient dms.DMSClient) (bool, error) {
+	dmsBatch := []types.ConfigurationParameter{}
+	flushDMSBatch := func() (bool, error) {
+		applied, err := checkDmsParamsApplied(device, dmsBatch, dmsClient)
+		dmsBatch = nil
+		return applied, err
+	}
+
+	for _, param := range params {
+		if isMlxRegParam(param) {
+			if err := validateMlxRegParam(param); err != nil {
+				return false, err
+			}
+			applied, err := flushDMSBatch()
+			if err != nil || !applied {
+				return applied, err
+			}
+			applied, err = m.checkMlxRegParamApplied(device, param)
+			if err != nil || !applied {
+				return applied, err
+			}
+			continue
+		}
+		dmsBatch = append(dmsBatch, param)
+	}
+
+	return flushDMSBatch()
+}
+
+func (m *spectrumXConfigManager) applyRuntimeParams(device *v1alpha1.NicDevice, params []types.ConfigurationParameter, dmsClient dms.DMSClient) error {
+	dmsBatch := []types.ConfigurationParameter{}
+	flushDMSBatch := func() error {
+		if len(dmsBatch) == 0 {
+			return nil
+		}
+		err := dmsClient.SetParameters(dmsBatch)
+		dmsBatch = nil
+		return err
+	}
+
+	for _, param := range params {
+		if isMlxRegParam(param) {
+			if err := validateMlxRegParam(param); err != nil {
+				return err
+			}
+			if err := flushDMSBatch(); err != nil {
+				return err
+			}
+			if err := m.setMlxRegParam(device, param); err != nil {
+				return err
+			}
+			continue
+		}
+		dmsBatch = append(dmsBatch, param)
+	}
+
+	return flushDMSBatch()
 }
 
 // RuntimeConfigApplied checks if the desired Spectrum-X runtime spec is applied to the device
@@ -368,7 +517,7 @@ func (m *spectrumXConfigManager) RuntimeConfigApplied(device *v1alpha1.NicDevice
 
 	roceParams := filterParameters(desiredConfig.RuntimeConfig.Roce, deviceType, numberOfPlanes, multiplaneMode)
 	log.Log.V(2).Info("SpectrumXConfigManager.RuntimeConfigApplied(): checking RoCE config", "device", device.Name)
-	roceApplied, err := checkDmsParamsApplied(device, roceParams, dmsClient)
+	roceApplied, err := m.checkRuntimeParamsApplied(device, roceParams, dmsClient)
 	if err != nil {
 		log.Log.Error(err, "RuntimeConfigApplied(): failed to check if RoCE config is applied", "device", device.Name)
 		return false, err
@@ -391,57 +540,14 @@ func (m *spectrumXConfigManager) RuntimeConfigApplied(device *v1alpha1.NicDevice
 	}
 
 	adaptiveRoutingParams := filterParameters(desiredConfig.RuntimeConfig.AdaptiveRouting, deviceType, numberOfPlanes, multiplaneMode)
-
-	if multiplaneMode == consts.MultiplaneModeHwplb && len(adaptiveRoutingParams) > 0 {
-		// Workaround: CC Probe MP mode must be checked BEFORE the last adaptive routing
-		// parameter is read. Split the params: all except last, then mlxreg, then last.
-		// Remove this workaround once the parameter is added to DMS.
-		lastIndex := len(adaptiveRoutingParams) - 1
-		beforeLastParams := adaptiveRoutingParams[:lastIndex]
-		lastParam := adaptiveRoutingParams[lastIndex:]
-
-		if len(beforeLastParams) > 0 {
-			log.Log.V(2).Info("SpectrumXConfigManager.RuntimeConfigApplied(): checking Adaptive Routing config (before CC Probe MP mode)", "device", device.Name)
-			applied, err := checkDmsParamsApplied(device, beforeLastParams, dmsClient)
-			if err != nil {
-				log.Log.Error(err, "RuntimeConfigApplied(): failed to check Adaptive Routing config (before CC Probe MP mode)", "device", device.Name)
-				return false, err
-			}
-			if !applied {
-				return false, nil
-			}
-		}
-
-		// Workaround: Check CC Probe MP mode via mlxreg on all PFs (not configurable via DMS)
-		log.Log.V(2).Info("SpectrumXConfigManager.RuntimeConfigApplied(): checking CC Probe MP mode via mlxreg", "device", device.Name)
-		ccProbeMPApplied, err := m.checkCCProbeMPMode(device)
-		if err != nil {
-			log.Log.Error(err, "RuntimeConfigApplied(): failed to check CC Probe MP mode", "device", device.Name)
-			return false, err
-		}
-		if !ccProbeMPApplied {
-			return false, nil
-		}
-
-		log.Log.V(2).Info("SpectrumXConfigManager.RuntimeConfigApplied(): checking Adaptive Routing config (after CC Probe MP mode)", "device", device.Name)
-		adaptiveRoutingApplied, err := checkDmsParamsApplied(device, lastParam, dmsClient)
-		if err != nil {
-			log.Log.Error(err, "RuntimeConfigApplied(): failed to check Adaptive Routing config (after CC Probe MP mode)", "device", device.Name)
-			return false, err
-		}
-		if !adaptiveRoutingApplied {
-			return false, nil
-		}
-	} else {
-		log.Log.V(2).Info("SpectrumXConfigManager.RuntimeConfigApplied(): checking Adaptive Routing config", "device", device.Name)
-		adaptiveRoutingApplied, err := checkDmsParamsApplied(device, adaptiveRoutingParams, dmsClient)
-		if err != nil {
-			log.Log.Error(err, "RuntimeConfigApplied(): failed to check if Adaptive Routing config is applied", "device", device.Name)
-			return false, err
-		}
-		if !adaptiveRoutingApplied {
-			return false, nil
-		}
+	log.Log.V(2).Info("SpectrumXConfigManager.RuntimeConfigApplied(): checking Adaptive Routing config", "device", device.Name)
+	adaptiveRoutingApplied, err := m.checkRuntimeParamsApplied(device, adaptiveRoutingParams, dmsClient)
+	if err != nil {
+		log.Log.Error(err, "RuntimeConfigApplied(): failed to check if Adaptive Routing config is applied", "device", device.Name)
+		return false, err
+	}
+	if !adaptiveRoutingApplied {
+		return false, nil
 	}
 
 	if desiredConfig.UseSoftwareCCAlgorithm {
@@ -465,7 +571,7 @@ func (m *spectrumXConfigManager) RuntimeConfigApplied(device *v1alpha1.NicDevice
 
 	congestionControlParams := filterParameters(desiredConfig.RuntimeConfig.CongestionControl, deviceType, numberOfPlanes, multiplaneMode)
 	log.Log.V(2).Info("SpectrumXConfigManager.RuntimeConfigApplied(): checking Congestion Control config", "device", device.Name)
-	congestionControlApplied, err := checkDmsParamsApplied(device, congestionControlParams, dmsClient)
+	congestionControlApplied, err := m.checkRuntimeParamsApplied(device, congestionControlParams, dmsClient)
 	if err != nil {
 		log.Log.Error(err, "RuntimeConfigApplied(): failed to check if Congestion Control config is applied", "device", device.Name)
 		return false, err
@@ -487,7 +593,7 @@ func (m *spectrumXConfigManager) RuntimeConfigApplied(device *v1alpha1.NicDevice
 	}
 	interPacketGapParams = filterParameters(interPacketGapParams, deviceType, numberOfPlanes, multiplaneMode)
 
-	overlayParamsApplied, err := checkDmsParamsApplied(device, interPacketGapParams, dmsClient)
+	overlayParamsApplied, err := m.checkRuntimeParamsApplied(device, interPacketGapParams, dmsClient)
 	if err != nil {
 		log.Log.Error(err, "ApplyRuntimeConfig(): failed to set Spectrum-X InterPacketGap config", "device", device.Name)
 		return false, err
@@ -522,7 +628,7 @@ func (m *spectrumXConfigManager) ApplyRuntimeConfig(device *v1alpha1.NicDevice) 
 
 	roceParams := filterParameters(desiredConfig.RuntimeConfig.Roce, deviceType, numberOfPlanes, multiplaneMode)
 	log.Log.V(2).Info("SpectrumXConfigManager.ApplyRuntimeConfig(): setting RoCE config", "device", device.Name)
-	err = dmsClient.SetParameters(roceParams)
+	err = m.applyRuntimeParams(device, roceParams, dmsClient)
 	if err != nil {
 		log.Log.Error(err, "ApplyRuntimeConfig(): failed to set Spectrum-X RoCE config", "device", device.Name)
 		return &types.RuntimeConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
@@ -537,45 +643,11 @@ func (m *spectrumXConfigManager) ApplyRuntimeConfig(device *v1alpha1.NicDevice) 
 	}
 
 	adaptiveRoutingParams := filterParameters(desiredConfig.RuntimeConfig.AdaptiveRouting, deviceType, numberOfPlanes, multiplaneMode)
-
-	if multiplaneMode == consts.MultiplaneModeHwplb && len(adaptiveRoutingParams) > 0 {
-		// Workaround: CC Probe MP mode must be set BEFORE the last adaptive routing
-		// parameter is applied. Split the params: all except last, then mlxreg, then last.
-		// Remove this workaround once the parameter is added to DMS.
-		lastIndex := len(adaptiveRoutingParams) - 1
-		beforeLastParams := adaptiveRoutingParams[:lastIndex]
-		lastParam := adaptiveRoutingParams[lastIndex:]
-
-		if len(beforeLastParams) > 0 {
-			log.Log.V(2).Info("SpectrumXConfigManager.ApplyRuntimeConfig(): setting Adaptive Routing config (before CC Probe MP mode)", "device", device.Name)
-			err = dmsClient.SetParameters(beforeLastParams)
-			if err != nil {
-				log.Log.Error(err, "ApplyRuntimeConfig(): failed to set Adaptive Routing config (before CC Probe MP mode)", "device", device.Name)
-				return &types.RuntimeConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
-			}
-		}
-
-		// Workaround: Set CC Probe MP mode via mlxreg on all PFs (not configurable via DMS)
-		log.Log.V(2).Info("SpectrumXConfigManager.ApplyRuntimeConfig(): setting CC Probe MP mode via mlxreg", "device", device.Name)
-		err = m.setCCProbeMPMode(device)
-		if err != nil {
-			log.Log.Error(err, "ApplyRuntimeConfig(): failed to set CC Probe MP mode", "device", device.Name)
-			return &types.RuntimeConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
-		}
-
-		log.Log.V(2).Info("SpectrumXConfigManager.ApplyRuntimeConfig(): setting Adaptive Routing config (after CC Probe MP mode)", "device", device.Name)
-		err = dmsClient.SetParameters(lastParam)
-		if err != nil {
-			log.Log.Error(err, "ApplyRuntimeConfig(): failed to set Adaptive Routing config (after CC Probe MP mode)", "device", device.Name)
-			return &types.RuntimeConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
-		}
-	} else {
-		log.Log.V(2).Info("SpectrumXConfigManager.ApplyRuntimeConfig(): setting Adaptive Routing config", "device", device.Name)
-		err = dmsClient.SetParameters(adaptiveRoutingParams)
-		if err != nil {
-			log.Log.Error(err, "ApplyRuntimeConfig(): failed to set Spectrum-X Adaptive Routing config", "device", device.Name)
-			return &types.RuntimeConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
-		}
+	log.Log.V(2).Info("SpectrumXConfigManager.ApplyRuntimeConfig(): setting Adaptive Routing config", "device", device.Name)
+	err = m.applyRuntimeParams(device, adaptiveRoutingParams, dmsClient)
+	if err != nil {
+		log.Log.Error(err, "ApplyRuntimeConfig(): failed to set Spectrum-X Adaptive Routing config", "device", device.Name)
+		return &types.RuntimeConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
 	}
 
 	if desiredConfig.UseSoftwareCCAlgorithm {
@@ -604,7 +676,7 @@ func (m *spectrumXConfigManager) ApplyRuntimeConfig(device *v1alpha1.NicDevice) 
 
 	congestionControlParams := filterParameters(desiredConfig.RuntimeConfig.CongestionControl, deviceType, numberOfPlanes, multiplaneMode)
 	log.Log.V(2).Info("SpectrumXConfigManager.ApplyRuntimeConfig(): setting Congestion Control config", "device", device.Name)
-	err = dmsClient.SetParameters(congestionControlParams)
+	err = m.applyRuntimeParams(device, congestionControlParams, dmsClient)
 	if err != nil {
 		log.Log.Error(err, "ApplyRuntimeConfig(): failed to set Spectrum-X Congestion Control config", "device", device.Name)
 		return &types.RuntimeConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
@@ -622,7 +694,7 @@ func (m *spectrumXConfigManager) ApplyRuntimeConfig(device *v1alpha1.NicDevice) 
 	}
 	interPacketGapParams = filterParameters(interPacketGapParams, deviceType, numberOfPlanes, multiplaneMode)
 
-	err = dmsClient.SetParameters(interPacketGapParams)
+	err = m.applyRuntimeParams(device, interPacketGapParams, dmsClient)
 	if err != nil {
 		log.Log.Error(err, "ApplyRuntimeConfig(): failed to set Spectrum-X InterPacketGap config", "device", device.Name)
 		return &types.RuntimeConfigurationApplyResult{Status: types.ApplyStatusFailed}, err

--- a/pkg/spectrumx/spectrumx_test.go
+++ b/pkg/spectrumx/spectrumx_test.go
@@ -59,8 +59,14 @@ func (c *fakeCmd) CombinedOutput() ([]byte, error) {
 
 type fakeExec struct {
 	execUtils.Interface
-	cmds []*fakeCmd
-	pos  int
+	cmds  []*fakeCmd
+	pos   int
+	calls []commandCall
+}
+
+type commandCall struct {
+	name string
+	args []string
 }
 
 const (
@@ -94,6 +100,22 @@ var (
 	nextCmd *fakeCmd
 )
 
+func ccProbeMPModeParam() types.ConfigurationParameter {
+	return types.ConfigurationParameter{
+		Name:       "CC Probe MP mode",
+		Value:      "0x00000001",
+		Multiplane: consts.MultiplaneModeHwplb,
+		MlxReg: &types.MlxRegParameter{
+			Register: "ROCE_ACCL",
+			Field:    "cc_probe_mp_mode",
+			SetFields: []types.MlxRegField{
+				{Name: "cc_probe_mp_mode", Value: "0x1"},
+				{Name: "cc_probe_mp_mode_field_select", Value: "0x1"},
+			},
+		},
+	}
+}
+
 func (f *fakeExec) next() execUtils.Cmd {
 	if f.cmds != nil && f.pos < len(f.cmds) {
 		c := f.cmds[f.pos]
@@ -102,8 +124,12 @@ func (f *fakeExec) next() execUtils.Cmd {
 	}
 	return nextCmd
 }
-func (f *fakeExec) Command(cmd string, args ...string) execUtils.Cmd { return f.next() }
+func (f *fakeExec) Command(cmd string, args ...string) execUtils.Cmd {
+	f.calls = append(f.calls, commandCall{name: cmd, args: append([]string{}, args...)})
+	return f.next()
+}
 func (f *fakeExec) CommandContext(ctx context.Context, cmd string, args ...string) execUtils.Cmd {
+	f.calls = append(f.calls, commandCall{name: cmd, args: append([]string{}, args...)})
 	return f.next()
 }
 
@@ -514,10 +540,6 @@ var _ = Describe("SpectrumXConfigManager", func() {
 				dmsCli.On("GetParameters", cfgs["v1"].RuntimeConfig.CongestionControl).Return(map[string]string{"/cc": "z"}, nil)
 				dmsCli.On("GetParameters", cfgs["v1"].RuntimeConfig.InterPacketGap.PureL3).Return(map[string]string{"/ipg": "25"}, nil)
 
-				// Stage mlxreg get for cc_probe_mp_mode check (1 PF)
-				execFake.cmds = []*fakeCmd{
-					{output: []byte(mlxregGetCCProbeMPSet), err: nil},
-				}
 				applied, err := manager.RuntimeConfigApplied(device)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(applied).To(BeTrue())
@@ -677,10 +699,6 @@ var _ = Describe("SpectrumXConfigManager", func() {
 					return len(params) == 1 && params[0].Name == bringUpInterfaceParamName
 				})).Return(nil)
 
-				// Stage mlxreg set for cc_probe_mp_mode (1 PF), then doca_spcx_cc
-				execFake.cmds = []*fakeCmd{
-					{output: []byte("ok"), err: nil}, // mlxreg set
-				}
 				nextCmd = &fakeCmd{output: []byte("started"), err: nil, delay: 5 * time.Second}
 				_, err := manager.ApplyRuntimeConfig(device)
 				Expect(err).NotTo(HaveOccurred())
@@ -856,10 +874,6 @@ var _ = Describe("SpectrumXConfigManager", func() {
 				dmsCli.On("GetParameters", expectedCC).Return(map[string]string{"/cc/match": "val4"}, nil)
 				dmsCli.On("GetParameters", cfgs["v1"].RuntimeConfig.InterPacketGap.PureL3).Return(map[string]string{"/ipg/match": "val6"}, nil)
 
-				// Stage mlxreg get for cc_probe_mp_mode check (1 PF)
-				execFake.cmds = []*fakeCmd{
-					{output: []byte(mlxregGetCCProbeMPSet), err: nil},
-				}
 				applied, err := manager.RuntimeConfigApplied(device)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(applied).To(BeTrue())
@@ -895,10 +909,6 @@ var _ = Describe("SpectrumXConfigManager", func() {
 				dmsCli.On("GetParameters", cfgs["v1"].RuntimeConfig.CongestionControl).Return(map[string]string{"/cc/match": "val5"}, nil)
 				dmsCli.On("GetParameters", cfgs["v1"].RuntimeConfig.InterPacketGap.PureL3).Return(map[string]string{"/ipg/match": "val6"}, nil)
 
-				// Stage mlxreg get for cc_probe_mp_mode check (1 PF)
-				execFake.cmds = []*fakeCmd{
-					{output: []byte(mlxregGetCCProbeMPSet), err: nil},
-				}
 				applied, err := manager.RuntimeConfigApplied(device)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(applied).To(BeTrue())
@@ -925,7 +935,6 @@ var _ = Describe("SpectrumXConfigManager", func() {
 					{Name: "ipg_match", Value: "100", DMSPath: "/ipg/match", DeviceId: "1023", Breakout: 4, Multiplane: consts.MultiplaneModeSwplb},
 				}
 
-				dmsCli.On("GetParameters", []types.ConfigurationParameter{}).Return(map[string]string{}, nil).Times(3)
 				dmsCli.On("GetParameters", expectedIPG).Return(map[string]string{"/ipg/match": "100"}, nil)
 
 				applied, err := manager.RuntimeConfigApplied(device)
@@ -1082,7 +1091,6 @@ var _ = Describe("SpectrumXConfigManager", func() {
 					{Name: "ipg_no_filter", Value: "500", DMSPath: "/ipg/nofilter"},
 				}
 
-				dmsCli.On("SetParameters", []types.ConfigurationParameter{}).Return(nil).Times(3)
 				dmsCli.On("SetParameters", expectedIPG).Return(nil)
 				dmsCli.On("SetParameters", mock.MatchedBy(func(params []types.ConfigurationParameter) bool {
 					return len(params) == 1 && params[0].Name == shutdownInterfaceParamName
@@ -1097,262 +1105,206 @@ var _ = Describe("SpectrumXConfigManager", func() {
 		})
 	})
 
-	Describe("CC Probe MP Mode (mlxreg workaround)", func() {
-		Describe("checkCCProbeMPMode", func() {
-			It("returns true when mlxreg output contains 0x00000001 for all PFs", func() {
-				device.Status.Ports = []v1alpha1.NicDevicePortSpec{
-					{PCI: "0000:00:00.0", RdmaInterface: "mlx5_0"},
-					{PCI: "0000:00:00.1", RdmaInterface: "mlx5_1"},
-				}
-				execFake.cmds = []*fakeCmd{
-					{output: []byte(mlxregGetCCProbeMPSet), err: nil},
-					{output: []byte(mlxregGetCCProbeMPSet), err: nil},
-				}
-				applied, err := manager.checkCCProbeMPMode(device)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(applied).To(BeTrue())
-			})
+	Describe("mlxreg runtime parameters", func() {
+		It("checks an mlxreg parameter on every PF", func() {
+			device.Status.Ports = []v1alpha1.NicDevicePortSpec{
+				{PCI: "0000:00:00.0", RdmaInterface: "mlx5_0"},
+				{PCI: "0000:00:00.1", RdmaInterface: "mlx5_1"},
+			}
+			execFake.cmds = []*fakeCmd{
+				{output: []byte(mlxregGetCCProbeMPSet), err: nil},
+				{output: []byte(mlxregGetCCProbeMPSet), err: nil},
+			}
 
-			It("returns false when any PF has 0x00000000", func() {
-				device.Status.Ports = []v1alpha1.NicDevicePortSpec{
-					{PCI: "0000:00:00.0", RdmaInterface: "mlx5_0"},
-					{PCI: "0000:00:00.1", RdmaInterface: "mlx5_1"},
-				}
-				execFake.cmds = []*fakeCmd{
-					{output: []byte(mlxregGetCCProbeMPSet), err: nil},
-					{output: []byte(mlxregGetCCProbeMPUnset), err: nil},
-				}
-				applied, err := manager.checkCCProbeMPMode(device)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(applied).To(BeFalse())
-			})
-
-			It("returns error when mlxreg command fails", func() {
-				device.Status.Ports = []v1alpha1.NicDevicePortSpec{
-					{PCI: "0000:00:00.0", RdmaInterface: "mlx5_0"},
-				}
-				execFake.cmds = []*fakeCmd{
-					{output: []byte(""), err: errors.New("mlxreg failed")},
-				}
-				_, err := manager.checkCCProbeMPMode(device)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("mlxreg"))
-			})
-
-			It("returns true for empty ports (no PFs to check)", func() {
-				device.Status.Ports = []v1alpha1.NicDevicePortSpec{}
-				applied, err := manager.checkCCProbeMPMode(device)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(applied).To(BeTrue())
-			})
+			applied, err := manager.checkMlxRegParamApplied(device, ccProbeMPModeParam())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(applied).To(BeTrue())
 		})
 
-		Describe("setCCProbeMPMode", func() {
-			It("succeeds when mlxreg set works on all PFs", func() {
-				device.Status.Ports = []v1alpha1.NicDevicePortSpec{
-					{PCI: "0000:00:00.0", RdmaInterface: "mlx5_0"},
-					{PCI: "0000:00:00.1", RdmaInterface: "mlx5_1"},
-				}
-				execFake.cmds = []*fakeCmd{
-					{output: []byte("ok"), err: nil},
-					{output: []byte("ok"), err: nil},
-				}
-				err := manager.setCCProbeMPMode(device)
-				Expect(err).NotTo(HaveOccurred())
-			})
+		It("returns false when an mlxreg value does not match", func() {
+			execFake.cmds = []*fakeCmd{{output: []byte(mlxregGetCCProbeMPUnset), err: nil}}
 
-			It("returns error when mlxreg set fails on a PF", func() {
-				device.Status.Ports = []v1alpha1.NicDevicePortSpec{
-					{PCI: "0000:00:00.0", RdmaInterface: "mlx5_0"},
-					{PCI: "0000:00:00.1", RdmaInterface: "mlx5_1"},
-				}
-				execFake.cmds = []*fakeCmd{
-					{output: []byte("ok"), err: nil},
-					{output: []byte(""), err: errors.New("mlxreg set error")},
-				}
-				err := manager.setCCProbeMPMode(device)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("mlxreg"))
-			})
+			applied, err := manager.checkMlxRegParamApplied(device, ccProbeMPModeParam())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(applied).To(BeFalse())
 		})
 
-		Describe("RuntimeConfigApplied with hwplb CC Probe MP mode", func() {
-			BeforeEach(func() {
-				device.Spec.Configuration.Template.SpectrumXOptimized.MultiplaneMode = consts.MultiplaneModeHwplb
-				device.Spec.Configuration.Template.SpectrumXOptimized.NumberOfPlanes = 2
-				device.Status.Ports = []v1alpha1.NicDevicePortSpec{
-					{PCI: "0000:00:00.0", RdmaInterface: "mlx5_0"},
-				}
-				cfgs["v1"].RuntimeConfig.AdaptiveRouting = []types.ConfigurationParameter{
-					{Name: "ar_before", Value: "y", DMSPath: "/ar/before"},
-					{Name: "ar_force", Value: "y", DMSPath: "/ar/force"},
-				}
-				cfgs["v1"].UseSoftwareCCAlgorithm = false
-			})
+		It("matches the exact mlxreg field name when a suffixed field appears first", func() {
+			output := `Sending access register...
 
-			It("returns true when all params including cc_probe_mp_mode are applied", func() {
-				dmsCli.On("GetParameters", []types.ConfigurationParameter{
-					{Name: "ar_before", Value: "y", DMSPath: "/ar/before"},
-				}).Return(map[string]string{"/ar/before": "y"}, nil)
-				dmsCli.On("GetParameters", []types.ConfigurationParameter{
-					{Name: "ar_force", Value: "y", DMSPath: "/ar/force"},
-				}).Return(map[string]string{"/ar/force": "y"}, nil)
-				dmsCli.On("GetParameters", cfgs["v1"].RuntimeConfig.Roce).Return(map[string]string{"/r": "x"}, nil)
-				dmsCli.On("GetParameters", cfgs["v1"].RuntimeConfig.CongestionControl).Return(map[string]string{"/cc": "z"}, nil)
-				dmsCli.On("GetParameters", cfgs["v1"].RuntimeConfig.InterPacketGap.PureL3).Return(map[string]string{"/ipg": "25"}, nil)
+Field Name                                     | Data
+============================================================
+cc_probe_mp_mode_field_select                  | 0x00000000
+cc_probe_mp_mode                               | 0x00000001
+============================================================`
+			execFake.cmds = []*fakeCmd{{output: []byte(output), err: nil}}
 
-				execFake.cmds = []*fakeCmd{
-					{output: []byte(mlxregGetCCProbeMPSet), err: nil},
-				}
-				applied, err := manager.RuntimeConfigApplied(device)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(applied).To(BeTrue())
-			})
-
-			It("returns false when cc_probe_mp_mode is not set", func() {
-				dmsCli.On("GetParameters", []types.ConfigurationParameter{
-					{Name: "ar_before", Value: "y", DMSPath: "/ar/before"},
-				}).Return(map[string]string{"/ar/before": "y"}, nil)
-				dmsCli.On("GetParameters", cfgs["v1"].RuntimeConfig.Roce).Return(map[string]string{"/r": "x"}, nil)
-
-				execFake.cmds = []*fakeCmd{
-					{output: []byte(mlxregGetCCProbeMPUnset), err: nil},
-				}
-				applied, err := manager.RuntimeConfigApplied(device)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(applied).To(BeFalse())
-			})
-
-			It("returns error when mlxreg check fails", func() {
-				dmsCli.On("GetParameters", []types.ConfigurationParameter{
-					{Name: "ar_before", Value: "y", DMSPath: "/ar/before"},
-				}).Return(map[string]string{"/ar/before": "y"}, nil)
-				dmsCli.On("GetParameters", cfgs["v1"].RuntimeConfig.Roce).Return(map[string]string{"/r": "x"}, nil)
-
-				execFake.cmds = []*fakeCmd{
-					{output: []byte(""), err: errors.New("mlxreg failed")},
-				}
-				_, err := manager.RuntimeConfigApplied(device)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("CC Probe MP mode"))
-			})
-
-			It("returns false when before-last AR params not applied", func() {
-				dmsCli.On("GetParameters", cfgs["v1"].RuntimeConfig.Roce).Return(map[string]string{"/r": "x"}, nil)
-				dmsCli.On("GetParameters", []types.ConfigurationParameter{
-					{Name: "ar_before", Value: "y", DMSPath: "/ar/before"},
-				}).Return(map[string]string{"/ar/before": "wrong"}, nil)
-
-				applied, err := manager.RuntimeConfigApplied(device)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(applied).To(BeFalse())
-			})
-
-			It("returns false when last AR param (AR Force) not applied", func() {
-				dmsCli.On("GetParameters", []types.ConfigurationParameter{
-					{Name: "ar_before", Value: "y", DMSPath: "/ar/before"},
-				}).Return(map[string]string{"/ar/before": "y"}, nil)
-				dmsCli.On("GetParameters", []types.ConfigurationParameter{
-					{Name: "ar_force", Value: "y", DMSPath: "/ar/force"},
-				}).Return(map[string]string{"/ar/force": "wrong"}, nil)
-				dmsCli.On("GetParameters", cfgs["v1"].RuntimeConfig.Roce).Return(map[string]string{"/r": "x"}, nil)
-
-				execFake.cmds = []*fakeCmd{
-					{output: []byte(mlxregGetCCProbeMPSet), err: nil},
-				}
-				applied, err := manager.RuntimeConfigApplied(device)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(applied).To(BeFalse())
-			})
+			applied, err := manager.checkMlxRegParamApplied(device, ccProbeMPModeParam())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(applied).To(BeTrue())
 		})
 
-		Describe("ApplyRuntimeConfig with hwplb CC Probe MP mode", func() {
-			BeforeEach(func() {
-				device.Spec.Configuration.Template.SpectrumXOptimized.MultiplaneMode = consts.MultiplaneModeHwplb
-				device.Spec.Configuration.Template.SpectrumXOptimized.NumberOfPlanes = 2
-				device.Status.Ports = []v1alpha1.NicDevicePortSpec{
-					{PCI: "0000:00:00.0", RdmaInterface: "mlx5_0"},
-				}
-				cfgs["v1"].RuntimeConfig.AdaptiveRouting = []types.ConfigurationParameter{
-					{Name: "ar_before", Value: "y", DMSPath: "/ar/before"},
-					{Name: "ar_force", Value: "y", DMSPath: "/ar/force"},
-				}
-				cfgs["v1"].UseSoftwareCCAlgorithm = false
-			})
+		It("matches equivalent mlxreg numeric values with different hex widths", func() {
+			param := ccProbeMPModeParam()
+			param.Value = "0x1"
+			execFake.cmds = []*fakeCmd{{output: []byte(mlxregGetCCProbeMPSet), err: nil}}
 
-			It("applies all params with mlxreg between AR groups", func() {
-				dmsCli.On("SetParameters", cfgs["v1"].RuntimeConfig.Roce).Return(nil)
-				dmsCli.On("SetParameters", []types.ConfigurationParameter{
-					{Name: "ar_before", Value: "y", DMSPath: "/ar/before"},
-				}).Return(nil)
-				dmsCli.On("SetParameters", []types.ConfigurationParameter{
-					{Name: "ar_force", Value: "y", DMSPath: "/ar/force"},
-				}).Return(nil)
-				dmsCli.On("SetParameters", cfgs["v1"].RuntimeConfig.CongestionControl).Return(nil)
-				dmsCli.On("SetParameters", cfgs["v1"].RuntimeConfig.InterPacketGap.PureL3).Return(nil)
-				dmsCli.On("SetParameters", mock.MatchedBy(func(params []types.ConfigurationParameter) bool {
-					return len(params) == 1 && params[0].Name == shutdownInterfaceParamName
-				})).Return(nil)
-				dmsCli.On("SetParameters", mock.MatchedBy(func(params []types.ConfigurationParameter) bool {
-					return len(params) == 1 && params[0].Name == bringUpInterfaceParamName
-				})).Return(nil)
+			applied, err := manager.checkMlxRegParamApplied(device, param)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(applied).To(BeTrue())
+		})
 
-				execFake.cmds = []*fakeCmd{
-					{output: []byte("ok"), err: nil}, // mlxreg set
-				}
-				_, err := manager.ApplyRuntimeConfig(device)
-				Expect(err).NotTo(HaveOccurred())
-			})
+		It("returns false when the mlxreg field is missing", func() {
+			execFake.cmds = []*fakeCmd{{output: []byte("other_field | 0x00000001"), err: nil}}
 
-			It("returns error when mlxreg set fails", func() {
-				dmsCli.On("SetParameters", cfgs["v1"].RuntimeConfig.Roce).Return(nil)
-				dmsCli.On("SetParameters", []types.ConfigurationParameter{
-					{Name: "ar_before", Value: "y", DMSPath: "/ar/before"},
-				}).Return(nil)
+			applied, err := manager.checkMlxRegParamApplied(device, ccProbeMPModeParam())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(applied).To(BeFalse())
+		})
 
-				execFake.cmds = []*fakeCmd{
-					{output: []byte(""), err: errors.New("mlxreg set error")},
-				}
-				_, err := manager.ApplyRuntimeConfig(device)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("CC Probe MP mode"))
-			})
+		It("returns error when mlxreg get fails", func() {
+			execFake.cmds = []*fakeCmd{{output: []byte("failed"), err: errors.New("mlxreg failed")}}
 
-			It("returns error when before-last AR set fails", func() {
-				dmsCli.On("SetParameters", cfgs["v1"].RuntimeConfig.Roce).Return(nil)
-				dmsCli.On("SetParameters", []types.ConfigurationParameter{
-					{Name: "ar_before", Value: "y", DMSPath: "/ar/before"},
-				}).Return(errors.New("dms set error"))
+			_, err := manager.checkMlxRegParamApplied(device, ccProbeMPModeParam())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("mlxreg"))
+		})
 
-				_, err := manager.ApplyRuntimeConfig(device)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("dms set error"))
-			})
+		It("returns an error when an mlxreg parameter also has a DMS path", func() {
+			param := ccProbeMPModeParam()
+			param.DMSPath = "/interfaces/interface/nvidia/roce/config/cc-probe-mp-mode"
 
-			It("checks cc_probe_mp_mode on multiple PFs", func() {
-				device.Status.Ports = []v1alpha1.NicDevicePortSpec{
-					{PCI: "0000:00:00.0", RdmaInterface: "mlx5_0"},
-					{PCI: "0000:00:00.1", RdmaInterface: "mlx5_1"},
-				}
-				dmsCli.On("GetParameters", []types.ConfigurationParameter{
-					{Name: "ar_before", Value: "y", DMSPath: "/ar/before"},
-				}).Return(map[string]string{"/ar/before": "y"}, nil)
-				dmsCli.On("GetParameters", []types.ConfigurationParameter{
-					{Name: "ar_force", Value: "y", DMSPath: "/ar/force"},
-				}).Return(map[string]string{"/ar/force": "y"}, nil)
-				dmsCli.On("GetParameters", cfgs["v1"].RuntimeConfig.Roce).Return(map[string]string{"/r": "x"}, nil)
-				dmsCli.On("GetParameters", cfgs["v1"].RuntimeConfig.CongestionControl).Return(map[string]string{"/cc": "z"}, nil)
-				dmsCli.On("GetParameters", cfgs["v1"].RuntimeConfig.InterPacketGap.PureL3).Return(map[string]string{"/ipg": "25"}, nil)
+			err := manager.setMlxRegParam(device, param)
+			Expect(err).To(MatchError(ContainSubstring("cannot define both dmsPath and mlxreg")))
+			Expect(execFake.calls).To(BeEmpty())
+		})
 
-				// 2 PFs → 2 mlxreg get commands
-				execFake.cmds = []*fakeCmd{
-					{output: []byte(mlxregGetCCProbeMPSet), err: nil},
-					{output: []byte(mlxregGetCCProbeMPSet), err: nil},
-				}
-				applied, err := manager.RuntimeConfigApplied(device)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(applied).To(BeTrue())
-			})
+		It("returns an error when an mlxreg set field value is empty", func() {
+			param := ccProbeMPModeParam()
+			param.MlxReg.SetFields[0].Value = ""
+
+			err := manager.setMlxRegParam(device, param)
+			Expect(err).To(MatchError(ContainSubstring("without value")))
+			Expect(execFake.calls).To(BeEmpty())
+		})
+
+		It("builds mlxreg set from setFields", func() {
+			execFake.cmds = []*fakeCmd{{output: []byte("ok"), err: nil}}
+
+			err := manager.setMlxRegParam(device, ccProbeMPModeParam())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(execFake.calls).To(HaveLen(1))
+			Expect(execFake.calls[0].name).To(Equal(mlxregBinary))
+			Expect(execFake.calls[0].args).To(Equal([]string{
+				"-d", "0000:00:00.0",
+				"--reg_name", "ROCE_ACCL",
+				"--set", "cc_probe_mp_mode=0x1,cc_probe_mp_mode_field_select=0x1",
+				"--yes",
+			}))
+		})
+
+		It("returns error when mlxreg set fails", func() {
+			execFake.cmds = []*fakeCmd{{output: []byte("failed"), err: errors.New("mlxreg set error")}}
+
+			err := manager.setMlxRegParam(device, ccProbeMPModeParam())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("mlxreg"))
+		})
+
+		It("checks ordered runtime params with DMS batches split by mlxreg barriers", func() {
+			params := []types.ConfigurationParameter{
+				{Name: "dms before 1", Value: "a", DMSPath: "/before/1"},
+				{Name: "dms before 2", Value: "b", DMSPath: "/before/2"},
+				ccProbeMPModeParam(),
+				{Name: "dms after", Value: "c", DMSPath: "/after"},
+			}
+			dmsCli.On("GetParameters", params[:2]).Return(map[string]string{"/before/1": "a", "/before/2": "b"}, nil).Once()
+			dmsCli.On("GetParameters", params[3:]).Return(map[string]string{"/after": "c"}, nil).Once()
+			execFake.cmds = []*fakeCmd{{output: []byte(mlxregGetCCProbeMPSet), err: nil}}
+
+			applied, err := manager.checkRuntimeParamsApplied(device, params, &dmsCli)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(applied).To(BeTrue())
+		})
+
+		It("applies ordered runtime params with DMS batches split by mlxreg barriers", func() {
+			params := []types.ConfigurationParameter{
+				{Name: "dms before 1", Value: "a", DMSPath: "/before/1"},
+				{Name: "dms before 2", Value: "b", DMSPath: "/before/2"},
+				ccProbeMPModeParam(),
+				{Name: "dms after", Value: "c", DMSPath: "/after"},
+			}
+			dmsCli.On("SetParameters", params[:2]).Return(nil).Once()
+			dmsCli.On("SetParameters", params[3:]).Return(nil).Once()
+			execFake.cmds = []*fakeCmd{{output: []byte("ok"), err: nil}}
+
+			err := manager.applyRuntimeParams(device, params, &dmsCli)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(execFake.calls).To(HaveLen(1))
+		})
+
+		It("validates mlxreg parameters before flushing a pending DMS batch", func() {
+			mixedParam := ccProbeMPModeParam()
+			mixedParam.DMSPath = "/mixed"
+			params := []types.ConfigurationParameter{
+				{Name: "dms before", Value: "a", DMSPath: "/before"},
+				mixedParam,
+			}
+
+			err := manager.applyRuntimeParams(device, params, &dmsCli)
+			Expect(err).To(MatchError(ContainSubstring("cannot define both dmsPath and mlxreg")))
+			dmsCli.AssertNotCalled(GinkgoT(), "SetParameters", mock.Anything)
+			Expect(execFake.calls).To(BeEmpty())
+		})
+
+		It("uses profile order for adaptive routing mlxreg parameters", func() {
+			device.Spec.Configuration.Template.SpectrumXOptimized.MultiplaneMode = consts.MultiplaneModeHwplb
+			device.Spec.Configuration.Template.SpectrumXOptimized.NumberOfPlanes = 2
+			cfgs["v1"].RuntimeConfig.AdaptiveRouting = []types.ConfigurationParameter{
+				{Name: "ar before", Value: "a", DMSPath: "/ar/before"},
+				ccProbeMPModeParam(),
+				{Name: "ar after", Value: "b", DMSPath: "/ar/after"},
+			}
+			cfgs["v1"].UseSoftwareCCAlgorithm = false
+
+			dmsCli.On("SetParameters", cfgs["v1"].RuntimeConfig.Roce).Return(nil)
+			dmsCli.On("SetParameters", cfgs["v1"].RuntimeConfig.AdaptiveRouting[:1]).Return(nil).Once()
+			dmsCli.On("SetParameters", cfgs["v1"].RuntimeConfig.AdaptiveRouting[2:]).Return(nil).Once()
+			dmsCli.On("SetParameters", cfgs["v1"].RuntimeConfig.CongestionControl).Return(nil)
+			dmsCli.On("SetParameters", cfgs["v1"].RuntimeConfig.InterPacketGap.PureL3).Return(nil)
+			dmsCli.On("SetParameters", mock.MatchedBy(func(params []types.ConfigurationParameter) bool {
+				return len(params) == 1 && params[0].Name == shutdownInterfaceParamName
+			})).Return(nil)
+			dmsCli.On("SetParameters", mock.MatchedBy(func(params []types.ConfigurationParameter) bool {
+				return len(params) == 1 && params[0].Name == bringUpInterfaceParamName
+			})).Return(nil)
+			execFake.cmds = []*fakeCmd{{output: []byte("ok"), err: nil}}
+
+			_, err := manager.ApplyRuntimeConfig(device)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("checks mlxreg parameters on multiple PFs when they are listed in the profile", func() {
+			device.Spec.Configuration.Template.SpectrumXOptimized.MultiplaneMode = consts.MultiplaneModeHwplb
+			device.Spec.Configuration.Template.SpectrumXOptimized.NumberOfPlanes = 2
+			device.Status.Ports = []v1alpha1.NicDevicePortSpec{
+				{PCI: "0000:00:00.0", RdmaInterface: "mlx5_0"},
+				{PCI: "0000:00:00.1", RdmaInterface: "mlx5_1"},
+			}
+			cfgs["v1"].RuntimeConfig.AdaptiveRouting = []types.ConfigurationParameter{ccProbeMPModeParam()}
+			cfgs["v1"].UseSoftwareCCAlgorithm = false
+
+			dmsCli.On("GetParameters", cfgs["v1"].RuntimeConfig.Roce).Return(map[string]string{"/r": "x"}, nil)
+			dmsCli.On("GetParameters", cfgs["v1"].RuntimeConfig.CongestionControl).Return(map[string]string{"/cc": "z"}, nil)
+			dmsCli.On("GetParameters", cfgs["v1"].RuntimeConfig.InterPacketGap.PureL3).Return(map[string]string{"/ipg": "25"}, nil)
+			execFake.cmds = []*fakeCmd{
+				{output: []byte(mlxregGetCCProbeMPSet), err: nil},
+				{output: []byte(mlxregGetCCProbeMPSet), err: nil},
+			}
+
+			applied, err := manager.RuntimeConfigApplied(device)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(applied).To(BeTrue())
 		})
 	})
 

--- a/pkg/types/spectrumx.go
+++ b/pkg/types/spectrumx.go
@@ -51,17 +51,29 @@ type InterPacketGapConfig struct {
 }
 
 type ConfigurationParameter struct {
-	Name               string `yaml:"name,omitempty"`
-	MlxConfig          string `yaml:"mlxconfig,omitempty"`
-	Value              string `yaml:"value,omitempty"`
-	ValueType          string `yaml:"valueType,omitempty"`
-	DMSPath            string `yaml:"dmsPath,omitempty"`
-	AlternativeValue   string `yaml:"alternativeValue,omitempty"`
-	DeviceId           string `yaml:"deviceId,omitempty"`
-	Breakout           int    `yaml:"breakout,omitempty"`
-	Multiplane         string `yaml:"multiplane,omitempty"`
-	IgnoreError        bool   `yaml:"ignoreError,omitempty"`
-	HwplbFirstPortOnly bool   `yaml:"hwplbFirstPortOnly,omitempty"`
+	Name               string           `yaml:"name,omitempty"`
+	MlxConfig          string           `yaml:"mlxconfig,omitempty"`
+	Value              string           `yaml:"value,omitempty"`
+	ValueType          string           `yaml:"valueType,omitempty"`
+	DMSPath            string           `yaml:"dmsPath,omitempty"`
+	MlxReg             *MlxRegParameter `yaml:"mlxreg,omitempty"`
+	AlternativeValue   string           `yaml:"alternativeValue,omitempty"`
+	DeviceId           string           `yaml:"deviceId,omitempty"`
+	Breakout           int              `yaml:"breakout,omitempty"`
+	Multiplane         string           `yaml:"multiplane,omitempty"`
+	IgnoreError        bool             `yaml:"ignoreError,omitempty"`
+	HwplbFirstPortOnly bool             `yaml:"hwplbFirstPortOnly,omitempty"`
+}
+
+type MlxRegParameter struct {
+	Register  string        `yaml:"register,omitempty"`
+	Field     string        `yaml:"field,omitempty"`
+	SetFields []MlxRegField `yaml:"setFields,omitempty"`
+}
+
+type MlxRegField struct {
+	Name  string `yaml:"name,omitempty"`
+	Value string `yaml:"value,omitempty"`
 }
 
 // ParseSpectrumXConfig unmarshals a SpectrumXConfig from raw YAML bytes.
@@ -72,8 +84,63 @@ func ParseSpectrumXConfig(data []byte) (*SpectrumXConfig, error) {
 	if err := yaml.Unmarshal(data, spectrumXConfig); err != nil {
 		return nil, err
 	}
+	if err := validateSpectrumXConfig(spectrumXConfig); err != nil {
+		return nil, err
+	}
 
 	return spectrumXConfig, nil
+}
+
+func validateSpectrumXConfig(config *SpectrumXConfig) error {
+	if config == nil {
+		return nil
+	}
+	runtimeParams := map[string][]ConfigurationParameter{
+		"roce":                  config.RuntimeConfig.Roce,
+		"adaptiveRouting":       config.RuntimeConfig.AdaptiveRouting,
+		"congestionControl":     config.RuntimeConfig.CongestionControl,
+		"interPacketGap.pureL3": config.RuntimeConfig.InterPacketGap.PureL3,
+		"interPacketGap.l3EVPN": config.RuntimeConfig.InterPacketGap.L3EVPN,
+	}
+	for section, params := range runtimeParams {
+		for i, param := range params {
+			if err := validateRuntimeParameter(section, i, param); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func validateRuntimeParameter(section string, index int, param ConfigurationParameter) error {
+	if param.MlxReg == nil {
+		return nil
+	}
+	paramID := fmt.Sprintf("%s[%d] parameter %q", section, index, param.Name)
+	if param.DMSPath != "" {
+		return fmt.Errorf("%s cannot define both dmsPath and mlxreg", paramID)
+	}
+	if param.Value == "" {
+		return fmt.Errorf("%s is missing value", paramID)
+	}
+	if param.MlxReg.Register == "" {
+		return fmt.Errorf("%s is missing mlxreg register", paramID)
+	}
+	if param.MlxReg.Field == "" {
+		return fmt.Errorf("%s is missing mlxreg field", paramID)
+	}
+	if len(param.MlxReg.SetFields) == 0 {
+		return fmt.Errorf("%s has no mlxreg setFields", paramID)
+	}
+	for i, field := range param.MlxReg.SetFields {
+		if field.Name == "" {
+			return fmt.Errorf("%s has mlxreg setFields[%d] without name", paramID, i)
+		}
+		if field.Value == "" {
+			return fmt.Errorf("%s has mlxreg setFields[%d] without value", paramID, i)
+		}
+	}
+	return nil
 }
 
 func LoadSpectrumXConfig(configPath string) (*SpectrumXConfig, error) {

--- a/pkg/types/spectrumx_test.go
+++ b/pkg/types/spectrumx_test.go
@@ -44,6 +44,16 @@ runtimeConfig:
     - name: ar_enabled
       mlxconfig: ROCE_ADAPTIVE_ROUTING_EN
       value: "1"
+    - name: cc_probe_mp_mode
+      value: "0x00000001"
+      mlxreg:
+        register: ROCE_ACCL
+        field: cc_probe_mp_mode
+        setFields:
+          - name: cc_probe_mp_mode
+            value: "0x1"
+          - name: cc_probe_mp_mode_field_select
+            value: "0x1"
   congestionControl:
     - name: cc_enabled
       mlxconfig: ROCE_CC_PRIO_MASK_P1
@@ -82,6 +92,13 @@ var _ = Describe("LoadSpectrumXConfig", func() {
 		Expect(cfg.DocaCCVersion).To(Equal("1.0"))
 		Expect(cfg.RuntimeConfig.AdaptiveRouting).ToNot(BeEmpty())
 		Expect(cfg.RuntimeConfig.AdaptiveRouting[0].Name).To(Equal("ar_enabled"))
+		Expect(cfg.RuntimeConfig.AdaptiveRouting[1].MlxReg).ToNot(BeNil())
+		Expect(cfg.RuntimeConfig.AdaptiveRouting[1].MlxReg.Register).To(Equal("ROCE_ACCL"))
+		Expect(cfg.RuntimeConfig.AdaptiveRouting[1].MlxReg.Field).To(Equal("cc_probe_mp_mode"))
+		Expect(cfg.RuntimeConfig.AdaptiveRouting[1].MlxReg.SetFields).To(Equal([]MlxRegField{
+			{Name: "cc_probe_mp_mode", Value: "0x1"},
+			{Name: "cc_probe_mp_mode_field_select", Value: "0x1"},
+		}))
 		Expect(cfg.RuntimeConfig.CongestionControl).ToNot(BeEmpty())
 		Expect(cfg.RuntimeConfig.InterPacketGap.PureL3[0].Name).To(Equal("ipg_pureL3"))
 		Expect(cfg.RuntimeConfig.InterPacketGap.L3EVPN[0].Name).To(Equal("ipg_l3evpn"))
@@ -110,5 +127,39 @@ var _ = Describe("ParseSpectrumXConfig", func() {
 	It("returns an error on malformed YAML", func() {
 		_, err := ParseSpectrumXConfig([]byte("mlxConfig: [this is: not valid"))
 		Expect(err).To(HaveOccurred())
+	})
+
+	It("returns an error when a runtime parameter mixes dmsPath and mlxreg", func() {
+		cfg := `
+runtimeConfig:
+  adaptiveRouting:
+    - name: mixed
+      value: "0x1"
+      dmsPath: /interfaces/interface/nvidia/roce/config/cc-per-plane
+      mlxreg:
+        register: ROCE_ACCL
+        field: cc_per_plane_en
+        setFields:
+          - name: cc_per_plane_en
+            value: "0x1"
+`
+		_, err := ParseSpectrumXConfig([]byte(cfg))
+		Expect(err).To(MatchError(ContainSubstring("cannot define both dmsPath and mlxreg")))
+	})
+
+	It("returns an error when an mlxreg set field has no value", func() {
+		cfg := `
+runtimeConfig:
+  adaptiveRouting:
+    - name: missing set value
+      value: "0x1"
+      mlxreg:
+        register: ROCE_ACCL
+        field: cc_per_plane_en
+        setFields:
+          - name: cc_per_plane_en
+`
+		_, err := ParseSpectrumXConfig([]byte(cfg))
+		Expect(err).To(MatchError(ContainSubstring("without value")))
 	})
 })


### PR DESCRIPTION
## Summary
- add optional mlxreg runtime parameters to Spectrum-X profile config
- execute runtime params in profile order, splitting DMS batches around mlxreg barriers
- remove the hardcoded cc_probe_mp_mode adaptive-routing special case

## Validation
- go test ./pkg/types/... -v
- go test ./pkg/spectrumx/... -v
- go build ./...