### PR TITLE
Guard VPD skip reporting behind discovery flag

### DIFF
--- a/internal/controller/devicediscovery_controller.go
+++ b/internal/controller/devicediscovery_controller.go
@@ -120,9 +120,16 @@ func (d *DeviceDiscoveryController) reconcile(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	skippedDevices := map[string]error{}
+	incompleteDevices := map[string]error{}
+	if incompleteDeviceReporter, ok := d.deviceDiscovery.(devicediscovery.IncompleteDeviceReporter); ok {
+		for pciKey, err := range incompleteDeviceReporter.IncompleteDevices() {
+			incompleteDevices[pciKey] = err
+		}
+	}
 	if skippedDeviceReporter, ok := d.deviceDiscovery.(devicediscovery.SkippedDeviceReporter); ok {
-		skippedDevices = skippedDeviceReporter.SkippedDevices()
+		for pciKey, err := range skippedDeviceReporter.SkippedDevices() {
+			incompleteDevices[pciKey] = err
+		}
 	}
 
 	list := &v1alpha1.NicDeviceList{}
@@ -153,8 +160,8 @@ func (d *DeviceDiscoveryController) reconcile(ctx context.Context) error {
 		observedDevice, exists := observedDevices[pciKey]
 
 		if !exists {
-			if skippedErr, skipped := skippedDevices[pciKey]; skipped {
-				log.Log.Info("device discovery was skipped, preserving existing NicDevice CR", "device", nicDeviceCR.Name, "pciKey", pciKey, "error", skippedErr)
+			if incompleteErr, incomplete := incompleteDevices[pciKey]; incomplete {
+				log.Log.Info("device discovery was incomplete, preserving existing NicDevice CR", "device", nicDeviceCR.Name, "pciKey", pciKey, "error", incompleteErr)
 				continue
 			}
 			log.Log.V(2).Info("device doesn't exist on the node anymore, deleting", "device", nicDeviceCR.Name)

--- a/internal/controller/devicediscovery_controller_test.go
+++ b/internal/controller/devicediscovery_controller_test.go
@@ -216,6 +216,29 @@ var _ = Describe("DeviceDiscoveryController", func() {
 				}, timeout).Should(Equal(serialNumber))
 			})
 
+			It("should preserve CRs for devices with incomplete discovery", func() {
+				deviceRegistry.deviceDiscovery = &skippedDeviceDiscovery{
+					devices: map[string]v1alpha1.NicDevice{},
+					incomplete: map[string]error{
+						pciDevKey: errors.New("vpd error"),
+					},
+				}
+
+				startManager(mgr, ctx, &wg)
+
+				Eventually(func() (string, error) {
+					device := &v1alpha1.NicDevice{}
+					err := k8sClient.Get(ctx, client.ObjectKey{
+						Name:      deviceName,
+						Namespace: namespaceName,
+					}, device)
+					if err != nil {
+						return "", err
+					}
+					return device.Status.SerialNumber, nil
+				}, timeout).Should(Equal(serialNumber))
+			})
+
 			It("should create new CRs for new devices", func() {
 				newPciDevKey := "0000:81:00"
 				newSerial := "new-serial-num"
@@ -261,8 +284,9 @@ var _ = Describe("DeviceDiscoveryController", func() {
 })
 
 type skippedDeviceDiscovery struct {
-	devices map[string]v1alpha1.NicDevice
-	skipped map[string]error
+	devices    map[string]v1alpha1.NicDevice
+	skipped    map[string]error
+	incomplete map[string]error
 }
 
 func (d *skippedDeviceDiscovery) DiscoverNicDevices() (map[string]v1alpha1.NicDevice, error) {
@@ -271,4 +295,8 @@ func (d *skippedDeviceDiscovery) DiscoverNicDevices() (map[string]v1alpha1.NicDe
 
 func (d *skippedDeviceDiscovery) SkippedDevices() map[string]error {
 	return d.skipped
+}
+
+func (d *skippedDeviceDiscovery) IncompleteDevices() map[string]error {
+	return d.incomplete
 }

--- a/pkg/devicediscovery/devicediscovery.go
+++ b/pkg/devicediscovery/devicediscovery.go
@@ -40,10 +40,16 @@ type SkippedDeviceReporter interface {
 	SkippedDevices() map[string]error
 }
 
+type IncompleteDeviceReporter interface {
+	// IncompleteDevices returns physical PCI device keys omitted because discovery could not build complete status.
+	IncompleteDevices() map[string]error
+}
+
 type deviceDiscovery struct {
-	utils          DeviceDiscoveryUtils
-	nvConfigUtils  nvconfig.NVConfigUtils
-	skippedDevices map[string]error
+	utils             DeviceDiscoveryUtils
+	nvConfigUtils     nvconfig.NVConfigUtils
+	skippedDevices    map[string]error
+	incompleteDevices map[string]error
 
 	nodeName string
 }
@@ -56,6 +62,7 @@ type deviceDiscovery struct {
 func (d *deviceDiscovery) DiscoverNicDevices() (map[string]v1alpha1.NicDevice, error) {
 	log.Log.Info("ConfigurationManager.DiscoverNicDevices()")
 	d.skippedDevices = map[string]error{}
+	d.incompleteDevices = map[string]error{}
 
 	pciDevices, err := d.utils.GetPCIDevices()
 	if err != nil {
@@ -98,7 +105,11 @@ func (d *deviceDiscovery) DiscoverNicDevices() (map[string]v1alpha1.NicDevice, e
 		vpd, err := d.utils.GetVPD(device.Address)
 		if err != nil {
 			log.Log.Error(err, "Failed to get device's part and serial numbers, skipping", "address", device.Address)
-			d.skipPhysicalDevice(statuses, pciKey, err)
+			// A VPD failure makes the whole physical device incomplete for this pass.
+			d.dropIncompleteDevice(statuses, pciKey, err)
+			if skipDeviceOnDiscoveryError {
+				d.skippedDevices[pciKey] = err
+			}
 			continue
 		}
 
@@ -207,6 +218,11 @@ func (d *deviceDiscovery) DiscoverNicDevices() (map[string]v1alpha1.NicDevice, e
 
 func (d *deviceDiscovery) skipPhysicalDevice(statuses map[string]v1alpha1.NicDeviceStatus, pciKey string, err error) {
 	d.skippedDevices[pciKey] = err
+	d.dropIncompleteDevice(statuses, pciKey, err)
+}
+
+func (d *deviceDiscovery) dropIncompleteDevice(statuses map[string]v1alpha1.NicDeviceStatus, pciKey string, err error) {
+	d.incompleteDevices[pciKey] = err
 	delete(statuses, pciKey)
 }
 
@@ -216,6 +232,14 @@ func (d *deviceDiscovery) SkippedDevices() map[string]error {
 		skippedDevices[pciKey] = err
 	}
 	return skippedDevices
+}
+
+func (d *deviceDiscovery) IncompleteDevices() map[string]error {
+	incompleteDevices := make(map[string]error, len(d.incompleteDevices))
+	for pciKey, err := range d.incompleteDevices {
+		incompleteDevices[pciKey] = err
+	}
+	return incompleteDevices
 }
 
 // pairNetworkBayDevices resolves PeerPCI for ConnectX-9 Network Bay siblings. The two ASICs of a

--- a/pkg/devicediscovery/devicediscovery_test.go
+++ b/pkg/devicediscovery/devicediscovery_test.go
@@ -149,6 +149,22 @@ var _ = Describe("DeviceDiscovery", func() {
 				devices, err := manager.DiscoverNicDevices()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(devices).To(BeEmpty())
+				Expect(manager.SkippedDevices()).To(BeEmpty())
+				Expect(manager.IncompleteDevices()).To(HaveKey("0000:00:00"))
+				mockUtils.AssertExpectations(GinkgoT())
+			})
+
+			It("should report skipped device if GetPartAndSerialNumber fails and SKIP_DEVICE_ON_DISCOVERY_ERROR is true", func() {
+				Expect(os.Setenv(consts.SKIP_DEVICE_ON_DISCOVERY_ERROR, consts.LabelValueTrue)).To(Succeed())
+				mockUtils.On("IsSriovVF", "0000:00:00.0").Return(false)
+				mockUtils.On("GetVPD", "0000:00:00.0").
+					Return(nil, errors.New("serial number error"))
+
+				devices, err := manager.DiscoverNicDevices()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(devices).To(BeEmpty())
+				Expect(manager.SkippedDevices()).To(HaveKey("0000:00:00"))
+				Expect(manager.IncompleteDevices()).To(HaveKey("0000:00:00"))
 				mockUtils.AssertExpectations(GinkgoT())
 			})
 
@@ -569,7 +585,45 @@ var _ = Describe("DeviceDiscovery", func() {
 			mockUtils.AssertExpectations(GinkgoT())
 		})
 
-		It("should skip the whole physical device when discovery fails after one port was added", func() {
+		It("should drop the whole physical device when VPD discovery fails after one port was added", func() {
+			mockUtils.On("GetPCIDevices").Return([]*pci.Device{
+				{
+					Address: "0000:00:00.0",
+					Vendor:  &pcidb.Vendor{ID: consts.MellanoxVendor},
+					Product: &pcidb.Product{ID: "test-id", Name: "Mellanox Device"},
+					Class:   &pcidb.Class{ID: "02"},
+				},
+				{
+					Address: "0000:00:00.1",
+					Vendor:  &pcidb.Vendor{ID: consts.MellanoxVendor},
+					Product: &pcidb.Product{ID: "test-id", Name: "Mellanox Device"},
+					Class:   &pcidb.Class{ID: "02"},
+				},
+			}, nil)
+
+			mockUtils.On("IsSriovVF", "0000:00:00.0").Return(false)
+			mockUtils.On("GetVPD", "0000:00:00.0").
+				Return(&types.VPD{PartNumber: "part-number", SerialNumber: "serial-number", ModelName: ""}, nil)
+			mockUtils.On("GetFirmwareVersionAndPSID", "0000:00:00.0").
+				Return("fw-version", "psid", nil)
+			mockUtils.On("GetInterfaceName", "0000:00:00.0").
+				Return("eth0")
+			mockUtils.On("GetRDMADeviceName", "0000:00:00.0").
+				Return("mlx5_0")
+
+			mockUtils.On("IsSriovVF", "0000:00:00.1").Return(false)
+			mockUtils.On("GetVPD", "0000:00:00.1").
+				Return(nil, errors.New("vpd error"))
+
+			devices, err := manager.DiscoverNicDevices()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(devices).To(BeEmpty())
+			Expect(manager.SkippedDevices()).To(BeEmpty())
+			Expect(manager.IncompleteDevices()).To(HaveKey("0000:00:00"))
+			mockUtils.AssertExpectations(GinkgoT())
+		})
+
+		It("should report the whole physical device as skipped when VPD discovery fails after one port was added and SKIP_DEVICE_ON_DISCOVERY_ERROR is true", func() {
 			Expect(os.Setenv(consts.SKIP_DEVICE_ON_DISCOVERY_ERROR, consts.LabelValueTrue)).To(Succeed())
 			mockUtils.On("GetPCIDevices").Return([]*pci.Device{
 				{
@@ -604,6 +658,7 @@ var _ = Describe("DeviceDiscovery", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(devices).To(BeEmpty())
 			Expect(manager.SkippedDevices()).To(HaveKey("0000:00:00"))
+			Expect(manager.IncompleteDevices()).To(HaveKey("0000:00:00"))
 			mockUtils.AssertExpectations(GinkgoT())
 		})
 	})


### PR DESCRIPTION
## Summary
- keep VPD discovery failures out of `SkippedDevices()` unless `SKIP_DEVICE_ON_DISCOVERY_ERROR=true`
- preserve existing enabled behavior where VPD failures are reported as skipped devices when the flag is set
- add regression coverage for both default and enabled VPD failure behavior

## Testing
- `go test ./pkg/devicediscovery/... -v`
- `go build ./...`
- `git diff --check`

Note: this follows up on the release backport review finding so `main` and the backport keep the same opt-in semantics.
