### PR TITLE
ci: remove netop CI branch trigger

### DIFF
--- a/.github/workflows/netop-ci.yaml
+++ b/.github/workflows/netop-ci.yaml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - network-operator-*
-    branches:
-      - network-operator-*
 
 jobs:
   call-reusable-ci-fork-workflow:


### PR DESCRIPTION
## Summary
- remove the `network-operator-*` branch trigger from the reusable fork-ci workflow on this release branch
- keep `network-operator-*` tag triggers for release builds

## Verification
- YAML parse check for `.github/workflows/netop-ci.*`
- `git diff --check`