### PR TITLE
feat: apply NVConfig through dms-cli

### DIFF
--- a/Dockerfile.nic-configuration-daemon
+++ b/Dockerfile.nic-configuration-daemon
@@ -30,6 +30,8 @@ FROM ${BASE_IMAGE_DOCA_FULL_RT_HOST:-nvcr.io/nvstaging/doca/doca:full-rt-3.5.0-h
 
 ARG TARGETARCH
 
+ENV PATH="/opt/mellanox/doca/services/dms:${PATH}"
+
 ARG PACKAGES="dpkg-dev libusb-1.0-0 ipmitool rshim curl systemd-sysv mstflint"
 
 # enable deb-src repos

--- a/docs/nic-configuration-library.md
+++ b/docs/nic-configuration-library.md
@@ -166,13 +166,13 @@ func NewConfigurationManager(
 1. **Query** current NV config via `nvConfigUtils.QueryNvConfig()`
 2. **Network Bay `set_system_conf` (baseline, applied first)** — for ConnectX-9 Network Bay devices (`template.networkBay` set and `status.networkBay` detected), the per-ASIC `set_system_conf <conf>[<asic>]` is applied **before** the regular / Spectrum-X params so those layer on top of it (override priority: `rawNvConfig` > Spectrum-X > system_conf). Drift is detected per-param via `nvconfig.ValidateSystemConf()`, which returns the overall match bit plus the names of the mismatched params; the manager ignores MISMATCH rows for params owned by a higher-priority layer (matched by exact per-index key — `rawNvConfig` index-range syntax like `MODULE_SPLIT_M0[0..3]` is rejected by CRD validation, so keys are always concrete); a change requires a reboot. Skipped for devices with `ResetToDefault`
 3. **Diff** desired vs current parameters. Params not present in the device's next-boot config are unsupported on this device (e.g. hidden because `ADVANCED_PCI_SETTINGS` is off) and are skipped — the operator does **not** auto-manage `ADVANCED_PCI_SETTINGS`; drive it explicitly via `template.rawNvConfig` if needed
-4. **Batch set** via `nvConfigUtils.SetNvConfigParametersBatch()` — single `mlxconfig set` call (`--force` added when `ConfigurationOptions.Force=true`). Apply reports `ApplyStatusPartiallyApplied` when any desired param was skipped as unsupported
+4. **Batch set** via `nvConfigUtils.SetNvConfigParametersBatch()` — one agentless `dms-cli` `/nvidia/nvconfig/apply` action per PCI target. The action carries the existing raw batch plus `with-default` and `force`; DMS compiles it into one `mlxconfig` invocation. Apply reports `ApplyStatusPartiallyApplied` when any desired param was skipped as unsupported
 5. **Optional reset** — `mlxfwreset` unless `ConfigurationOptions.SkipReset=true`
 
 **`ConfigurationOptions`:**
 - `SkipReset` — skip `mlxfwreset` after applying NV config
-- `WithDefault` — add `--with_default` to `mlxconfig set`
-- `Force` — add `--force` to `mlxconfig set` and `set_system_conf` (lets mlxconfig accept a batch it would otherwise refuse due to implicit parameter dependencies)
+- `WithDefault` — request `--with_default` through the DMS NVConfig apply action
+- `Force` — request `--force` through the DMS NVConfig apply action and add it to `set_system_conf` (lets mlxconfig accept a batch it would otherwise refuse due to implicit parameter dependencies)
 
 #### Runtime Configuration Flow
 
@@ -297,6 +297,64 @@ dmsc -a localhost:9339 --insecure --target 0000:08:00.0 set --timeout 5m \
 
 ---
 
+### pkg/dmscli/ — Agentless DMS CLI API
+
+Source: `pkg/dmscli/nvconfig.go`
+
+`pkg/dmscli` wraps the local, agentless `dms-cli` executable with package-level
+functions; there is no client object or stored runtime state. Its first
+supported action is bulk NVConfig apply. The request already models both raw
+native parameters and typed XPath operations so other projects and future
+doSPCX integration can reuse the same API.
+
+```go
+type NVConfigXPathOperation struct {
+    Path   string
+    Values map[string]any
+}
+
+type NVConfigParam struct {
+    Param string
+    Value any // JSON string, boolean, or number
+}
+
+type ApplyNVConfigRequest struct {
+    Target      string
+    Ports       []int
+    Typed       []NVConfigXPathOperation
+    Raw         []NVConfigParam
+    WithDefault bool
+    Force       bool
+}
+
+func ApplyNVConfig(
+    ctx context.Context,
+    execInterface execUtils.Interface,
+    request ApplyNVConfigRequest,
+) (*ApplyNVConfigResult, error)
+```
+
+The caller supplies the repository-standard `k8s.io/utils/exec.Interface`; this
+reuses the existing command abstraction and supports
+`k8s.io/utils/exec/testing.FakeExec` in tests. Command output is logged at V(2)
+through a `logr.Logger` carried by the context. The command shape is:
+
+```text
+dms-cli --json -t pci/<BDF> --input <payload-json> /nvidia/nvconfig/apply
+```
+
+`dms-cli` must be available on the caller's `PATH`. The daemon image adds the
+standard DOCA installation directory, `/opt/mellanox/doca/services/dms`, to its
+runtime `PATH`.
+
+The payload supports `ports`, `typed`, `raw`, `with-default`, and `force`.
+`Target` is carried by `-t` and is not serialized. The operator currently
+populates only `Raw`, `WithDefault`, and `Force`; `ports` and `typed` are omitted
+until doSPCX planning and typed XPath generation are introduced in a later
+phase.
+
+---
+
 ### pkg/spectrumx/ — Spectrum-X Configuration
 
 Source: `pkg/spectrumx/spectrumx.go`
@@ -362,10 +420,10 @@ type NVConfigUtils interface {
     // SetNvConfigParameter sets a single NV config parameter
     SetNvConfigParameter(port v1alpha1.NicDevicePortSpec, paramName string, paramValue string) error
 
-    // SetNvConfigParametersBatch sets multiple parameters in single mlxconfig call
+    // SetNvConfigParametersBatch sets multiple parameters in one DMS NVConfig action
     // params: map of paramName → paramValue
-    // withDefault: add --with_default flag
-    // force: add --force flag
+    // withDefault: request --with_default from DMS
+    // force: request --force from DMS
     SetNvConfigParametersBatch(port v1alpha1.NicDevicePortSpec, params map[string]string, withDefault bool, force bool) error
 
     // ResetNvConfig resets NIC's NV config to defaults
@@ -389,10 +447,13 @@ func NewNVConfigUtils() NVConfigUtils
 
 **Batch command format:**
 ```
-mlxconfig -d <device> --yes [--with_default] [--force] set PARAM1=VAL1 PARAM2=VAL2 ...
+dms-cli --json -t pci/<BDF> --input <payload-json> /nvidia/nvconfig/apply
 ```
-Parameter names are sorted for deterministic command generation.
-`<device>` is `port.FwctlDevice` when discovered, otherwise `port.PCI`.
+Parameter names are sorted before they are encoded as raw DMS entries. The
+target is always `pci/<port.PCI>`; the discovered `FwctlDevice` value is not
+passed to the NVConfig apply action. Query, single-parameter set, reset, and
+Network Bay system-conf operations continue to invoke `mlxconfig` directly in
+this phase.
 
 **System conf command format (ConnectX-9 Network Bay):**
 ```
@@ -722,7 +783,7 @@ All external commands use `cmd.CombinedOutput()` (not `cmd.Output()`) and log un
 
 ### Batch Operations
 
-- **mlxconfig**: `SetNvConfigParametersBatch()` applies multiple params in single `mlxconfig set` call
+- **NVConfig apply**: `SetNvConfigParametersBatch()` sends one sorted raw batch per PCI target through `dms-cli`; DMS executes the corresponding single `mlxconfig` operation
 - **DMS**: `GetParameters()` batches `--path` entries per concrete interface (with a separate global batch), and `SetParameters()` sends all `--update` entries in a single `dmsc set` command with `--timeout 5m`
 - **IgnoreError**: per-parameter flag; in batch mode, errors are suppressed only if ALL params have `IgnoreError=true`
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/Mellanox/maintenance-operator/api v0.3.0
 	github.com/Mellanox/rdmamap v1.2.0
+	github.com/go-logr/logr v1.4.3
 	github.com/jaypipes/ghw v0.25.0
 	github.com/jaypipes/pcidb v1.1.1
 	github.com/onsi/ginkgo/v2 v2.32.0
@@ -30,7 +31,6 @@ require (
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect

--- a/pkg/configuration/manager.go
+++ b/pkg/configuration/manager.go
@@ -187,6 +187,39 @@ func validateTemplateParamsApplied(nvConfigsForPorts map[string]types.NvConfigQu
 	return configUpdateNeeded, rebootNeeded, unsupportedParams
 }
 
+type nvConfigApplyDiff struct {
+	changed     map[string]string
+	unchanged   []string
+	unsupported []string
+}
+
+func buildNVConfigApplyDiff(nvConfig types.NvConfigQuery, desiredConfig map[string]string, force bool) nvConfigApplyDiff {
+	diff := nvConfigApplyDiff{
+		changed:     make(map[string]string, len(desiredConfig)),
+		unchanged:   []string{},
+		unsupported: []string{},
+	}
+	for param, value := range desiredConfig {
+		if force {
+			diff.changed[param] = value
+			continue
+		}
+		nextValues, found := nvConfig.NextBootConfig[param]
+		if !found {
+			diff.unsupported = append(diff.unsupported, param)
+			continue
+		}
+		if slices.Contains(nextValues, value) {
+			diff.unchanged = append(diff.unchanged, param)
+			continue
+		}
+		diff.changed[param] = value
+	}
+	sort.Strings(diff.unchanged)
+	sort.Strings(diff.unsupported)
+	return diff
+}
+
 // ApplyNVConfiguration calculates device's missing nv spec configuration and applies it to the device on the host
 // returns *ConfigurationApplyResult - result of the apply operation
 // returns error - there were errors while applying nv configuration
@@ -258,29 +291,26 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 	//     breakout before postBreakout without --force).
 	for _, port := range device.Status.Ports {
 		nvConfig := nvConfigsForPorts[port.PCI]
-		batch := map[string]string{}
-		if options.Force {
-			// Copy rather than alias desiredParams: it is reused across PF iterations, and the
-			// SetNvConfigParametersBatch contract does not forbid mutating its params argument.
-			for param, value := range desiredParams {
-				batch[param] = value
-			}
-		} else {
-			for param, value := range desiredParams {
-				nextValues, found := nvConfig.NextBootConfig[param]
-				if !found {
-					hasUnsupportedParams = true
-					continue
-				}
-				if !slices.Contains(nextValues, value) {
-					batch[param] = value
-				}
-			}
-		}
+		diff := buildNVConfigApplyDiff(nvConfig, desiredParams, options.Force)
+		batch := diff.changed
+		hasUnsupportedParams = hasUnsupportedParams || len(diff.unsupported) > 0
+		target := "pci/" + port.PCI
+		log.Log.V(2).Info("nv config apply diff",
+			"device", device.Name,
+			"target", target,
+			"force", options.Force,
+			"comparedToNextBoot", !options.Force,
+			"desiredCount", len(desiredParams),
+			"changedCount", len(batch),
+			"changedParams", batch,
+			"unchangedCount", len(diff.unchanged),
+			"unchangedParams", diff.unchanged,
+			"unsupportedCount", len(diff.unsupported),
+			"unsupportedParams", diff.unsupported)
 		if len(batch) == 0 {
 			continue
 		}
-		log.Log.V(2).Info("applying nv config to device", "device", device.Name, "pci", port.PCI, "fwctlDevice", port.FwctlDevice, "config", batch, "force", options.Force)
+		log.Log.V(2).Info("applying nv config batch", "device", device.Name, "target", target, "params", batch, "force", options.Force)
 		if err := h.nvConfigUtils.SetNvConfigParametersBatch(port, batch, options.WithDefault, options.Force); err != nil {
 			log.Log.Error(err, "Failed to apply nv config parameters", "device", device.Name, "params", batch)
 			return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err

--- a/pkg/configuration/manager_test.go
+++ b/pkg/configuration/manager_test.go
@@ -51,6 +51,34 @@ func mismatchSystemConf(mismatchedParams ...string) []interface{} {
 }
 
 var _ = Describe("ConfigurationManager", func() {
+	Describe("buildNVConfigApplyDiff", func() {
+		It("separates changed, unchanged, and unsupported parameters", func() {
+			diff := buildNVConfigApplyDiff(types.NvConfigQuery{
+				NextBootConfig: map[string][]string{
+					"CHANGED":   {"old"},
+					"UNCHANGED": {"requested"},
+				},
+			}, map[string]string{
+				"CHANGED":     "requested",
+				"UNCHANGED":   "requested",
+				"UNSUPPORTED": "requested",
+			}, false)
+
+			Expect(diff.changed).To(Equal(map[string]string{"CHANGED": "requested"}))
+			Expect(diff.unchanged).To(Equal([]string{"UNCHANGED"}))
+			Expect(diff.unsupported).To(Equal([]string{"UNSUPPORTED"}))
+		})
+
+		It("classifies every desired parameter as changed when force is enabled", func() {
+			desired := map[string]string{"A": "1", "B": "2"}
+			diff := buildNVConfigApplyDiff(types.NewNvConfigQuery(), desired, true)
+
+			Expect(diff.changed).To(Equal(desired))
+			Expect(diff.unchanged).To(BeEmpty())
+			Expect(diff.unsupported).To(BeEmpty())
+		})
+	})
+
 	Describe("configurationManager.ValidateDeviceNvSpec", func() {
 		var (
 			mockHostUtils        mocks.ConfigurationUtils

--- a/pkg/dmscli/nvconfig.go
+++ b/pkg/dmscli/nvconfig.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package dmscli provides operations backed by the agentless dms-cli executable.
+package dmscli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/go-logr/logr"
+	execUtils "k8s.io/utils/exec"
+)
+
+const (
+	dmsCLIExecutable  = "dms-cli"
+	nvConfigApplyPath = "/nvidia/nvconfig/apply"
+)
+
+// NVConfigXPathOperation describes typed NVConfig intent using a DMS XPath and
+// the values to apply below that path.
+type NVConfigXPathOperation struct {
+	Path   string         `json:"path"`
+	Values map[string]any `json:"values"`
+}
+
+// NVConfigParam is one raw native NVConfig assignment.
+type NVConfigParam struct {
+	Param string `json:"param"`
+	Value any    `json:"value"`
+}
+
+// ApplyNVConfigRequest is the payload for /nvidia/nvconfig/apply. Target is
+// supplied through dms-cli's -t flag and is therefore excluded from the JSON
+// payload. Ports provide fanout context for typed mappings containing {port}.
+type ApplyNVConfigRequest struct {
+	Target      string                   `json:"-"`
+	Ports       []int                    `json:"ports,omitempty"`
+	Typed       []NVConfigXPathOperation `json:"typed,omitempty"`
+	Raw         []NVConfigParam          `json:"raw,omitempty"`
+	WithDefault bool                     `json:"with-default"`
+	Force       bool                     `json:"force"`
+}
+
+// ApplyNVConfigResult is the command-level result returned by DMS after the
+// compiled NVConfig batch is executed.
+type ApplyNVConfigResult struct {
+	Status        string   `json:"status"`
+	PrimaryTarget string   `json:"primary-target,omitempty"`
+	CompiledCount int      `json:"compiled-count,omitempty"`
+	RequiresReset bool     `json:"requires-reset,omitempty"`
+	WithDefault   bool     `json:"with-default,omitempty"`
+	Force         bool     `json:"force,omitempty"`
+	Params        []string `json:"params,omitempty"`
+	ErrorMessage  string   `json:"error_msg,omitempty"`
+}
+
+// ApplyNVConfig applies one typed/raw NVConfig batch to a PCI target.
+func ApplyNVConfig(ctx context.Context, execInterface execUtils.Interface, request ApplyNVConfigRequest) (*ApplyNVConfigResult, error) {
+	if execInterface == nil {
+		return nil, fmt.Errorf("command executor must not be nil")
+	}
+	if err := validateApplyNVConfigRequest(request); err != nil {
+		return nil, err
+	}
+
+	payload, err := json.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("marshal NVConfig request for target %q: %w", request.Target, err)
+	}
+
+	args := []string{
+		"--json",
+		"-t", request.Target,
+		"--input", string(payload),
+		nvConfigApplyPath,
+	}
+	command := execInterface.CommandContext(ctx, dmsCLIExecutable, args...)
+	output, commandErr := command.CombinedOutput()
+	commandAndArgs := append([]string{dmsCLIExecutable}, args...)
+	logr.FromContextOrDiscard(ctx).V(2).Info("command output",
+		"command", commandAndArgs,
+		"target", request.Target,
+		"output", string(output))
+
+	result, decodeErr := decodeApplyNVConfigResult(output)
+	if commandErr != nil {
+		detail := strings.TrimSpace(string(output))
+		if result != nil && result.ErrorMessage != "" {
+			detail = result.ErrorMessage
+		}
+		if detail != "" {
+			return result, fmt.Errorf("apply NVConfig to target %q: %w: %s", request.Target, commandErr, detail)
+		}
+		return result, fmt.Errorf("apply NVConfig to target %q: %w", request.Target, commandErr)
+	}
+	if decodeErr != nil {
+		return nil, fmt.Errorf("decode NVConfig apply result for target %q: %w", request.Target, decodeErr)
+	}
+	if result.Status != "ok" {
+		detail := result.ErrorMessage
+		if detail == "" {
+			detail = fmt.Sprintf("unexpected status %q", result.Status)
+		}
+		return result, fmt.Errorf("apply NVConfig to target %q: %s", request.Target, detail)
+	}
+
+	return result, nil
+}
+
+func validateApplyNVConfigRequest(request ApplyNVConfigRequest) error {
+	if strings.TrimSpace(request.Target) == "" {
+		return fmt.Errorf("NVConfig target must not be empty")
+	}
+	if len(request.Typed) == 0 && len(request.Raw) == 0 {
+		return fmt.Errorf("NVConfig request must contain at least one typed or raw operation")
+	}
+	for index, port := range request.Ports {
+		if port < 1 || port > 255 {
+			return fmt.Errorf("NVConfig port at index %d must be between 1 and 255", index)
+		}
+	}
+	for index, operation := range request.Typed {
+		if strings.TrimSpace(operation.Path) == "" {
+			return fmt.Errorf("typed NVConfig operation at index %d must have a path", index)
+		}
+		if operation.Values == nil {
+			return fmt.Errorf("typed NVConfig operation at index %d must have a values object", index)
+		}
+		if len(operation.Values) == 0 {
+			return fmt.Errorf("typed NVConfig operation at index %d must have at least one value", index)
+		}
+	}
+	for index, param := range request.Raw {
+		if strings.TrimSpace(param.Param) == "" {
+			return fmt.Errorf("raw NVConfig parameter at index %d must have a name", index)
+		}
+		if !isJSONScalar(param.Value) {
+			return fmt.Errorf("raw NVConfig parameter %q must have a string, boolean, or numeric value", param.Param)
+		}
+	}
+	return nil
+}
+
+func isJSONScalar(value any) bool {
+	if value == nil {
+		return false
+	}
+	switch reflect.ValueOf(value).Kind() {
+	case reflect.String, reflect.Bool,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
+		reflect.Float32, reflect.Float64:
+		return true
+	default:
+		return false
+	}
+}
+
+func decodeApplyNVConfigResult(output []byte) (*ApplyNVConfigResult, error) {
+	if len(strings.TrimSpace(string(output))) == 0 {
+		return nil, fmt.Errorf("dms-cli returned an empty response")
+	}
+
+	result := &ApplyNVConfigResult{}
+	if err := json.Unmarshal(output, result); err != nil {
+		return nil, fmt.Errorf("invalid dms-cli JSON response: %w", err)
+	}
+	return result, nil
+}

--- a/pkg/dmscli/nvconfig_test.go
+++ b/pkg/dmscli/nvconfig_test.go
@@ -1,0 +1,352 @@
+/*
+Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dmscli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	execUtils "k8s.io/utils/exec"
+	execTesting "k8s.io/utils/exec/testing"
+)
+
+type recordedCommand struct {
+	executable string
+	args       []string
+}
+
+type capturedLogEntry struct {
+	message string
+	fields  map[string]any
+}
+
+type capturingLogSink struct {
+	entries *[]capturedLogEntry
+	values  []any
+	name    string
+}
+
+func (s *capturingLogSink) Init(logr.RuntimeInfo) {}
+
+func (s *capturingLogSink) Enabled(int) bool {
+	return true
+}
+
+func (s *capturingLogSink) Info(_ int, message string, keysAndValues ...any) {
+	allValues := append(append([]any(nil), s.values...), keysAndValues...)
+	fields := make(map[string]any, len(allValues)/2)
+	for index := 0; index+1 < len(allValues); index += 2 {
+		key, ok := allValues[index].(string)
+		if ok {
+			fields[key] = allValues[index+1]
+		}
+	}
+	*s.entries = append(*s.entries, capturedLogEntry{message: s.name + message, fields: fields})
+}
+
+func (s *capturingLogSink) Error(err error, message string, keysAndValues ...any) {
+	s.Info(0, message, append(keysAndValues, "error", err)...)
+}
+
+func (s *capturingLogSink) WithValues(keysAndValues ...any) logr.LogSink {
+	clone := *s
+	clone.values = append(append([]any(nil), s.values...), keysAndValues...)
+	return &clone
+}
+
+func (s *capturingLogSink) WithName(name string) logr.LogSink {
+	clone := *s
+	clone.name = s.name + name + "/"
+	return &clone
+}
+
+func fakeExecutor(output []byte, commandErr error, commands *[]recordedCommand) *execTesting.FakeExec {
+	command := &execTesting.FakeCmd{}
+	command.CombinedOutputScript = append(command.CombinedOutputScript, func() ([]byte, []byte, error) {
+		return output, nil, commandErr
+	})
+
+	executor := &execTesting.FakeExec{}
+	executor.CommandScript = []execTesting.FakeCommandAction{
+		func(executable string, args ...string) execUtils.Cmd {
+			*commands = append(*commands, recordedCommand{
+				executable: executable,
+				args:       append([]string(nil), args...),
+			})
+			return command
+		},
+	}
+	return executor
+}
+
+var _ = Describe("NVConfig apply", func() {
+	const target = "pci/0000:3b:00.0"
+
+	var (
+		commands []recordedCommand
+		executor *execTesting.FakeExec
+	)
+
+	BeforeEach(func() {
+		commands = nil
+		executor = fakeExecutor([]byte(`{
+			"status":"ok",
+			"primary-target":"pci/0000:3b:00.0",
+			"compiled-count":2,
+			"requires-reset":true,
+			"with-default":true,
+			"force":false,
+			"params":["A=1","B=2"]
+		}`), nil, &commands)
+	})
+
+	It("sends raw parameters and flags through the agentless action", func() {
+		result, err := ApplyNVConfig(context.Background(), executor, ApplyNVConfigRequest{
+			Target:      target,
+			Ports:       nil,
+			Typed:       nil,
+			Raw:         []NVConfigParam{{Param: "A", Value: "1"}, {Param: "B", Value: "2"}},
+			WithDefault: true,
+			Force:       false,
+		})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(&ApplyNVConfigResult{
+			Status:        "ok",
+			PrimaryTarget: target,
+			CompiledCount: 2,
+			RequiresReset: true,
+			WithDefault:   true,
+			Force:         false,
+			Params:        []string{"A=1", "B=2"},
+			ErrorMessage:  "",
+		}))
+		Expect(commands).To(HaveLen(1))
+		Expect(commands[0].executable).To(Equal(dmsCLIExecutable))
+		Expect(commands[0].args).To(HaveLen(6))
+		Expect(commands[0].args[0:4]).To(Equal([]string{"--json", "-t", target, "--input"}))
+		Expect(commands[0].args[5]).To(Equal(nvConfigApplyPath))
+
+		var payload map[string]any
+		Expect(json.Unmarshal([]byte(commands[0].args[4]), &payload)).To(Succeed())
+		Expect(payload).To(Equal(map[string]any{
+			"raw": []any{
+				map[string]any{"param": "A", "value": "1"},
+				map[string]any{"param": "B", "value": "2"},
+			},
+			"with-default": true,
+			"force":        false,
+		}))
+	})
+
+	It("logs the exact command argv, target, and combined output", func() {
+		entries := []capturedLogEntry{}
+		ctx := logr.NewContext(context.Background(), logr.New(&capturingLogSink{entries: &entries}))
+
+		_, err := ApplyNVConfig(ctx, executor, ApplyNVConfigRequest{
+			Target:      target,
+			Ports:       nil,
+			Typed:       nil,
+			Raw:         []NVConfigParam{{Param: "A", Value: "1"}},
+			WithDefault: false,
+			Force:       false,
+		})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(entries).To(HaveLen(1))
+		Expect(entries[0].message).To(Equal("command output"))
+		Expect(entries[0].fields).To(HaveKeyWithValue("command", append([]string{dmsCLIExecutable}, commands[0].args...)))
+		Expect(entries[0].fields).To(HaveKeyWithValue("target", target))
+		Expect(entries[0].fields["output"]).To(ContainSubstring(`"compiled-count":2`))
+	})
+
+	It("serializes typed XPath operations, port fanout, arrays, and raw overrides", func() {
+		_, err := ApplyNVConfig(context.Background(), executor, ApplyNVConfigRequest{
+			Target: target,
+			Ports:  []int{1, 2},
+			Typed: []NVConfigXPathOperation{
+				{
+					Path: "/nvidia/cc/config",
+					Values: map[string]any{
+						"user-programmable": true,
+						"profile":           "spcx",
+					},
+				},
+				{
+					Path: "/nvidia/link/breakout/module/[0]/port/[1]",
+					Values: map[string]any{
+						"lanes": []int{0, 1, 2, 3},
+					},
+				},
+			},
+			Raw: []NVConfigParam{
+				{Param: "USER_PROGRAMMABLE_CC", Value: true},
+				{Param: "NUM_OF_PF", Value: 2},
+			},
+			WithDefault: false,
+			Force:       true,
+		})
+
+		Expect(err).NotTo(HaveOccurred())
+		var payload struct {
+			Ports       []int                    `json:"ports"`
+			Typed       []NVConfigXPathOperation `json:"typed"`
+			Raw         []NVConfigParam          `json:"raw"`
+			WithDefault bool                     `json:"with-default"`
+			Force       bool                     `json:"force"`
+		}
+		Expect(json.Unmarshal([]byte(commands[0].args[4]), &payload)).To(Succeed())
+		Expect(payload.Ports).To(Equal([]int{1, 2}))
+		Expect(payload.Typed).To(HaveLen(2))
+		Expect(payload.Typed[0].Path).To(Equal("/nvidia/cc/config"))
+		Expect(payload.Typed[0].Values).To(HaveKeyWithValue("user-programmable", true))
+		Expect(payload.Typed[1].Values).To(HaveKey("lanes"))
+		Expect(payload.Raw).To(Equal([]NVConfigParam{
+			{Param: "USER_PROGRAMMABLE_CC", Value: true},
+			{Param: "NUM_OF_PF", Value: float64(2)},
+		}))
+		Expect(payload.WithDefault).To(BeFalse())
+		Expect(payload.Force).To(BeTrue())
+	})
+
+	It("returns the structured DMS error and preserves the command error", func() {
+		commandErr := errors.New("exit status 7")
+		executor = fakeExecutor([]byte(`{"status":"error","error_msg":"mlxconfig rejected the batch"}`), commandErr, &commands)
+
+		result, err := ApplyNVConfig(context.Background(), executor, ApplyNVConfigRequest{
+			Target:      target,
+			Ports:       nil,
+			Typed:       nil,
+			Raw:         []NVConfigParam{{Param: "A", Value: "1"}},
+			WithDefault: false,
+			Force:       false,
+		})
+
+		Expect(result).To(Equal(&ApplyNVConfigResult{Status: "error", ErrorMessage: "mlxconfig rejected the batch"}))
+		Expect(err).To(MatchError(ContainSubstring("mlxconfig rejected the batch")))
+		Expect(errors.Is(err, commandErr)).To(BeTrue())
+	})
+
+	It("rejects a successful command with an error status", func() {
+		executor = fakeExecutor([]byte(`{"status":"error","error_msg":"invalid payload"}`), nil, &commands)
+
+		result, err := ApplyNVConfig(context.Background(), executor, ApplyNVConfigRequest{
+			Target:      target,
+			Ports:       nil,
+			Typed:       nil,
+			Raw:         []NVConfigParam{{Param: "A", Value: "1"}},
+			WithDefault: false,
+			Force:       false,
+		})
+
+		Expect(result).To(Equal(&ApplyNVConfigResult{Status: "error", ErrorMessage: "invalid payload"}))
+		Expect(err).To(MatchError(ContainSubstring("invalid payload")))
+	})
+
+	It("rejects invalid JSON output", func() {
+		executor = fakeExecutor([]byte("not-json"), nil, &commands)
+
+		_, err := ApplyNVConfig(context.Background(), executor, ApplyNVConfigRequest{
+			Target:      target,
+			Ports:       nil,
+			Typed:       nil,
+			Raw:         []NVConfigParam{{Param: "A", Value: "1"}},
+			WithDefault: false,
+			Force:       false,
+		})
+
+		Expect(err).To(MatchError(ContainSubstring("invalid dms-cli JSON response")))
+	})
+
+	It("validates the target and operation set before execution", func() {
+		_, err := ApplyNVConfig(context.Background(), executor, ApplyNVConfigRequest{
+			Target:      "",
+			Ports:       nil,
+			Typed:       nil,
+			Raw:         []NVConfigParam{{Param: "A", Value: "1"}},
+			WithDefault: false,
+			Force:       false,
+		})
+		Expect(err).To(MatchError("NVConfig target must not be empty"))
+
+		_, err = ApplyNVConfig(context.Background(), executor, ApplyNVConfigRequest{
+			Target:      target,
+			Ports:       nil,
+			Typed:       nil,
+			Raw:         nil,
+			WithDefault: false,
+			Force:       false,
+		})
+		Expect(err).To(MatchError("NVConfig request must contain at least one typed or raw operation"))
+		Expect(commands).To(BeEmpty())
+	})
+
+	It("validates typed, raw, and port payload fields before execution", func() {
+		invalidRequests := []struct {
+			request ApplyNVConfigRequest
+			message string
+		}{
+			{
+				request: ApplyNVConfigRequest{Target: target, Ports: []int{0}, Typed: nil, Raw: []NVConfigParam{{Param: "A", Value: "1"}}},
+				message: "NVConfig port at index 0 must be between 1 and 255",
+			},
+			{
+				request: ApplyNVConfigRequest{Target: target, Ports: nil, Typed: []NVConfigXPathOperation{{Path: "", Values: map[string]any{}}}, Raw: nil},
+				message: "typed NVConfig operation at index 0 must have a path",
+			},
+			{
+				request: ApplyNVConfigRequest{Target: target, Ports: nil, Typed: []NVConfigXPathOperation{{Path: "/nvidia/pci", Values: nil}}, Raw: nil},
+				message: "typed NVConfig operation at index 0 must have a values object",
+			},
+			{
+				request: ApplyNVConfigRequest{Target: target, Ports: nil, Typed: []NVConfigXPathOperation{{Path: "/nvidia/pci", Values: map[string]any{}}}, Raw: nil},
+				message: "typed NVConfig operation at index 0 must have at least one value",
+			},
+			{
+				request: ApplyNVConfigRequest{Target: target, Ports: nil, Typed: nil, Raw: []NVConfigParam{{Param: "", Value: "1"}}},
+				message: "raw NVConfig parameter at index 0 must have a name",
+			},
+			{
+				request: ApplyNVConfigRequest{Target: target, Ports: nil, Typed: nil, Raw: []NVConfigParam{{Param: "A", Value: []int{1}}}},
+				message: "raw NVConfig parameter \"A\" must have a string, boolean, or numeric value",
+			},
+		}
+
+		for _, test := range invalidRequests {
+			_, err := ApplyNVConfig(context.Background(), executor, test.request)
+			Expect(err).To(MatchError(test.message))
+		}
+		Expect(commands).To(BeEmpty())
+	})
+
+	It("rejects a nil command executor without panicking", func() {
+		request := ApplyNVConfigRequest{
+			Target:      target,
+			Ports:       nil,
+			Typed:       nil,
+			Raw:         []NVConfigParam{{Param: "A", Value: "1"}},
+			WithDefault: false,
+			Force:       false,
+		}
+
+		_, err := ApplyNVConfig(context.Background(), nil, request)
+		Expect(err).To(MatchError("command executor must not be nil"))
+	})
+})

--- a/pkg/dmscli/suite_test.go
+++ b/pkg/dmscli/suite_test.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dmscli
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDMSCLI(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "DMS CLI Suite")
+}

--- a/pkg/nvconfig/utils.go
+++ b/pkg/nvconfig/utils.go
@@ -23,10 +23,12 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/go-logr/logr"
 	execUtils "k8s.io/utils/exec"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/Mellanox/nic-configuration-operator/api/v1alpha1"
+	"github.com/Mellanox/nic-configuration-operator/pkg/dmscli"
 	"github.com/Mellanox/nic-configuration-operator/pkg/types"
 	"github.com/Mellanox/nic-configuration-operator/pkg/utils"
 )
@@ -54,9 +56,8 @@ type NVConfigUtils interface {
 	QueryNvConfig(ctx context.Context, port v1alpha1.NicDevicePortSpec, parameters []string) (types.NvConfigQuery, error)
 	// SetNvConfigParameter sets a nv config parameter for a mellanox device
 	SetNvConfigParameter(port v1alpha1.NicDevicePortSpec, paramName string, paramValue string) error
-	// SetNvConfigParametersBatch sets multiple nv config parameters for a mellanox device in a single mlxconfig call
-	// When force is true, --force is passed to mlxconfig so it accepts a batch it would otherwise refuse
-	// due to implicit parameter dependencies.
+	// SetNvConfigParametersBatch sets multiple NVConfig parameters in one DMS NVConfig action.
+	// withDefault and force are forwarded to DMS, which applies them to the compiled mlxconfig batch.
 	SetNvConfigParametersBatch(port v1alpha1.NicDevicePortSpec, params map[string]string, withDefault bool, force bool) error
 	// ResetNvConfig resets NIC's nv config
 	ResetNvConfig(port v1alpha1.NicDevicePortSpec) error
@@ -208,43 +209,49 @@ func (h *nvConfigUtils) SetNvConfigParameter(port v1alpha1.NicDevicePortSpec, pa
 	return nil
 }
 
-// SetNvConfigParametersBatch sets multiple nv config parameters for a mellanox device in a single mlxconfig call
+// SetNvConfigParametersBatch sets multiple nv config parameters for a Mellanox device in one DMS NVConfig action.
 func (h *nvConfigUtils) SetNvConfigParametersBatch(port v1alpha1.NicDevicePortSpec, params map[string]string, withDefault bool, force bool) error {
-	targetDevice := resolveDevice(port)
-	log.Log.Info("ConfigurationUtils.SetNvConfigParametersBatch()", "pciAddr", port.PCI, "targetDevice", targetDevice, "params", params, "withDefault", withDefault, "force", force)
-
 	if len(params) == 0 {
 		return nil
 	}
+	if h.execInterface == nil {
+		return fmt.Errorf("command executor must not be nil")
+	}
 
-	// Build sorted param list for deterministic command
+	target := "pci/" + port.PCI
+	log.Log.Info("ConfigurationUtils.SetNvConfigParametersBatch()", "pciAddr", port.PCI, "target", target, "params", params, "withDefault", withDefault, "force", force)
+
+	// Build a sorted raw list to preserve deterministic batch construction.
 	paramNames := make([]string, 0, len(params))
 	for name := range params {
 		paramNames = append(paramNames, name)
 	}
 	sort.Strings(paramNames)
 
-	paramArgs := make([]string, 0, len(params))
+	raw := make([]dmscli.NVConfigParam, 0, len(params))
 	for _, name := range paramNames {
-		paramArgs = append(paramArgs, name+"="+params[name])
+		raw = append(raw, dmscli.NVConfigParam{Param: name, Value: params[name]})
 	}
 
-	args := []string{"-d", targetDevice, "--yes"}
-	if withDefault {
-		args = append(args, "--with_default")
-	}
-	if force {
-		args = append(args, "--force")
-	}
-	args = append(args, "set")
-	args = append(args, paramArgs...)
-
-	cmd := h.execInterface.Command("mlxconfig", args...)
-	output, err := utils.RunCommand(cmd)
+	ctx := logr.NewContext(context.Background(), log.Log)
+	result, err := dmscli.ApplyNVConfig(ctx, h.execInterface, dmscli.ApplyNVConfigRequest{
+		Target:      target,
+		Raw:         raw,
+		WithDefault: withDefault,
+		Force:       force,
+	})
 	if err != nil {
-		log.Log.Error(err, "SetNvConfigParametersBatch(): Failed to run mlxconfig", "output", string(output))
+		log.Log.Error(err, "SetNvConfigParametersBatch(): DMS NVConfig apply failed", "target", target)
 		return err
 	}
+	log.Log.V(2).Info("DMS NVConfig apply succeeded",
+		"target", target,
+		"primaryTarget", result.PrimaryTarget,
+		"compiledCount", result.CompiledCount,
+		"requiresReset", result.RequiresReset,
+		"withDefault", result.WithDefault,
+		"force", result.Force,
+		"params", result.Params)
 	return nil
 }
 

--- a/pkg/nvconfig/utils_test.go
+++ b/pkg/nvconfig/utils_test.go
@@ -17,11 +17,14 @@ package nvconfig
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
 
 	"github.com/Mellanox/nic-configuration-operator/api/v1alpha1"
 	"github.com/Mellanox/nic-configuration-operator/pkg/consts"
+	"github.com/Mellanox/nic-configuration-operator/pkg/dmscli"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/exec"
@@ -127,9 +130,7 @@ Configurations:                              Default         Current         Nex
 				},
 			}
 
-			h = &nvConfigUtils{
-				execInterface: fakeExec,
-			}
+			h = &nvConfigUtils{execInterface: fakeExec}
 		})
 
 		It("should parse mlxconfig output correctly", func() {
@@ -603,58 +604,106 @@ Result: Device configuration does NOT match the system configuration.
 
 	Describe("SetNvConfigParametersBatch", func() {
 		var (
-			h          *nvConfigUtils
-			fakeExec   *execTesting.FakeExec
-			pciAddress = "0000:3b:00.0"
+			h             *nvConfigUtils
+			fakeExec      *execTesting.FakeExec
+			commandName   string
+			commandArgs   []string
+			commandOutput []byte
+			commandErr    error
+			pciAddress    = "0000:3b:00.0"
 		)
 
 		BeforeEach(func() {
+			commandName = ""
+			commandArgs = nil
+			commandOutput = []byte(`{"status":"ok"}`)
+			commandErr = nil
+
+			cmd := &execTesting.FakeCmd{}
+			cmd.CombinedOutputScript = append(cmd.CombinedOutputScript, func() ([]byte, []byte, error) {
+				return commandOutput, nil, commandErr
+			})
 			fakeExec = &execTesting.FakeExec{}
+			fakeExec.CommandScript = []execTesting.FakeCommandAction{
+				func(name string, args ...string) exec.Cmd {
+					commandName = name
+					commandArgs = append([]string(nil), args...)
+					return cmd
+				},
+			}
 			h = &nvConfigUtils{execInterface: fakeExec}
 		})
 
-		It("appends --force when force is true", func() {
-			cmd := &execTesting.FakeCmd{}
-			cmd.OutputScript = append(cmd.OutputScript, func() ([]byte, []byte, error) {
-				return []byte("ok"), nil, nil
-			})
-			fakeExec.CommandScript = []execTesting.FakeCommandAction{
-				func(name string, args ...string) exec.Cmd {
-					Expect(name).To(Equal("mlxconfig"))
-					Expect(args).To(Equal([]string{"-d", pciAddress, "--yes", "--force", "set", "PARAM=1"}))
-					return cmd
-				},
+		It("sends a sorted raw batch and forwards with-default and force", func() {
+			Expect(h.SetNvConfigParametersBatch(nvconfigPort(pciAddress), map[string]string{
+				"Z_PARAM": "2",
+				"A_PARAM": "1",
+			}, true, true)).To(Succeed())
+
+			Expect(commandName).To(Equal("dms-cli"))
+			Expect(commandArgs[0:4]).To(Equal([]string{"--json", "-t", "pci/" + pciAddress, "--input"}))
+			Expect(commandArgs[5]).To(Equal("/nvidia/nvconfig/apply"))
+
+			var payload struct {
+				Raw         []dmscli.NVConfigParam `json:"raw"`
+				WithDefault bool                   `json:"with-default"`
+				Force       bool                   `json:"force"`
 			}
-			Expect(h.SetNvConfigParametersBatch(nvconfigPort(pciAddress), map[string]string{"PARAM": "1"}, false, true)).To(Succeed())
+			Expect(json.Unmarshal([]byte(commandArgs[4]), &payload)).To(Succeed())
+			Expect(payload).To(Equal(struct {
+				Raw         []dmscli.NVConfigParam `json:"raw"`
+				WithDefault bool                   `json:"with-default"`
+				Force       bool                   `json:"force"`
+			}{
+				Raw: []dmscli.NVConfigParam{
+					{Param: "A_PARAM", Value: "1"},
+					{Param: "Z_PARAM", Value: "2"},
+				},
+				WithDefault: true,
+				Force:       true,
+			}))
+
+			var rawPayload map[string]any
+			Expect(json.Unmarshal([]byte(commandArgs[4]), &rawPayload)).To(Succeed())
+			Expect(rawPayload).NotTo(HaveKey("ports"))
+			Expect(rawPayload).NotTo(HaveKey("typed"))
 		})
 
-		It("omits --force when force is false", func() {
-			cmd := &execTesting.FakeCmd{}
-			cmd.OutputScript = append(cmd.OutputScript, func() ([]byte, []byte, error) {
-				return []byte("ok"), nil, nil
-			})
-			fakeExec.CommandScript = []execTesting.FakeCommandAction{
-				func(name string, args ...string) exec.Cmd {
-					Expect(args).To(Equal([]string{"-d", pciAddress, "--yes", "set", "PARAM=1"}))
-					return cmd
-				},
-			}
+		It("forwards false flag values explicitly", func() {
 			Expect(h.SetNvConfigParametersBatch(nvconfigPort(pciAddress), map[string]string{"PARAM": "1"}, false, false)).To(Succeed())
+
+			var payload map[string]any
+			Expect(json.Unmarshal([]byte(commandArgs[4]), &payload)).To(Succeed())
+			Expect(payload).To(HaveKeyWithValue("with-default", false))
+			Expect(payload).To(HaveKeyWithValue("force", false))
 		})
 
-		It("uses fwctl device when present", func() {
-			cmd := &execTesting.FakeCmd{}
-			cmd.OutputScript = append(cmd.OutputScript, func() ([]byte, []byte, error) {
-				return []byte("ok"), nil, nil
-			})
-			fakeExec.CommandScript = []execTesting.FakeCommandAction{
-				func(name string, args ...string) exec.Cmd {
-					Expect(args).To(Equal([]string{"-d", "/dev/fwctl/fwctl3", "--yes", "set", "PARAM=1"}))
-					return cmd
-				},
-			}
+		It("passes the PCI target and does not use fwctl metadata", func() {
 			port := v1alpha1.NicDevicePortSpec{PCI: pciAddress, FwctlDevice: "/dev/fwctl/fwctl3"}
 			Expect(h.SetNvConfigParametersBatch(port, map[string]string{"PARAM": "1"}, false, false)).To(Succeed())
+
+			Expect(commandArgs[0:3]).To(Equal([]string{"--json", "-t", "pci/" + pciAddress}))
+		})
+
+		It("does not invoke DMS for an empty batch", func() {
+			Expect(h.SetNvConfigParametersBatch(nvconfigPort(pciAddress), map[string]string{}, true, true)).To(Succeed())
+			Expect(fakeExec.CommandCalls).To(BeZero())
+		})
+
+		It("propagates DMS apply failures", func() {
+			applyErr := errors.New("exit status 1")
+			commandOutput = []byte(`{"status":"error","error_msg":"DMS apply failed"}`)
+			commandErr = applyErr
+
+			err := h.SetNvConfigParametersBatch(nvconfigPort(pciAddress), map[string]string{"PARAM": "1"}, false, false)
+			Expect(err).To(MatchError(ContainSubstring("DMS apply failed")))
+			Expect(errors.Is(err, applyErr)).To(BeTrue())
+		})
+
+		It("returns an error when the command executor is not initialized", func() {
+			h.execInterface = nil
+
+			Expect(h.SetNvConfigParametersBatch(nvconfigPort(pciAddress), map[string]string{"PARAM": "1"}, false, false)).To(MatchError("command executor must not be nil"))
 		})
 	})
 })


### PR DESCRIPTION
## Summary

- add a package-level `pkg/dmscli` API for the agentless `/nvidia/nvconfig/apply` action, with no client lifecycle or stored runtime state
- reuse the repository-standard `k8s.io/utils/exec.Interface` for context-aware command execution and `FakeExec` testing
- model raw scalar values, typed XPath operations, port fanout, `with-default`, and `force` in the reusable request type
- route the existing `SetNvConfigParametersBatch` seam through `dms-cli` while preserving configuration calculation, per-PF batching, status, and reboot behavior
- omit `ports` and `typed` from the current raw-only action payload
- add `/opt/mellanox/doca/services/dms` to the daemon runtime `PATH`, matching the standard `doca-dms` package layout while keeping the Go package runtime-agnostic
- log the exact `dms-cli` argv and combined stdout/stderr, per-target changed/unchanged/unsupported diff, and structured DMS apply result
- use only the canonical `pci/<BDF>` action target; `FwctlDevice` metadata is neither passed nor reported as the apply target
- keep NVConfig query/reset/system-conf, runtime configuration, Spectrum-X planning, and the existing `dmsc`/`dmsd` paths unchanged in this phase

The public `NVConfigUtils` signature is unchanged, so this is backward compatible for downstream Go consumers.

## Command shape

```text
dms-cli --json -t pci/<BDF> --input <payload-json> /nvidia/nvconfig/apply
```

The command log contains the executable and complete argv as a structured array, including the exact JSON payload, followed by the combined command output. The configuration manager logs why each desired parameter was applied, skipped as already staged, or skipped as unsupported.

## Compatibility

This path requires a `doca-dms` build containing DMS source commit `39e47e6209` (`/nvidia/nvconfig/apply`), first present on the 3.5 line in build `3.5.0069-1`. There is intentionally no direct-`mlxconfig` fallback for this batch apply operation.

## Verification

- `go test ./pkg/dmscli/... ./pkg/nvconfig/... ./pkg/configuration/... -v -timeout 10m`
- `KUBEBUILDER_ASSETS=<absolute 1.31.0 assets path> go test $(go list ./... | rg -v /e2e) -timeout 15m`
- `go build ./...`
- `go vet ./...`
- `make lint`
- `git diff --check upstream/main`

All passed locally. The cluster-dependent e2e suite remains outside the repository unit-test target and was not run without a configured cluster.
