### PR TITLE
feat: add node-scoped configuration batches

### DIFF
--- a/docs/nic-configuration-library.md
+++ b/docs/nic-configuration-library.md
@@ -35,11 +35,22 @@ rebootRequired, err := fwMgr.InstallFirmware(ctx, device, &types.FirmwareInstall
     FwFilePath: "/path/to/fw.bin",
 })
 
-// 3. Apply NV configuration
+// 3. Apply NV configuration to the complete node device set
 nvUtils := nvconfig.NewNVConfigUtils()
 spectrumXMgr := spectrumx.NewSpectrumXConfigManager(dmsSrv, configs)
 cfgMgr := configuration.NewConfigurationManager(nil, dmsSrv, nvUtils, spectrumXMgr)
-result, err := cfgMgr.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
+requests := make([]types.NVConfigurationRequest, 0, len(devices))
+for i := range devices {
+    requests = append(requests, types.NVConfigurationRequest{
+        Device:  &devices[i],
+        Options: &types.ConfigurationOptions{},
+    })
+}
+results, err := cfgMgr.ApplyNVConfigurations(ctx, nodeName, requests)
+for _, deviceResult := range results {
+    // deviceResult is present even when this device failed. Callers can report
+    // status independently for every device before handling the aggregate err.
+}
 ```
 
 ### With external DMS server (library mode)
@@ -137,19 +148,35 @@ Source: `pkg/configuration/manager.go`
 ```go
 type ConfigurationManager interface {
     // ValidateDeviceNvSpec validates device's NV spec against host configuration
-    // returns: nv config update required, reboot required, error
-    ValidateDeviceNvSpec(ctx context.Context, device *v1alpha1.NicDevice) (bool, bool, error)
+    // returns: nv config update required, reboot required, unsupported params, error
+    ValidateDeviceNvSpec(ctx context.Context, device *v1alpha1.NicDevice) (bool, bool, []string, error)
 
     // ApplyNVConfiguration calculates and applies missing NV spec configuration
     ApplyNVConfiguration(ctx context.Context, device *v1alpha1.NicDevice, options *types.ConfigurationOptions) (*types.ConfigurationApplyResult, error)
 
+    // ApplyNVConfigurations applies NV configuration concurrently to a node device set
+    ApplyNVConfigurations(ctx context.Context, nodeName string, requests []types.NVConfigurationRequest) ([]types.DeviceNVConfigurationResult, error)
+
     // ApplyRuntimeConfiguration calculates and applies missing runtime spec configuration
     ApplyRuntimeConfiguration(ctx context.Context, device *v1alpha1.NicDevice) (*types.RuntimeConfigurationApplyResult, error)
+
+    // ApplyRuntimeConfigurations applies runtime configuration concurrently to a node device set
+    ApplyRuntimeConfigurations(ctx context.Context, nodeName string, requests []types.RuntimeConfigurationRequest) ([]types.DeviceRuntimeConfigurationResult, error)
 
     // ResetNicFirmware resets NIC's firmware via mlxfwreset
     ResetNicFirmware(ctx context.Context, device *v1alpha1.NicDevice) error
 }
 ```
+
+The plural APIs preserve input order and return one result for every input device, including
+failed and skipped devices. Their returned error joins all per-device errors; callers should
+process the result slice first so successful and failed devices can be reported independently.
+Every node device should be included in the request. Set `Skip` when a device belongs to the
+node-scoped inventory but should not run the legacy per-device operation in this pass; its result
+will have `Skipped=true`. This keeps the complete topology available to node-scoped integrations.
+The singular APIs remain available for compatibility and are also the per-device implementation
+used by the plural methods. `nodeName` identifies the node-scoped configuration operation and is
+reserved for integrations that require the complete node topology.
 
 **Constructor:**
 ```go

--- a/internal/controller/nicdevice_controller.go
+++ b/internal/controller/nicdevice_controller.go
@@ -88,6 +88,7 @@ type nicDeviceConfigurationStatus struct {
 	requestedFirmwareVersion     string
 	nvConfigUpdateRequired       bool
 	rebootRequired               bool
+	runtimeConfigReady           bool
 	// unsupportedNvParams lists desired nv params that are hidden on this device (absent from
 	// NextBootConfig). Surfaces as PartiallyApplied in the ConfigUpdateInProgress condition.
 	unsupportedNvParams []string
@@ -216,7 +217,7 @@ func (r *NicDeviceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 		log.Log.Info("maintenance allowed, applying nv config")
 
-		err = runInParallel(ctx, configStatuses, r.applyNvConfig)
+		err = r.applyNvConfigs(ctx, configStatuses)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -232,7 +233,7 @@ func (r *NicDeviceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	log.Log.Info("applying runtime config")
-	err = runInParallel(ctx, configStatuses, r.applyRuntimeConfig)
+	err = r.applyRuntimeConfigs(ctx, configStatuses)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -493,12 +494,68 @@ func runInParallel(ctx context.Context, statuses nicDeviceConfigurationStatuses,
 	return nil
 }
 
-// applyRuntimeConfig applies device's runtime spec
-// if update is successful, applies status condition UpdateSuccessful, otherwise RuntimeConfigUpdateFailed
-// if rebootRequired, sets status condition PendingReboot
-// if status.rebootRequired == true, skips the device
-// returns nil if device's config update was successful, error otherwise
-func (r *NicDeviceReconciler) applyRuntimeConfig(ctx context.Context, status *nicDeviceConfigurationStatus) error {
+// applyRuntimeConfigs prepares all eligible devices, applies their runtime configuration as one
+// node-scoped batch, and then reports each result on the corresponding NicDevice.
+func (r *NicDeviceReconciler) applyRuntimeConfigs(ctx context.Context, statuses nicDeviceConfigurationStatuses) error {
+	preparationErr := runInParallel(ctx, statuses, r.prepareRuntimeConfig)
+
+	requests := make([]types.RuntimeConfigurationRequest, 0, len(statuses))
+	statusByDevice := make(map[*v1alpha1.NicDevice]*nicDeviceConfigurationStatus, len(statuses))
+	for _, status := range statuses {
+		requests = append(requests, types.RuntimeConfigurationRequest{
+			Device: status.device,
+			Skip:   !status.runtimeConfigReady,
+		})
+		statusByDevice[status.device] = status
+	}
+
+	results, batchErr := r.ConfigurationManager.ApplyRuntimeConfigurations(ctx, r.NodeName, requests)
+	observedErrors := []error{preparationErr, batchErr}
+	handledDevices := make(map[*v1alpha1.NicDevice]struct{}, len(results))
+	handlerErrors := make([]error, len(results))
+	var waitGroup sync.WaitGroup
+	for index, deviceResult := range results {
+		status, found := statusByDevice[deviceResult.Device]
+		if !found {
+			observedErrors = append(observedErrors, fmt.Errorf("runtime configuration returned a result for an unknown device"))
+			continue
+		}
+		if _, duplicate := handledDevices[deviceResult.Device]; duplicate {
+			observedErrors = append(observedErrors, fmt.Errorf("runtime configuration returned duplicate results for device %q", deviceResult.Device.Name))
+			continue
+		}
+		handledDevices[deviceResult.Device] = struct{}{}
+		if deviceResult.Skipped {
+			continue
+		}
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			handlerErrors[index] = r.handleRuntimeConfigResult(ctx, status, deviceResult.Result, deviceResult.Err)
+		}()
+	}
+	waitGroup.Wait()
+	observedErrors = append(observedErrors, handlerErrors...)
+
+	for _, request := range requests {
+		if _, found := handledDevices[request.Device]; found {
+			continue
+		}
+		err := fmt.Errorf("runtime configuration did not return a result for device %q", request.Device.Name)
+		if request.Skip {
+			observedErrors = append(observedErrors, err)
+			continue
+		}
+		observedErrors = append(observedErrors, r.handleRuntimeConfigResult(ctx, statusByDevice[request.Device], nil, err))
+	}
+
+	return errors.Join(observedErrors...)
+}
+
+// prepareRuntimeConfig runs the controller-owned prerequisites for one device. The actual runtime
+// configuration is performed later by ConfigurationManager as part of the complete node batch.
+func (r *NicDeviceReconciler) prepareRuntimeConfig(ctx context.Context, status *nicDeviceConfigurationStatus) error {
+	status.runtimeConfigReady = false
 	if status.device.Spec.Configuration == nil || status.rebootRequired {
 		return nil
 	}
@@ -529,28 +586,32 @@ func (r *NicDeviceReconciler) applyRuntimeConfig(ctx context.Context, status *ni
 
 	targetVersion, err := r.SpectrumXManager.GetDocaCCTargetVersion(status.device)
 	if err != nil {
-		return err
+		return r.reportRuntimeConfigError(ctx, status.device, err)
 	}
 
 	if targetVersion != "" {
 		err = r.FirmwareManager.InstallDocaSpcXCC(ctx, status.device, targetVersion)
 		if err != nil {
-			return err
+			return r.reportRuntimeConfigError(ctx, status.device, err)
 		}
 	}
+	status.runtimeConfigReady = true
+	return nil
+}
 
-	_, err = r.ConfigurationManager.ApplyRuntimeConfiguration(ctx, status.device)
-	if err != nil {
-		updateErr := r.updateConfigInProgressStatusCondition(ctx, status.device, consts.RuntimeConfigUpdateFailedReason, metav1.ConditionFalse, err.Error())
-		if updateErr != nil {
-			log.Log.Error(err, "failed to update device status condition", "device", status.device.Name)
-		}
-		return err
+func (r *NicDeviceReconciler) handleRuntimeConfigResult(
+	ctx context.Context,
+	status *nicDeviceConfigurationStatus,
+	_ *types.RuntimeConfigurationApplyResult,
+	applyErr error,
+) error {
+	if applyErr != nil {
+		return r.reportRuntimeConfigError(ctx, status.device, applyErr)
 	}
 
 	specJson, err := json.Marshal(status.device.Spec)
 	if err != nil {
-		return err
+		return r.reportRuntimeConfigError(ctx, status.device, err)
 	}
 
 	if status.device.Annotations == nil {
@@ -559,7 +620,7 @@ func (r *NicDeviceReconciler) applyRuntimeConfig(ctx context.Context, status *ni
 	status.device.Annotations[consts.LastAppliedStateAnnotation] = string(specJson)
 	err = r.Update(ctx, status.device)
 	if err != nil {
-		return err
+		return r.reportRuntimeConfigError(ctx, status.device, err)
 	}
 
 	reason := consts.UpdateSuccessfulReason
@@ -574,6 +635,16 @@ func (r *NicDeviceReconciler) applyRuntimeConfig(ctx context.Context, status *ni
 	}
 
 	return nil
+}
+
+func (r *NicDeviceReconciler) reportRuntimeConfigError(ctx context.Context, device *v1alpha1.NicDevice, err error) error {
+	updateErr := r.updateConfigInProgressStatusCondition(
+		ctx, device, consts.RuntimeConfigUpdateFailedReason, metav1.ConditionFalse, err.Error(),
+	)
+	if updateErr != nil {
+		log.Log.Error(updateErr, "failed to update device status condition", "device", device.Name)
+	}
+	return errors.Join(err, updateErr)
 }
 
 // handleReboot schedules maintenance and reboots the node if maintenance is allowed
@@ -616,37 +687,90 @@ func (r *NicDeviceReconciler) stripLastAppliedStateAnnotation(ctx context.Contex
 	return r.Update(ctx, status.device)
 }
 
-// applyNvConfig applies device's non-volatile spec
-// if update is correct, applies status condition PendingReboot, otherwise NonVolatileConfigUpdateFailed
-// sets rebootRequired flags for each device's configuration status
-// if status.nvConfigUpdateRequired == false, skips the device
-// returns nil if config update was successful, error otherwise
-func (r *NicDeviceReconciler) applyNvConfig(ctx context.Context, status *nicDeviceConfigurationStatus) error {
-	if status.device.Spec.Configuration == nil || !status.nvConfigUpdateRequired {
-		return nil
-	}
-
-	options := &types.ConfigurationOptions{SkipReset: true}
-	if status.device.Spec.Configuration.Template != nil {
-		options.Force = status.device.Spec.Configuration.Template.Force
-	}
-
-	result, err := r.ConfigurationManager.ApplyNVConfiguration(ctx, status.device, options)
-	if err != nil {
-		if types.IsIncorrectSpecError(err) {
-			updateErr := r.updateConfigInProgressStatusCondition(ctx, status.device, consts.IncorrectSpecReason, metav1.ConditionFalse, err.Error())
-			if updateErr != nil {
-				log.Log.Error(err, "failed to update device status condition", "device", status.device.Name)
-			}
-		} else {
-			updateErr := r.updateConfigInProgressStatusCondition(ctx, status.device, consts.NonVolatileConfigUpdateFailedReason, metav1.ConditionFalse, err.Error())
-			if updateErr != nil {
-				log.Log.Error(err, "failed to update device status condition", "device", status.device.Name)
+// applyNvConfigs applies NV configuration as one node-scoped batch and reports each result on the
+// corresponding NicDevice without losing successful outcomes when another device fails.
+func (r *NicDeviceReconciler) applyNvConfigs(ctx context.Context, statuses nicDeviceConfigurationStatuses) error {
+	requests := make([]types.NVConfigurationRequest, 0, len(statuses))
+	statusByDevice := make(map[*v1alpha1.NicDevice]*nicDeviceConfigurationStatus, len(statuses))
+	for _, status := range statuses {
+		request := types.NVConfigurationRequest{
+			Device: status.device,
+			Skip:   status.device.Spec.Configuration == nil || !status.nvConfigUpdateRequired,
+		}
+		if !request.Skip {
+			request.Options = &types.ConfigurationOptions{SkipReset: true}
+			if status.device.Spec.Configuration.Template != nil {
+				request.Options.Force = status.device.Spec.Configuration.Template.Force
 			}
 		}
-		return err
+		requests = append(requests, request)
+		statusByDevice[status.device] = status
 	}
-	err = r.updateConfigInProgressStatusCondition(ctx, status.device, consts.PendingRebootReason, metav1.ConditionTrue, "")
+
+	results, batchErr := r.ConfigurationManager.ApplyNVConfigurations(ctx, r.NodeName, requests)
+	observedErrors := []error{batchErr}
+	handledDevices := make(map[*v1alpha1.NicDevice]struct{}, len(results))
+	handlerErrors := make([]error, len(results))
+	var waitGroup sync.WaitGroup
+	for index, deviceResult := range results {
+		status, found := statusByDevice[deviceResult.Device]
+		if !found {
+			observedErrors = append(observedErrors, fmt.Errorf("NV configuration returned a result for an unknown device"))
+			continue
+		}
+		if _, duplicate := handledDevices[deviceResult.Device]; duplicate {
+			observedErrors = append(observedErrors, fmt.Errorf("NV configuration returned duplicate results for device %q", deviceResult.Device.Name))
+			continue
+		}
+		handledDevices[deviceResult.Device] = struct{}{}
+		if deviceResult.Skipped {
+			continue
+		}
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			handlerErrors[index] = r.handleNVConfigResult(ctx, status, deviceResult.Result, deviceResult.Err)
+		}()
+	}
+	waitGroup.Wait()
+	observedErrors = append(observedErrors, handlerErrors...)
+
+	for _, request := range requests {
+		if _, found := handledDevices[request.Device]; found {
+			continue
+		}
+		err := fmt.Errorf("NV configuration did not return a result for device %q", request.Device.Name)
+		if request.Skip {
+			observedErrors = append(observedErrors, err)
+			continue
+		}
+		observedErrors = append(observedErrors, r.handleNVConfigResult(ctx, statusByDevice[request.Device], nil, err))
+	}
+
+	return errors.Join(observedErrors...)
+}
+
+func (r *NicDeviceReconciler) handleNVConfigResult(
+	ctx context.Context,
+	status *nicDeviceConfigurationStatus,
+	result *types.ConfigurationApplyResult,
+	applyErr error,
+) error {
+	if applyErr != nil {
+		reason := consts.NonVolatileConfigUpdateFailedReason
+		if types.IsIncorrectSpecError(applyErr) {
+			reason = consts.IncorrectSpecReason
+		}
+		updateErr := r.updateConfigInProgressStatusCondition(
+			ctx, status.device, reason, metav1.ConditionFalse, applyErr.Error(),
+		)
+		if updateErr != nil {
+			log.Log.Error(updateErr, "failed to update device status condition", "device", status.device.Name)
+		}
+		return errors.Join(applyErr, updateErr)
+	}
+
+	err := r.updateConfigInProgressStatusCondition(ctx, status.device, consts.PendingRebootReason, metav1.ConditionTrue, "")
 	if err != nil {
 		return err
 	}

--- a/internal/controller/nicdevice_controller_test.go
+++ b/internal/controller/nicdevice_controller_test.go
@@ -93,6 +93,44 @@ var _ = Describe("NicDeviceReconciler", func() {
 
 		deviceDiscoveryReconcileTime = 1 * time.Second
 		configurationManager = &configurationMocks.ConfigurationManager{}
+		configurationManager.On("ApplyNVConfigurations", mock.Anything, nodeName, mock.Anything).
+			Return(func(
+				batchCtx context.Context,
+				_ string,
+				requests []types.NVConfigurationRequest,
+			) ([]types.DeviceNVConfigurationResult, error) {
+				results := make([]types.DeviceNVConfigurationResult, len(requests))
+				errs := make([]error, len(requests))
+				for index, request := range requests {
+					if request.Skip {
+						results[index] = types.DeviceNVConfigurationResult{Device: request.Device, Skipped: true}
+						continue
+					}
+					result, err := configurationManager.ApplyNVConfiguration(batchCtx, request.Device, request.Options)
+					results[index] = types.DeviceNVConfigurationResult{Device: request.Device, Result: result, Err: err}
+					errs[index] = err
+				}
+				return results, errors.Join(errs...)
+			}).Maybe()
+		configurationManager.On("ApplyRuntimeConfigurations", mock.Anything, nodeName, mock.Anything).
+			Return(func(
+				batchCtx context.Context,
+				_ string,
+				requests []types.RuntimeConfigurationRequest,
+			) ([]types.DeviceRuntimeConfigurationResult, error) {
+				results := make([]types.DeviceRuntimeConfigurationResult, len(requests))
+				errs := make([]error, len(requests))
+				for index, request := range requests {
+					if request.Skip {
+						results[index] = types.DeviceRuntimeConfigurationResult{Device: request.Device, Skipped: true}
+						continue
+					}
+					result, err := configurationManager.ApplyRuntimeConfiguration(batchCtx, request.Device)
+					results[index] = types.DeviceRuntimeConfigurationResult{Device: request.Device, Result: result, Err: err}
+					errs[index] = err
+				}
+				return results, errors.Join(errs...)
+			}).Maybe()
 		firmwareManager = &firmwareMocks.FirmwareManager{}
 		maintenanceManager = &maintenanceMocks.MaintenanceManager{}
 		hostUtils = &hostMocks.HostUtils{}
@@ -786,6 +824,64 @@ var _ = Describe("NicDeviceReconciler", func() {
 
 			configurationManager.AssertNotCalled(GinkgoT(), "ApplyRuntimeConfiguration", mock.Anything, mock.Anything)
 			maintenanceManager.AssertExpectations(GinkgoT())
+		})
+
+		It("reports each device's NV batch result independently", func() {
+			applyErr := errors.New("second device apply failed")
+			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, matchFirstDevice).Return(true, true, nil, nil)
+			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, matchSecondDevice).Return(true, true, nil, nil)
+			configurationManager.On("ApplyNVConfiguration", mock.Anything, matchFirstDevice, mock.Anything).
+				Return(&types.ConfigurationApplyResult{Status: types.ApplyStatusSuccess, RebootRequired: true}, nil)
+			configurationManager.On("ApplyNVConfiguration", mock.Anything, matchSecondDevice, mock.Anything).
+				Return(&types.ConfigurationApplyResult{Status: types.ApplyStatusFailed, RebootRequired: false}, applyErr)
+			maintenanceManager.On("ScheduleMaintenance", mock.Anything).Return(nil)
+			maintenanceManager.On("MaintenanceAllowed", mock.Anything).Return(true, nil)
+
+			createDevices()
+
+			Eventually(getDeviceConditions, timeout).Should(testutils.MatchCondition(metav1.Condition{
+				Type:   consts.ConfigUpdateInProgressCondition,
+				Status: metav1.ConditionTrue,
+				Reason: consts.PendingRebootReason,
+			}))
+			Eventually(func() []metav1.Condition {
+				device := &v1alpha1.NicDevice{}
+				Expect(k8sClient.Get(ctx, k8sTypes.NamespacedName{Name: secondDeviceName, Namespace: namespaceName}, device)).To(Succeed())
+				return device.Status.Conditions
+			}, timeout).Should(testutils.MatchCondition(metav1.Condition{
+				Type:    consts.ConfigUpdateInProgressCondition,
+				Status:  metav1.ConditionFalse,
+				Reason:  consts.NonVolatileConfigUpdateFailedReason,
+				Message: applyErr.Error(),
+			}))
+		})
+
+		It("reports each device's runtime batch result independently", func() {
+			applyErr := errors.New("second device runtime apply failed")
+			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, matchFirstDevice).Return(false, false, nil, nil)
+			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, matchSecondDevice).Return(false, false, nil, nil)
+			configurationManager.On("ApplyRuntimeConfiguration", mock.Anything, matchFirstDevice).
+				Return(&types.RuntimeConfigurationApplyResult{Status: types.ApplyStatusSuccess}, nil)
+			configurationManager.On("ApplyRuntimeConfiguration", mock.Anything, matchSecondDevice).
+				Return(&types.RuntimeConfigurationApplyResult{Status: types.ApplyStatusFailed}, applyErr)
+
+			createDevices()
+
+			Eventually(getDeviceConditions, timeout).Should(testutils.MatchCondition(metav1.Condition{
+				Type:   consts.ConfigUpdateInProgressCondition,
+				Status: metav1.ConditionFalse,
+				Reason: consts.UpdateSuccessfulReason,
+			}))
+			Eventually(func() []metav1.Condition {
+				device := &v1alpha1.NicDevice{}
+				Expect(k8sClient.Get(ctx, k8sTypes.NamespacedName{Name: secondDeviceName, Namespace: namespaceName}, device)).To(Succeed())
+				return device.Status.Conditions
+			}, timeout).Should(testutils.MatchCondition(metav1.Condition{
+				Type:    consts.ConfigUpdateInProgressCondition,
+				Status:  metav1.ConditionFalse,
+				Reason:  consts.RuntimeConfigUpdateFailedReason,
+				Message: applyErr.Error(),
+			}))
 		})
 	})
 

--- a/pkg/configuration/batch.go
+++ b/pkg/configuration/batch.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configuration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/Mellanox/nic-configuration-operator/api/v1alpha1"
+	"github.com/Mellanox/nic-configuration-operator/pkg/types"
+)
+
+// ApplyNVConfigurations applies NV configuration to all requests in parallel.
+// Results preserve input order and include one entry for every request, even when
+// one or more devices fail. The returned error joins all per-device failures.
+func (h configurationManager) ApplyNVConfigurations(
+	ctx context.Context,
+	nodeName string,
+	requests []types.NVConfigurationRequest,
+) ([]types.DeviceNVConfigurationResult, error) {
+	log.FromContext(ctx).V(2).Info("applying NV configuration batch", "node", nodeName, "devices", len(requests))
+	return applyNVConfigurations(ctx, requests, h.ApplyNVConfiguration)
+}
+
+func applyNVConfigurations(
+	ctx context.Context,
+	requests []types.NVConfigurationRequest,
+	apply func(context.Context, *v1alpha1.NicDevice, *types.ConfigurationOptions) (*types.ConfigurationApplyResult, error),
+) ([]types.DeviceNVConfigurationResult, error) {
+	results := make([]types.DeviceNVConfigurationResult, len(requests))
+	errs := make([]error, len(requests))
+
+	var waitGroup sync.WaitGroup
+	for index := range requests {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+
+			request := requests[index]
+			result := types.DeviceNVConfigurationResult{Device: request.Device}
+			switch {
+			case request.Device == nil:
+				result.Err = fmt.Errorf("NV configuration request at index %d has a nil device", index)
+			case request.Skip:
+				result.Skipped = true
+			case request.Options == nil:
+				result.Err = fmt.Errorf("NV configuration options for device %q must not be nil", request.Device.Name)
+			case ctx.Err() != nil:
+				result.Err = ctx.Err()
+			default:
+				result.Result, result.Err = apply(ctx, request.Device, request.Options)
+				if result.Result == nil && result.Err == nil {
+					result.Err = fmt.Errorf("NV configuration for device %q returned neither a result nor an error", request.Device.Name)
+				}
+			}
+
+			results[index] = result
+			errs[index] = result.Err
+		}()
+	}
+	waitGroup.Wait()
+
+	return results, errors.Join(errs...)
+}
+
+// ApplyRuntimeConfigurations applies runtime configuration to all devices in parallel.
+// Results preserve input order and include one entry for every device, even when
+// one or more devices fail. The returned error joins all per-device failures.
+func (h configurationManager) ApplyRuntimeConfigurations(
+	ctx context.Context,
+	nodeName string,
+	requests []types.RuntimeConfigurationRequest,
+) ([]types.DeviceRuntimeConfigurationResult, error) {
+	log.FromContext(ctx).V(2).Info("applying runtime configuration batch", "node", nodeName, "devices", len(requests))
+	return applyRuntimeConfigurations(ctx, requests, h.ApplyRuntimeConfiguration)
+}
+
+func applyRuntimeConfigurations(
+	ctx context.Context,
+	requests []types.RuntimeConfigurationRequest,
+	apply func(context.Context, *v1alpha1.NicDevice) (*types.RuntimeConfigurationApplyResult, error),
+) ([]types.DeviceRuntimeConfigurationResult, error) {
+	results := make([]types.DeviceRuntimeConfigurationResult, len(requests))
+	errs := make([]error, len(requests))
+
+	var waitGroup sync.WaitGroup
+	for index := range requests {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+
+			request := requests[index]
+			result := types.DeviceRuntimeConfigurationResult{Device: request.Device}
+			switch {
+			case request.Device == nil:
+				result.Err = fmt.Errorf("runtime configuration request at index %d has a nil device", index)
+			case request.Skip:
+				result.Skipped = true
+			case ctx.Err() != nil:
+				result.Err = ctx.Err()
+			default:
+				result.Result, result.Err = apply(ctx, request.Device)
+				if result.Result == nil && result.Err == nil {
+					result.Err = fmt.Errorf("runtime configuration for device %q returned neither a result nor an error", request.Device.Name)
+				}
+			}
+
+			results[index] = result
+			errs[index] = result.Err
+		}()
+	}
+	waitGroup.Wait()
+
+	return results, errors.Join(errs...)
+}

--- a/pkg/configuration/batch_test.go
+++ b/pkg/configuration/batch_test.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configuration
+
+import (
+	"context"
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Mellanox/nic-configuration-operator/api/v1alpha1"
+	"github.com/Mellanox/nic-configuration-operator/pkg/types"
+)
+
+var _ = Describe("configuration batches", func() {
+	newDevice := func(name string) *v1alpha1.NicDevice {
+		return &v1alpha1.NicDevice{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	}
+
+	Describe("NV configuration", func() {
+		It("preserves per-device results and input order when one device fails", func() {
+			first := newDevice("first")
+			second := newDevice("second")
+			secondErr := errors.New("second failed")
+			options := &types.ConfigurationOptions{SkipReset: true, WithDefault: false, Force: false}
+
+			results, err := applyNVConfigurations(
+				context.Background(),
+				[]types.NVConfigurationRequest{
+					{Device: first, Options: options},
+					{Device: second, Options: options},
+				},
+				func(_ context.Context, device *v1alpha1.NicDevice, _ *types.ConfigurationOptions) (*types.ConfigurationApplyResult, error) {
+					if device.Name == second.Name {
+						return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed, RebootRequired: false}, secondErr
+					}
+					return &types.ConfigurationApplyResult{Status: types.ApplyStatusSuccess, RebootRequired: true}, nil
+				},
+			)
+
+			Expect(err).To(MatchError(secondErr))
+			Expect(results).To(HaveLen(2))
+			Expect(results[0].Device).To(BeIdenticalTo(first))
+			Expect(results[0].Result).To(Equal(&types.ConfigurationApplyResult{
+				Status: types.ApplyStatusSuccess, RebootRequired: true,
+			}))
+			Expect(results[0].Err).NotTo(HaveOccurred())
+			Expect(results[1].Device).To(BeIdenticalTo(second))
+			Expect(results[1].Result).To(Equal(&types.ConfigurationApplyResult{
+				Status: types.ApplyStatusFailed, RebootRequired: false,
+			}))
+			Expect(results[1].Err).To(MatchError(secondErr))
+		})
+
+		It("reports invalid requests without dropping their result entries", func() {
+			device := newDevice("missing-options")
+			applyCalled := false
+
+			results, err := applyNVConfigurations(
+				context.Background(),
+				[]types.NVConfigurationRequest{{Device: nil, Options: &types.ConfigurationOptions{}}, {Device: device, Options: nil}},
+				func(_ context.Context, _ *v1alpha1.NicDevice, _ *types.ConfigurationOptions) (*types.ConfigurationApplyResult, error) {
+					applyCalled = true
+					return nil, nil
+				},
+			)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("index 0 has a nil device"))
+			Expect(err.Error()).To(ContainSubstring("options for device \"missing-options\" must not be nil"))
+			Expect(results).To(HaveLen(2))
+			Expect(results[0].Device).To(BeNil())
+			Expect(results[0].Err).To(HaveOccurred())
+			Expect(results[1].Device).To(BeIdenticalTo(device))
+			Expect(results[1].Err).To(HaveOccurred())
+			Expect(applyCalled).To(BeFalse())
+		})
+
+		It("retains skipped devices without invoking their per-device apply", func() {
+			device := newDevice("skipped")
+			applyCalled := false
+
+			results, err := applyNVConfigurations(
+				context.Background(),
+				[]types.NVConfigurationRequest{{Device: device, Options: nil, Skip: true}},
+				func(_ context.Context, _ *v1alpha1.NicDevice, _ *types.ConfigurationOptions) (*types.ConfigurationApplyResult, error) {
+					applyCalled = true
+					return nil, nil
+				},
+			)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(results).To(Equal([]types.DeviceNVConfigurationResult{{Device: device, Skipped: true}}))
+			Expect(applyCalled).To(BeFalse())
+		})
+
+		It("rejects an empty per-device outcome", func() {
+			device := newDevice("empty-result")
+
+			results, err := applyNVConfigurations(
+				context.Background(),
+				[]types.NVConfigurationRequest{{Device: device, Options: &types.ConfigurationOptions{}}},
+				func(_ context.Context, _ *v1alpha1.NicDevice, _ *types.ConfigurationOptions) (*types.ConfigurationApplyResult, error) {
+					return nil, nil
+				},
+			)
+
+			Expect(err).To(MatchError(`NV configuration for device "empty-result" returned neither a result nor an error`))
+			Expect(results).To(HaveLen(1))
+			Expect(errors.Is(err, results[0].Err)).To(BeTrue())
+		})
+	})
+
+	Describe("runtime configuration", func() {
+		It("preserves per-device results and input order when one device fails", func() {
+			first := newDevice("first")
+			second := newDevice("second")
+			firstErr := errors.New("first failed")
+
+			results, err := applyRuntimeConfigurations(
+				context.Background(),
+				[]types.RuntimeConfigurationRequest{{Device: first}, {Device: second}},
+				func(_ context.Context, device *v1alpha1.NicDevice) (*types.RuntimeConfigurationApplyResult, error) {
+					if device.Name == first.Name {
+						return &types.RuntimeConfigurationApplyResult{Status: types.ApplyStatusFailed}, firstErr
+					}
+					return &types.RuntimeConfigurationApplyResult{Status: types.ApplyStatusSuccess}, nil
+				},
+			)
+
+			Expect(err).To(MatchError(firstErr))
+			Expect(results).To(HaveLen(2))
+			Expect(results[0].Device).To(BeIdenticalTo(first))
+			Expect(results[0].Result).To(Equal(&types.RuntimeConfigurationApplyResult{Status: types.ApplyStatusFailed}))
+			Expect(results[0].Err).To(MatchError(firstErr))
+			Expect(results[1].Device).To(BeIdenticalTo(second))
+			Expect(results[1].Result).To(Equal(&types.RuntimeConfigurationApplyResult{Status: types.ApplyStatusSuccess}))
+			Expect(results[1].Err).NotTo(HaveOccurred())
+		})
+
+		It("reports cancellation for every device without invoking apply", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			applyCalled := false
+
+			results, err := applyRuntimeConfigurations(
+				ctx,
+				[]types.RuntimeConfigurationRequest{{Device: newDevice("first")}, {Device: newDevice("second")}},
+				func(_ context.Context, _ *v1alpha1.NicDevice) (*types.RuntimeConfigurationApplyResult, error) {
+					applyCalled = true
+					return nil, nil
+				},
+			)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(context.Canceled.Error()))
+			Expect(results).To(HaveLen(2))
+			Expect(results[0].Err).To(MatchError(context.Canceled))
+			Expect(results[1].Err).To(MatchError(context.Canceled))
+			Expect(applyCalled).To(BeFalse())
+		})
+
+		It("retains skipped devices without invoking their per-device apply", func() {
+			device := newDevice("skipped")
+			applyCalled := false
+
+			results, err := applyRuntimeConfigurations(
+				context.Background(),
+				[]types.RuntimeConfigurationRequest{{Device: device, Skip: true}},
+				func(_ context.Context, _ *v1alpha1.NicDevice) (*types.RuntimeConfigurationApplyResult, error) {
+					applyCalled = true
+					return nil, nil
+				},
+			)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(results).To(Equal([]types.DeviceRuntimeConfigurationResult{{Device: device, Skipped: true}}))
+			Expect(applyCalled).To(BeFalse())
+		})
+
+		It("rejects an empty per-device outcome", func() {
+			device := newDevice("empty-result")
+
+			results, err := applyRuntimeConfigurations(
+				context.Background(),
+				[]types.RuntimeConfigurationRequest{{Device: device}},
+				func(_ context.Context, _ *v1alpha1.NicDevice) (*types.RuntimeConfigurationApplyResult, error) {
+					return nil, nil
+				},
+			)
+
+			Expect(err).To(MatchError(`runtime configuration for device "empty-result" returned neither a result nor an error`))
+			Expect(results).To(HaveLen(1))
+			Expect(errors.Is(err, results[0].Err)).To(BeTrue())
+		})
+	})
+})

--- a/pkg/configuration/manager.go
+++ b/pkg/configuration/manager.go
@@ -47,10 +47,16 @@ type ConfigurationManager interface {
 	// returns *ConfigurationApplyResult - result of the apply operation
 	// returns error - there were errors while applying nv configuration
 	ApplyNVConfiguration(ctx context.Context, device *v1alpha1.NicDevice, options *types.ConfigurationOptions) (*types.ConfigurationApplyResult, error)
+	// ApplyNVConfigurations applies NV configuration to a node-scoped device batch in parallel.
+	// The returned result slice contains one entry per request in the same order, including failures.
+	ApplyNVConfigurations(ctx context.Context, nodeName string, requests []types.NVConfigurationRequest) ([]types.DeviceNVConfigurationResult, error)
 	// ApplyRuntimeConfiguration calculates device's missing runtime spec configuration and applies it to the device on the host
 	// returns *RuntimeConfigurationApplyResult - result of the apply operation
 	// returns error - there were errors while applying runtime configuration
 	ApplyRuntimeConfiguration(ctx context.Context, device *v1alpha1.NicDevice) (*types.RuntimeConfigurationApplyResult, error)
+	// ApplyRuntimeConfigurations applies runtime configuration to a node-scoped device batch in parallel.
+	// The returned result slice contains one entry per device in the same order, including failures.
+	ApplyRuntimeConfigurations(ctx context.Context, nodeName string, requests []types.RuntimeConfigurationRequest) ([]types.DeviceRuntimeConfigurationResult, error)
 	// ResetNicFirmware resets NIC's firmware
 	// Operation can be long, required context to be able to terminate by timeout
 	// IB devices need to communicate with other nodes for confirmation

--- a/pkg/configuration/mocks/ConfigurationManager.go
+++ b/pkg/configuration/mocks/ConfigurationManager.go
@@ -16,6 +16,60 @@ type ConfigurationManager struct {
 	mock.Mock
 }
 
+// ApplyNVConfigurations provides a mock function with given fields: ctx, nodeName, requests
+func (_m *ConfigurationManager) ApplyNVConfigurations(ctx context.Context, nodeName string, requests []types.NVConfigurationRequest) ([]types.DeviceNVConfigurationResult, error) {
+	ret := _m.Called(ctx, nodeName, requests)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ApplyNVConfigurations")
+	}
+
+	var r0 []types.DeviceNVConfigurationResult
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, []types.NVConfigurationRequest) ([]types.DeviceNVConfigurationResult, error)); ok {
+		return rf(ctx, nodeName, requests)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, []types.NVConfigurationRequest) []types.DeviceNVConfigurationResult); ok {
+		r0 = rf(ctx, nodeName, requests)
+	} else if ret.Get(0) != nil {
+		r0 = ret.Get(0).([]types.DeviceNVConfigurationResult)
+	}
+	if rf, ok := ret.Get(1).(func(context.Context, string, []types.NVConfigurationRequest) error); ok {
+		r1 = rf(ctx, nodeName, requests)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ApplyRuntimeConfigurations provides a mock function with given fields: ctx, nodeName, devices
+func (_m *ConfigurationManager) ApplyRuntimeConfigurations(ctx context.Context, nodeName string, requests []types.RuntimeConfigurationRequest) ([]types.DeviceRuntimeConfigurationResult, error) {
+	ret := _m.Called(ctx, nodeName, requests)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ApplyRuntimeConfigurations")
+	}
+
+	var r0 []types.DeviceRuntimeConfigurationResult
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, []types.RuntimeConfigurationRequest) ([]types.DeviceRuntimeConfigurationResult, error)); ok {
+		return rf(ctx, nodeName, requests)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, []types.RuntimeConfigurationRequest) []types.DeviceRuntimeConfigurationResult); ok {
+		r0 = rf(ctx, nodeName, requests)
+	} else if ret.Get(0) != nil {
+		r0 = ret.Get(0).([]types.DeviceRuntimeConfigurationResult)
+	}
+	if rf, ok := ret.Get(1).(func(context.Context, string, []types.RuntimeConfigurationRequest) error); ok {
+		r1 = rf(ctx, nodeName, requests)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // ApplyNVConfiguration provides a mock function with given fields: ctx, device, options
 func (_m *ConfigurationManager) ApplyNVConfiguration(ctx context.Context, device *v1alpha1.NicDevice, options *types.ConfigurationOptions) (*types.ConfigurationApplyResult, error) {
 	ret := _m.Called(ctx, device, options)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -85,6 +85,37 @@ type RuntimeConfigurationApplyResult struct {
 	Status ApplyStatus
 }
 
+// NVConfigurationRequest associates a device with its NV configuration options.
+type NVConfigurationRequest struct {
+	Device  *v1alpha1.NicDevice
+	Options *ConfigurationOptions
+	Skip    bool
+}
+
+// DeviceNVConfigurationResult is the NV configuration outcome for one device.
+// Device is the same pointer supplied in the corresponding request.
+type DeviceNVConfigurationResult struct {
+	Device  *v1alpha1.NicDevice
+	Result  *ConfigurationApplyResult
+	Skipped bool
+	Err     error
+}
+
+// RuntimeConfigurationRequest identifies a device in a node-scoped runtime configuration batch.
+type RuntimeConfigurationRequest struct {
+	Device *v1alpha1.NicDevice
+	Skip   bool
+}
+
+// DeviceRuntimeConfigurationResult is the runtime configuration outcome for one device.
+// Device is the same pointer supplied in the corresponding request.
+type DeviceRuntimeConfigurationResult struct {
+	Device  *v1alpha1.NicDevice
+	Result  *RuntimeConfigurationApplyResult
+	Skipped bool
+	Err     error
+}
+
 // FirmwareInstallOptions contains options for firmware installation
 type FirmwareInstallOptions struct {
 	Version    string // FW version (for K8s cache lookup in operator mode)


### PR DESCRIPTION
## Summary

- add node-scoped NV and runtime configuration APIs that receive the complete device set
- preserve input order and return an outcome for every device, including failed and skipped devices
- retain the existing singular configuration methods for library callers
- update the NicDevice controller to apply batches while reporting status independently per device
- add batch unit tests, multi-device controller coverage, mocks, and library documentation

## Motivation

This is a prerequisite for moving Spectrum-X prepare/configure planning into the configuration layer. The configuration manager needs the complete node topology, including devices that do not require the legacy per-device operation during a reconcile. Such devices are retained through explicit skipped requests.

Per-device results keep controller status reporting intact: one device can reach `PendingReboot` or `UpdateSuccessful` while another reports its own apply failure.

## Compatibility

The existing singular methods remain available. External custom implementations of the `ConfigurationManager` interface need to implement the two new plural methods.

## Verification

- `go test ./pkg/configuration/... -count=1`
- `go test -race ./pkg/configuration/... -count=1`
- `go test ./internal/controller -count=1` (99 specs)
- `go build ./...`
- `make lint` (0 issues)
- `git diff --check`