### PR TITLE
feat: parse doSPCX semantic plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,11 @@ Spectrum-X profiles can configure NICs with multiple data planes. Available mode
 starts its existing concurrent per-device NV apply, it calls `PreparePlan` once for the node's
 Spectrum-X device group with the `prepare` stage. It does the same with the `configure` stage before
 the existing concurrent runtime apply. Plan preparation never executes generated plan operations.
+`GetPreparedPlan` parses the host-k8s `plan.semantic.groups` contract and makes the semantic plan
+available to library consumers. `BuildDMSOperationPlan` turns it into an ordered, target-resolved
+DMS operation plan, including current plus pending queries for prepare-stage NVConfig. This
+translation remains execution-free. Configure groups `eswitch` and `vf-lifecycle` are intentionally excluded from the
+current operation plan and reported as skipped; unknown groups fail closed.
 
 The manager creates its command executor internally and points the `dms-cli` child process at the
 Blueprints source tree fixed at `/opt/nvidia/blueprints`. The daemon image build must inject a

--- a/docs/nic-configuration-library.md
+++ b/docs/nic-configuration-library.md
@@ -301,18 +301,26 @@ dmsc -a localhost:9339 --insecure --target 0000:08:00.0 set --timeout 5m \
 
 ### pkg/dmscli/ — Agentless DMS CLI API
 
-Sources: `pkg/dmscli/nvconfig.go`, `pkg/dmscli/blueprints.go`
+Sources: `pkg/dmscli/nvconfig.go`, `pkg/dmscli/blueprints.go`, `pkg/dmscli/xpath.go`
 
 `pkg/dmscli` wraps the local, agentless `dms-cli` executable with package-level
-functions; there is no client object or stored runtime state. Its first
-supported actions are bulk NVConfig apply and Blueprints plan generation. The
-request already models both raw native parameters and typed XPath operations so
-other projects and later doSPCX plan execution can reuse the same API.
+functions; there is no client object or stored runtime state. It supports bulk
+NVConfig apply, Blueprints plan generation, and generic typed XPath GET and SET.
+The same typed operation is shared by ordinary DMS SET and NVConfig apply so
+other projects can reuse the API without depending on NCO's Spectrum-X policy.
 
 ```go
-type NVConfigXPathOperation struct {
+type XPathOperation struct {
     Path   string
     Values map[string]any
+}
+
+// Compatibility alias used by ApplyNVConfigRequest.
+type NVConfigXPathOperation = XPathOperation
+
+type XPathQuery struct {
+    Path   string
+    Leaves []string
 }
 
 type NVConfigParam struct {
@@ -350,6 +358,20 @@ func GenerateBlueprintPlan(
     execInterface execUtils.Interface,
     request BlueprintPlanRequest,
 ) (*BlueprintPlanResult, error)
+
+func QueryXPaths(
+    ctx context.Context,
+    execInterface execUtils.Interface,
+    target string,
+    queries []XPathQuery,
+) (*QueryXPathsResult, error)
+
+func SetXPaths(
+    ctx context.Context,
+    execInterface execUtils.Interface,
+    target string,
+    operations []XPathOperation,
+) (*SetXPathsResult, error)
 ```
 
 The caller supplies the repository-standard `k8s.io/utils/exec.Interface`; this
@@ -367,9 +389,24 @@ runtime `PATH`.
 
 The payload supports `ports`, `typed`, `raw`, `with-default`, and `force`.
 `Target` is carried by `-t` and is not serialized. The operator currently
-populates only `Raw`, `WithDefault`, and `Force`; `ports` and `typed` are omitted
-until doSPCX planning and typed XPath generation are introduced in a later
-phase.
+populates only `Raw`, `WithDefault`, and `Force`; semantic prepare operations
+are parsed and translated but are not yet connected to NVConfig execution.
+
+Typed GET and SET preserve query/group order and use `;` as a literal argument
+between DMS containers:
+
+```text
+dms-cli --json -t pci/<BDF> /nvidia/link/ipg admin \
+  \; /nvidia/link/physical admin-status
+dms-cli --json -t pci/<BDF> /nvidia/link/physical admin-status=down \
+  \; /nvidia/link/physical admin-status=up
+```
+
+SET value keys are sorted for deterministic command lines. Scalar leaf-list
+values use repeated assignments (`lanes=0 lanes=1 ...`), avoiding the current
+DMS compact-list parsing limitation. GET normalizes flat, backend-wrapped, and
+container-keyed JSON responses and surfaces partial and `not-supported` results
+as errors while preserving their structured result.
 
 Blueprint planning uses this command shape:
 
@@ -415,7 +452,7 @@ device membership before touching hardware.
 
 ### pkg/spectrumx/ — Spectrum-X Configuration
 
-Sources: `pkg/spectrumx/spectrumx.go`, `pkg/spectrumx/prepareplan.go`
+Sources: `pkg/spectrumx/spectrumx.go`, `pkg/spectrumx/prepareplan.go`, `pkg/spectrumx/semanticplan.go`
 
 #### PlanManager Interface
 
@@ -428,9 +465,10 @@ const (
 )
 
 type Plan struct {
-    Name  string
-    Stage PlanStage
-    JSON  json.RawMessage
+    Name     string
+    Stage    PlanStage
+    JSON     json.RawMessage
+    Semantic *SemanticPlan
 }
 
 type PlanManager interface {
@@ -443,8 +481,20 @@ type PlanManager interface {
 Spectrum-X device group. It is a no-op when none of the supplied devices enable
 Spectrum-X. `GetPreparedPlan` retrieves the persisted plan without invoking
 `dms-cli`, and rejects it unless its cached inputs and target map still match the
-supplied device. The existing Spectrum-X manager implementation provides both
-methods and creates the command executor internally:
+supplied device. It also parses the host-k8s `plan.semantic.groups` surface and
+resolves every `operation_ref` through `plan.operations`. The parser preserves
+group and operation ordering, including repeated writes, and does not inspect
+bare-metal steps, services, or artifacts.
+
+`SemanticPlan.BuildDMSOperationPlan(ctx)` resolves `pf_netdev_all` and
+`pf_rdma_scope` to target-specific query and SET batches without executing
+them. Queries represent the final desired state; prepare-stage queries include
+both the current and `-pending` leaves used by the doSPCX NVConfig gate. SET
+operations preserve the complete transition sequence. `post-breakout` remains
+an ordered phase marker. Configure groups `eswitch` and `vf-lifecycle` are parsed and validated
+but explicitly reported as skipped; unknown groups fail closed. The existing
+Spectrum-X manager implementation provides both plan lifecycle methods and
+creates the command executor internally:
 
 ```go
 type SpectrumXManager interface {

--- a/pkg/dmscli/nvconfig.go
+++ b/pkg/dmscli/nvconfig.go
@@ -32,12 +32,9 @@ const (
 	nvConfigApplyPath = "/nvidia/nvconfig/apply"
 )
 
-// NVConfigXPathOperation describes typed NVConfig intent using a DMS XPath and
-// the values to apply below that path.
-type NVConfigXPathOperation struct {
-	Path   string         `json:"path"`
-	Values map[string]any `json:"values"`
-}
+// NVConfigXPathOperation is retained as a compatibility alias for the generic
+// XPathOperation used by dms-cli GET, SET, and NVConfig apply operations.
+type NVConfigXPathOperation = XPathOperation
 
 // NVConfigParam is one raw native NVConfig assignment.
 type NVConfigParam struct {

--- a/pkg/dmscli/xpath.go
+++ b/pkg/dmscli/xpath.go
@@ -1,0 +1,633 @@
+/*
+Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dmscli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/go-logr/logr"
+	execUtils "k8s.io/utils/exec"
+)
+
+const (
+	xpathStatusError   = "error"
+	xpathStatusPartial = "partial"
+)
+
+// XPathOperation describes typed intent below one DMS XPath.
+type XPathOperation struct {
+	Path   string         `json:"path"`
+	Values map[string]any `json:"values"`
+}
+
+// XPathQuery identifies leaves to read below one DMS XPath.
+type XPathQuery struct {
+	Path   string
+	Leaves []string
+}
+
+// XPathStatus is one normalized per-path DMS result.
+type XPathStatus struct {
+	Path         string `json:"path"`
+	Status       string `json:"status"`
+	ErrorCode    int    `json:"error_code,omitempty"`
+	Error        string `json:"error,omitempty"`
+	ErrorMessage string `json:"error_msg,omitempty"`
+}
+
+// QueryXPathsResult is the normalized result of a typed DMS GET. Values and
+// NotSupported are keyed by the requested container or keyed-list XPath.
+type QueryXPathsResult struct {
+	Status       string
+	Values       map[string]map[string]any
+	NotSupported map[string][]string
+	Results      []XPathStatus
+	ErrorMessage string
+}
+
+// SetXPathsResult is the normalized result of a typed DMS SET.
+type SetXPathsResult struct {
+	Status       string
+	Results      []XPathStatus
+	ErrorMessage string
+}
+
+// QueryXPaths reads one or more leaf batches from a DMS target.
+func QueryXPaths(
+	ctx context.Context,
+	execInterface execUtils.Interface,
+	target string,
+	queries []XPathQuery,
+) (*QueryXPathsResult, error) {
+	if execInterface == nil {
+		return nil, fmt.Errorf("command executor must not be nil")
+	}
+	if err := validateXPathQueries(target, queries); err != nil {
+		return nil, err
+	}
+
+	args := []string{"--json", "-t", target}
+	for index, query := range queries {
+		if index > 0 {
+			args = append(args, ";")
+		}
+		args = append(args, query.Path)
+		args = append(args, query.Leaves...)
+	}
+
+	command := execInterface.CommandContext(ctx, dmsCLIExecutable, args...)
+	output, commandErr := command.CombinedOutput()
+	commandAndArgs := append([]string{dmsCLIExecutable}, args...)
+	logr.FromContextOrDiscard(ctx).V(2).Info("command output",
+		"command", commandAndArgs,
+		"target", target,
+		"output", string(output))
+
+	result, decodeErr := decodeQueryXPathsResult(output, queries)
+	if commandErr != nil {
+		return result, xpathCommandError("query", target, output, resultErrorMessage(result), commandErr)
+	}
+	if decodeErr != nil {
+		return nil, fmt.Errorf("decode XPath query result for target %q: %w", target, decodeErr)
+	}
+	if queryResultFailed(result) {
+		detail := result.ErrorMessage
+		if detail == "" {
+			detail = fmt.Sprintf("unexpected status %q", result.Status)
+		}
+		return result, fmt.Errorf("query XPaths from target %q: %s", target, detail)
+	}
+
+	return result, nil
+}
+
+// SetXPaths applies an ordered sequence of typed operations to a DMS target.
+func SetXPaths(
+	ctx context.Context,
+	execInterface execUtils.Interface,
+	target string,
+	operations []XPathOperation,
+) (*SetXPathsResult, error) {
+	if execInterface == nil {
+		return nil, fmt.Errorf("command executor must not be nil")
+	}
+	args, err := xpathSetArgs(target, operations)
+	if err != nil {
+		return nil, err
+	}
+
+	command := execInterface.CommandContext(ctx, dmsCLIExecutable, args...)
+	output, commandErr := command.CombinedOutput()
+	commandAndArgs := append([]string{dmsCLIExecutable}, args...)
+	logr.FromContextOrDiscard(ctx).V(2).Info("command output",
+		"command", commandAndArgs,
+		"target", target,
+		"output", string(output))
+
+	result, decodeErr := decodeSetXPathsResult(output)
+	if commandErr != nil {
+		return result, xpathCommandError("set", target, output, setResultErrorMessage(result), commandErr)
+	}
+	if decodeErr != nil {
+		return nil, fmt.Errorf("decode XPath set result for target %q: %w", target, decodeErr)
+	}
+	if setResultFailed(result) {
+		detail := result.ErrorMessage
+		if detail == "" {
+			detail = fmt.Sprintf("unexpected status %q", result.Status)
+		}
+		return result, fmt.Errorf("set XPaths on target %q: %s", target, detail)
+	}
+
+	return result, nil
+}
+
+func validateXPathQueries(target string, queries []XPathQuery) error {
+	if strings.TrimSpace(target) == "" {
+		return fmt.Errorf("XPath target must not be empty")
+	}
+	if len(queries) == 0 {
+		return fmt.Errorf("XPath query must contain at least one path")
+	}
+	paths := make(map[string]struct{}, len(queries))
+	for queryIndex, query := range queries {
+		if err := validateXPath(query.Path); err != nil {
+			return fmt.Errorf("XPath query at index %d: %w", queryIndex, err)
+		}
+		if _, found := paths[query.Path]; found {
+			return fmt.Errorf("XPath query path %q is duplicated", query.Path)
+		}
+		paths[query.Path] = struct{}{}
+		if len(query.Leaves) == 0 {
+			return fmt.Errorf("XPath query %q must contain at least one leaf", query.Path)
+		}
+		leaves := make(map[string]struct{}, len(query.Leaves))
+		for leafIndex, leaf := range query.Leaves {
+			if err := validateXPathLeaf(leaf); err != nil {
+				return fmt.Errorf("XPath query %q leaf at index %d: %w", query.Path, leafIndex, err)
+			}
+			if _, found := leaves[leaf]; found {
+				return fmt.Errorf("XPath query %q leaf %q is duplicated", query.Path, leaf)
+			}
+			leaves[leaf] = struct{}{}
+		}
+	}
+	return nil
+}
+
+func xpathSetArgs(target string, operations []XPathOperation) ([]string, error) {
+	if strings.TrimSpace(target) == "" {
+		return nil, fmt.Errorf("XPath target must not be empty")
+	}
+	if len(operations) == 0 {
+		return nil, fmt.Errorf("XPath set must contain at least one operation")
+	}
+
+	args := []string{"--json", "-t", target}
+	for operationIndex, operation := range operations {
+		if err := validateXPath(operation.Path); err != nil {
+			return nil, fmt.Errorf("XPath operation at index %d: %w", operationIndex, err)
+		}
+		if len(operation.Values) == 0 {
+			return nil, fmt.Errorf("XPath operation %q must contain at least one value", operation.Path)
+		}
+		if operationIndex > 0 {
+			args = append(args, ";")
+		}
+		args = append(args, operation.Path)
+
+		leaves := make([]string, 0, len(operation.Values))
+		for leaf := range operation.Values {
+			leaves = append(leaves, leaf)
+		}
+		sort.Strings(leaves)
+		for _, leaf := range leaves {
+			if err := validateXPathLeaf(leaf); err != nil {
+				return nil, fmt.Errorf("XPath operation %q: %w", operation.Path, err)
+			}
+			values, err := formatXPathValues(operation.Values[leaf])
+			if err != nil {
+				return nil, fmt.Errorf("XPath operation %q leaf %q: %w", operation.Path, leaf, err)
+			}
+			for _, value := range values {
+				args = append(args, leaf+"="+value)
+			}
+		}
+	}
+	return args, nil
+}
+
+func validateXPath(path string) error {
+	if strings.TrimSpace(path) == "" {
+		return fmt.Errorf("path must not be empty")
+	}
+	if path != strings.TrimSpace(path) || !strings.HasPrefix(path, "/nvidia/") {
+		return fmt.Errorf("path %q must be an absolute /nvidia XPath", path)
+	}
+	if strings.ContainsAny(path, " \t\r\n;") {
+		return fmt.Errorf("path %q contains unsupported characters", path)
+	}
+	return nil
+}
+
+func validateXPathLeaf(leaf string) error {
+	if strings.TrimSpace(leaf) == "" {
+		return fmt.Errorf("leaf must not be empty")
+	}
+	if leaf != strings.TrimSpace(leaf) || strings.ContainsAny(leaf, "/=; \t\r\n") {
+		return fmt.Errorf("leaf %q contains unsupported characters", leaf)
+	}
+	return nil
+}
+
+func formatXPathValues(value any) ([]string, error) {
+	if value == nil {
+		return nil, fmt.Errorf("value must not be null")
+	}
+	reflected := reflect.ValueOf(value)
+	if reflected.Kind() != reflect.Array && reflected.Kind() != reflect.Slice {
+		formatted, err := formatXPathScalar(value)
+		if err != nil {
+			return nil, err
+		}
+		return []string{formatted}, nil
+	}
+
+	if reflected.Len() == 0 {
+		return nil, fmt.Errorf("leaf-list must contain at least one value")
+	}
+	result := make([]string, reflected.Len())
+	for index := 0; index < reflected.Len(); index++ {
+		formatted, err := formatXPathScalar(reflected.Index(index).Interface())
+		if err != nil {
+			return nil, fmt.Errorf("leaf-list item at index %d: %w", index, err)
+		}
+		result[index] = formatted
+	}
+	return result, nil
+}
+
+func formatXPathScalar(value any) (string, error) {
+	if value == nil {
+		return "", fmt.Errorf("value must not be null")
+	}
+	if number, ok := value.(json.Number); ok {
+		if _, err := strconv.ParseFloat(string(number), 64); err != nil {
+			return "", fmt.Errorf("invalid JSON number %q", number)
+		}
+		return string(number), nil
+	}
+
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.String:
+		return reflected.String(), nil
+	case reflect.Bool:
+		return strconv.FormatBool(reflected.Bool()), nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return strconv.FormatInt(reflected.Int(), 10), nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return strconv.FormatUint(reflected.Uint(), 10), nil
+	case reflect.Float32, reflect.Float64:
+		floating := reflected.Float()
+		if math.IsNaN(floating) || math.IsInf(floating, 0) {
+			return "", fmt.Errorf("floating-point value must be finite")
+		}
+		return strconv.FormatFloat(floating, 'g', -1, reflected.Type().Bits()), nil
+	default:
+		return "", fmt.Errorf("value must be a string, boolean, or number")
+	}
+}
+
+type xpathResponse struct {
+	Status       string         `json:"status"`
+	Values       map[string]any `json:"values"`
+	NotSupported []string       `json:"not-supported"`
+	Results      []XPathStatus  `json:"results"`
+	Error        string         `json:"error"`
+	ErrorMessage string         `json:"error_msg"`
+}
+
+func decodeQueryXPathsResult(output []byte, queries []XPathQuery) (*QueryXPathsResult, error) {
+	root, err := decodeXPathResponseObject(output)
+	if err != nil {
+		return nil, err
+	}
+	result := &QueryXPathsResult{
+		Status:       "ok",
+		Values:       map[string]map[string]any{},
+		NotSupported: map[string][]string{},
+		Results:      nil,
+		ErrorMessage: "",
+	}
+
+	if isXPathResponseEnvelope(root) {
+		response, err := decodeXPathResponse(root)
+		if err != nil {
+			return nil, err
+		}
+		if len(queries) != 1 {
+			if response.Status == "ok" {
+				return nil, fmt.Errorf("unkeyed successful dms-cli response is ambiguous for %d query paths", len(queries))
+			}
+			result.Status = response.Status
+			result.Results = append(result.Results, response.Results...)
+			result.ErrorMessage = responseErrorMessage(response)
+			return result, nil
+		}
+		mergeQueryResponse(result, queries[0].Path, response)
+		result.Status = response.Status
+		if result.Status == "ok" && len(response.NotSupported) > 0 {
+			result.Status = xpathStatusPartial
+		}
+		return result, nil
+	}
+	if len(queries) == 1 {
+		if _, found := root[queries[0].Path]; !found && !hasXPathKey(root) {
+			values := map[string]any{}
+			if err := decodeJSON(output, &values); err != nil {
+				return nil, err
+			}
+			result.Values[queries[0].Path] = values
+			return result, nil
+		}
+	}
+
+	succeeded := 0
+	failed := 0
+	hasPartial := false
+	for _, query := range queries {
+		raw, found := root[query.Path]
+		if !found {
+			return nil, fmt.Errorf("dms-cli response does not contain query path %q", query.Path)
+		}
+		response, err := decodeKeyedQueryResponse(raw)
+		if err != nil {
+			return nil, fmt.Errorf("decode response for query path %q: %w", query.Path, err)
+		}
+		mergeQueryResponse(result, query.Path, response)
+		if queryResponseFailed(response) {
+			failed++
+			hasPartial = hasPartial || response.Status == xpathStatusPartial
+		} else {
+			succeeded++
+		}
+	}
+	switch {
+	case failed == 0:
+		result.Status = "ok"
+	case succeeded > 0 || hasPartial:
+		result.Status = xpathStatusPartial
+	default:
+		result.Status = xpathStatusError
+	}
+	return result, nil
+}
+
+func hasXPathKey(object map[string]json.RawMessage) bool {
+	for key := range object {
+		if strings.HasPrefix(key, "/") {
+			return true
+		}
+	}
+	return false
+}
+
+func isXPathResponseEnvelope(object map[string]json.RawMessage) bool {
+	if rawStatus, found := object["status"]; found {
+		var status string
+		if err := json.Unmarshal(rawStatus, &status); err == nil {
+			switch status {
+			case "ok", xpathStatusError, xpathStatusPartial:
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func decodeKeyedQueryResponse(raw json.RawMessage) (xpathResponse, error) {
+	object := map[string]json.RawMessage{}
+	if err := decodeJSON(raw, &object); err != nil {
+		return xpathResponse{}, err
+	}
+	if isXPathResponseEnvelope(object) {
+		var response xpathResponse
+		if err := decodeJSON(raw, &response); err != nil {
+			return xpathResponse{}, err
+		}
+		return response, nil
+	}
+
+	values := map[string]any{}
+	if err := decodeJSON(raw, &values); err != nil {
+		return xpathResponse{}, err
+	}
+	return xpathResponse{Status: "ok", Values: values}, nil
+}
+
+func decodeSetXPathsResult(output []byte) (*SetXPathsResult, error) {
+	root, err := decodeXPathResponseObject(output)
+	if err != nil {
+		return nil, err
+	}
+	result := &SetXPathsResult{Status: "ok", Results: nil, ErrorMessage: ""}
+	if _, hasStatus := root["status"]; hasStatus {
+		response, err := decodeXPathResponse(root)
+		if err != nil {
+			return nil, err
+		}
+		result.Status = response.Status
+		result.Results = response.Results
+		result.ErrorMessage = response.ErrorMessage
+		if result.ErrorMessage == "" {
+			result.ErrorMessage = response.Error
+		}
+		return result, nil
+	}
+
+	paths := make([]string, 0, len(root))
+	for path := range root {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	failed := 0
+	for _, path := range paths {
+		var response xpathResponse
+		if err := decodeJSON(root[path], &response); err != nil {
+			return nil, fmt.Errorf("decode response for set path %q: %w", path, err)
+		}
+		status := XPathStatus{
+			Path:         path,
+			Status:       response.Status,
+			Error:        response.Error,
+			ErrorMessage: response.ErrorMessage,
+		}
+		result.Results = append(result.Results, status)
+		if response.Status != "ok" {
+			failed++
+			if result.ErrorMessage == "" {
+				result.ErrorMessage = response.ErrorMessage
+				if result.ErrorMessage == "" {
+					result.ErrorMessage = response.Error
+				}
+			}
+		}
+	}
+	if failed == len(paths) {
+		result.Status = xpathStatusError
+	} else if failed > 0 {
+		result.Status = xpathStatusPartial
+	}
+	return result, nil
+}
+
+func decodeXPathResponseObject(output []byte) (map[string]json.RawMessage, error) {
+	if len(bytes.TrimSpace(output)) == 0 {
+		return nil, fmt.Errorf("dms-cli returned an empty response")
+	}
+	root := map[string]json.RawMessage{}
+	if err := decodeJSON(output, &root); err != nil {
+		return nil, fmt.Errorf("invalid dms-cli JSON response: %w", err)
+	}
+	if len(root) == 0 {
+		return nil, fmt.Errorf("dms-cli returned an empty JSON object")
+	}
+	return root, nil
+}
+
+func decodeXPathResponse(root map[string]json.RawMessage) (xpathResponse, error) {
+	encoded, err := json.Marshal(root)
+	if err != nil {
+		return xpathResponse{}, err
+	}
+	var response xpathResponse
+	if err := decodeJSON(encoded, &response); err != nil {
+		return xpathResponse{}, err
+	}
+	return response, nil
+}
+
+func decodeJSON(content []byte, value any) error {
+	decoder := json.NewDecoder(bytes.NewReader(content))
+	decoder.UseNumber()
+	if err := decoder.Decode(value); err != nil {
+		return err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("response contains trailing JSON data")
+		}
+		return fmt.Errorf("decode trailing JSON data: %w", err)
+	}
+	return nil
+}
+
+func mergeQueryResponse(result *QueryXPathsResult, path string, response xpathResponse) {
+	result.Values[path] = response.Values
+	if len(response.NotSupported) > 0 {
+		result.NotSupported[path] = append([]string(nil), response.NotSupported...)
+	}
+	result.Results = append(result.Results, response.Results...)
+	if response.ErrorMessage != "" && result.ErrorMessage == "" {
+		result.ErrorMessage = response.ErrorMessage
+	}
+	if response.Error != "" && result.ErrorMessage == "" {
+		result.ErrorMessage = response.Error
+	}
+}
+
+func queryResponseFailed(response xpathResponse) bool {
+	if response.Status != "ok" || len(response.NotSupported) > 0 {
+		return true
+	}
+	for _, result := range response.Results {
+		if result.Status != "ok" {
+			return true
+		}
+	}
+	return false
+}
+
+func responseErrorMessage(response xpathResponse) string {
+	if response.ErrorMessage != "" {
+		return response.ErrorMessage
+	}
+	return response.Error
+}
+
+func queryResultFailed(result *QueryXPathsResult) bool {
+	if result == nil || result.Status != "ok" {
+		return true
+	}
+	for _, unsupported := range result.NotSupported {
+		if len(unsupported) > 0 {
+			return true
+		}
+	}
+	for _, status := range result.Results {
+		if status.Status != "ok" {
+			return true
+		}
+	}
+	return false
+}
+
+func setResultFailed(result *SetXPathsResult) bool {
+	if result == nil || result.Status != "ok" {
+		return true
+	}
+	for _, status := range result.Results {
+		if status.Status != "ok" {
+			return true
+		}
+	}
+	return false
+}
+
+func resultErrorMessage(result *QueryXPathsResult) string {
+	if result == nil {
+		return ""
+	}
+	return result.ErrorMessage
+}
+
+func setResultErrorMessage(result *SetXPathsResult) string {
+	if result == nil {
+		return ""
+	}
+	return result.ErrorMessage
+}
+
+func xpathCommandError(operation, target string, output []byte, detail string, commandErr error) error {
+	if detail == "" {
+		detail = strings.TrimSpace(string(output))
+	}
+	if detail != "" {
+		return fmt.Errorf("%s XPaths on target %q: %w: %s", operation, target, commandErr, detail)
+	}
+	return fmt.Errorf("%s XPaths on target %q: %w", operation, target, commandErr)
+}

--- a/pkg/dmscli/xpath_test.go
+++ b/pkg/dmscli/xpath_test.go
@@ -1,0 +1,312 @@
+/*
+Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dmscli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("typed XPath operations", func() {
+	const target = "pci/0000:64:00.0"
+
+	var commands []recordedCommand
+
+	BeforeEach(func() {
+		commands = nil
+	})
+
+	Describe("QueryXPaths", func() {
+		It("batches query paths and decodes keyed values", func() {
+			executor := fakeExecutor([]byte(`{
+				"/nvidia/link/ipg":{"status":"ok","values":{"admin":25}},
+				"/nvidia/link/physical":{"status":"ok","values":{"admin-status":"up"}}
+			}`), nil, &commands)
+
+			result, err := QueryXPaths(context.Background(), executor, target, []XPathQuery{
+				{Path: "/nvidia/link/ipg", Leaves: []string{"admin"}},
+				{Path: "/nvidia/link/physical", Leaves: []string{"admin-status"}},
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Status).To(Equal("ok"))
+			Expect(result.Values).To(HaveKeyWithValue("/nvidia/link/ipg", map[string]any{"admin": json.Number("25")}))
+			Expect(result.Values).To(HaveKeyWithValue("/nvidia/link/physical", map[string]any{"admin-status": "up"}))
+			Expect(result.NotSupported).To(BeEmpty())
+			Expect(commands).To(HaveLen(1))
+			Expect(commands[0].args).To(Equal([]string{
+				"--json", "-t", target,
+				"/nvidia/link/ipg", "admin",
+				";", "/nvidia/link/physical", "admin-status",
+			}))
+		})
+
+		It("decodes one unkeyed query response", func() {
+			executor := fakeExecutor([]byte(`{"status":"ok","values":{"enabled":true}}`), nil, &commands)
+
+			result, err := QueryXPaths(context.Background(), executor, target, []XPathQuery{
+				{Path: "/nvidia/data-direct", Leaves: []string{"enabled"}},
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Values).To(Equal(map[string]map[string]any{
+				"/nvidia/data-direct": {"enabled": true},
+			}))
+		})
+
+		It("decodes the documented flat single-container JSON response", func() {
+			executor := fakeExecutor([]byte(`{"operating-mode":"dpu"}`), nil, &commands)
+
+			result, err := QueryXPaths(context.Background(), executor, target, []XPathQuery{
+				{Path: "/nvidia/mode", Leaves: []string{"operating-mode"}},
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Values).To(Equal(map[string]map[string]any{
+				"/nvidia/mode": {"operating-mode": "dpu"},
+			}))
+		})
+
+		It("does not confuse a flat status leaf with response metadata", func() {
+			executor := fakeExecutor([]byte(`{"status":"ready"}`), nil, &commands)
+
+			result, err := QueryXPaths(context.Background(), executor, target, []XPathQuery{
+				{Path: "/nvidia/reset", Leaves: []string{"status"}},
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Values).To(Equal(map[string]map[string]any{
+				"/nvidia/reset": {"status": "ready"},
+			}))
+		})
+
+		It("decodes flat values nested below keyed query paths", func() {
+			executor := fakeExecutor([]byte(`{
+				"/nvidia/pci":{"sriov-enabled":true},
+				"/nvidia/roce":{"adaptive-routing":true}
+			}`), nil, &commands)
+
+			result, err := QueryXPaths(context.Background(), executor, target, []XPathQuery{
+				{Path: "/nvidia/pci", Leaves: []string{"sriov-enabled"}},
+				{Path: "/nvidia/roce", Leaves: []string{"adaptive-routing"}},
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Values).To(HaveKeyWithValue("/nvidia/pci", map[string]any{"sriov-enabled": true}))
+			Expect(result.Values).To(HaveKeyWithValue("/nvidia/roce", map[string]any{"adaptive-routing": true}))
+		})
+
+		It("returns capability filtering as a query error", func() {
+			executor := fakeExecutor([]byte(`{
+				"status":"ok",
+				"values":{"adaptive-routing":true},
+				"not-supported":["cc-steering-ext"]
+			}`), nil, &commands)
+
+			result, err := QueryXPaths(context.Background(), executor, target, []XPathQuery{
+				{Path: "/nvidia/roce", Leaves: []string{"adaptive-routing", "cc-steering-ext"}},
+			})
+
+			Expect(result.Status).To(Equal("partial"))
+			Expect(result.NotSupported).To(HaveKeyWithValue("/nvidia/roce", []string{"cc-steering-ext"}))
+			Expect(err).To(MatchError(ContainSubstring("unexpected status \"partial\"")))
+		})
+
+		It("preserves a structured partial result and command error", func() {
+			commandErr := errors.New("exit status 10")
+			executor := fakeExecutor([]byte(`{
+				"status":"partial",
+				"results":[
+					{"path":"/nvidia/mode/operating-mode","status":"error","error_code":4,"error":"not-supported"},
+					{"path":"/nvidia/pci/sriov-enabled","status":"ok"}
+				]
+			}`), commandErr, &commands)
+
+			result, err := QueryXPaths(context.Background(), executor, target, []XPathQuery{
+				{Path: "/nvidia/mode", Leaves: []string{"operating-mode"}},
+				{Path: "/nvidia/pci", Leaves: []string{"sriov-enabled"}},
+			})
+
+			Expect(result.Status).To(Equal("partial"))
+			Expect(result.Results).To(HaveLen(2))
+			Expect(errors.Is(err, commandErr)).To(BeTrue())
+		})
+
+		It("normalizes mixed keyed query results as partial", func() {
+			executor := fakeExecutor([]byte(`{
+				"/nvidia/pci":{"status":"ok","values":{"sriov-enabled":true}},
+				"/nvidia/lag":{"status":"error","error":"not-supported","values":{}}
+			}`), nil, &commands)
+
+			result, err := QueryXPaths(context.Background(), executor, target, []XPathQuery{
+				{Path: "/nvidia/pci", Leaves: []string{"sriov-enabled"}},
+				{Path: "/nvidia/lag", Leaves: []string{"resource-allocation"}},
+			})
+
+			Expect(result.Status).To(Equal("partial"))
+			Expect(result.Values).To(HaveKey("/nvidia/pci"))
+			Expect(result.Values).To(HaveKey("/nvidia/lag"))
+			Expect(err).To(MatchError(ContainSubstring("not-supported")))
+		})
+
+		DescribeTable("validates query input before execution",
+			func(targetValue string, queries []XPathQuery, expected string) {
+				executor := fakeExecutor([]byte(`{"status":"ok","values":{}}`), nil, &commands)
+
+				result, err := QueryXPaths(context.Background(), executor, targetValue, queries)
+
+				Expect(result).To(BeNil())
+				Expect(err).To(MatchError(ContainSubstring(expected)))
+				Expect(commands).To(BeEmpty())
+			},
+			Entry("empty target", "", []XPathQuery{{Path: "/nvidia/pci", Leaves: []string{"num-pfs"}}}, "target"),
+			Entry("no paths", target, nil, "at least one path"),
+			Entry("invalid path", target, []XPathQuery{{Path: "nvidia/pci", Leaves: []string{"num-pfs"}}}, "absolute /nvidia"),
+			Entry("no leaves", target, []XPathQuery{{Path: "/nvidia/pci", Leaves: nil}}, "at least one leaf"),
+			Entry("invalid leaf", target, []XPathQuery{{Path: "/nvidia/pci", Leaves: []string{"num/pfs"}}}, "unsupported characters"),
+			Entry("duplicate path", target, []XPathQuery{
+				{Path: "/nvidia/pci", Leaves: []string{"num-pfs"}},
+				{Path: "/nvidia/pci", Leaves: []string{"num-vfs"}},
+			}, "duplicated"),
+			Entry("duplicate leaf", target, []XPathQuery{{Path: "/nvidia/pci", Leaves: []string{"num-pfs", "num-pfs"}}}, "duplicated"),
+		)
+
+		It("rejects a nil command executor", func() {
+			result, err := QueryXPaths(context.Background(), nil, target, []XPathQuery{
+				{Path: "/nvidia/pci", Leaves: []string{"num-pfs"}},
+			})
+
+			Expect(result).To(BeNil())
+			Expect(err).To(MatchError("command executor must not be nil"))
+		})
+	})
+
+	Describe("SetXPaths", func() {
+		It("preserves operation order and expands leaf-lists as repeated assignments", func() {
+			executor := fakeExecutor([]byte(`{"status":"ok"}`), nil, &commands)
+
+			result, err := SetXPaths(context.Background(), executor, target, []XPathOperation{
+				{
+					Path: "/nvidia/roce",
+					Values: map[string]any{
+						"tx-sched-locality-mode": "accumulative",
+						"adaptive-routing":       true,
+					},
+				},
+				{Path: "/nvidia/link/physical", Values: map[string]any{"admin-status": "down"}},
+				{Path: "/nvidia/link/physical", Values: map[string]any{"admin-status": "up"}},
+				{Path: "/nvidia/link/breakout/module/[0]/port/[1]", Values: map[string]any{"lanes": []int{0, 1, 2, 3}}},
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Status).To(Equal("ok"))
+			Expect(commands).To(HaveLen(1))
+			Expect(commands[0].args).To(Equal([]string{
+				"--json", "-t", target,
+				"/nvidia/roce", "adaptive-routing=true", "tx-sched-locality-mode=accumulative",
+				";", "/nvidia/link/physical", "admin-status=down",
+				";", "/nvidia/link/physical", "admin-status=up",
+				";", "/nvidia/link/breakout/module/[0]/port/[1]", "lanes=0", "lanes=1", "lanes=2", "lanes=3",
+			}))
+		})
+
+		It("returns a partial set result with the command error", func() {
+			commandErr := errors.New("exit status 10")
+			executor := fakeExecutor([]byte(`{
+				"status":"partial",
+				"results":[
+					{"path":"/nvidia/roce/cc-steering-ext","status":"error","error_code":4,"error":"not-supported"},
+					{"path":"/nvidia/roce/adaptive-routing","status":"ok"}
+				]
+			}`), commandErr, &commands)
+
+			result, err := SetXPaths(context.Background(), executor, target, []XPathOperation{
+				{Path: "/nvidia/roce", Values: map[string]any{"adaptive-routing": true, "cc-steering-ext": "enabled"}},
+			})
+
+			Expect(result.Status).To(Equal("partial"))
+			Expect(result.Results).To(HaveLen(2))
+			Expect(errors.Is(err, commandErr)).To(BeTrue())
+		})
+
+		It("normalizes keyed multi-container statuses", func() {
+			executor := fakeExecutor([]byte(`{
+				"/nvidia/pci":{"status":"ok"},
+				"/nvidia/lag":{"status":"error","error":"not-supported"}
+			}`), nil, &commands)
+
+			result, err := SetXPaths(context.Background(), executor, target, []XPathOperation{
+				{Path: "/nvidia/pci", Values: map[string]any{"sriov-enabled": true}},
+				{Path: "/nvidia/lag", Values: map[string]any{"resource-allocation": "pre-allocation"}},
+			})
+
+			Expect(result.Status).To(Equal("partial"))
+			Expect(result.Results).To(HaveLen(2))
+			Expect(err).To(MatchError(ContainSubstring("not-supported")))
+		})
+
+		It("logs the exact command and combined output", func() {
+			executor := fakeExecutor([]byte(`{"status":"ok"}`), nil, &commands)
+			entries := []capturedLogEntry{}
+			ctx := logr.NewContext(context.Background(), logr.New(&capturingLogSink{entries: &entries}))
+
+			_, err := SetXPaths(ctx, executor, target, []XPathOperation{
+				{Path: "/nvidia/pci", Values: map[string]any{"num-pfs": 2}},
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(entries).To(HaveLen(1))
+			Expect(entries[0].fields).To(HaveKeyWithValue("command", append([]string{dmsCLIExecutable}, commands[0].args...)))
+			Expect(entries[0].fields).To(HaveKeyWithValue("target", target))
+			Expect(entries[0].fields).To(HaveKeyWithValue("output", `{"status":"ok"}`))
+		})
+
+		DescribeTable("rejects invalid set input before execution",
+			func(targetValue string, operations []XPathOperation, expected string) {
+				executor := fakeExecutor([]byte(`{"status":"ok"}`), nil, &commands)
+
+				result, err := SetXPaths(context.Background(), executor, targetValue, operations)
+
+				Expect(result).To(BeNil())
+				Expect(err).To(MatchError(ContainSubstring(expected)))
+				Expect(commands).To(BeEmpty())
+			},
+			Entry("empty target", "", []XPathOperation{{Path: "/nvidia/pci", Values: map[string]any{"num-pfs": 2}}}, "target"),
+			Entry("no operations", target, nil, "at least one operation"),
+			Entry("invalid path", target, []XPathOperation{{Path: "nvidia/pci", Values: map[string]any{"num-pfs": 2}}}, "absolute /nvidia"),
+			Entry("no values", target, []XPathOperation{{Path: "/nvidia/pci", Values: nil}}, "at least one value"),
+			Entry("invalid leaf", target, []XPathOperation{{Path: "/nvidia/pci", Values: map[string]any{"num/pfs": 2}}}, "unsupported characters"),
+			Entry("null value", target, []XPathOperation{{Path: "/nvidia/pci", Values: map[string]any{"num-pfs": nil}}}, "must not be null"),
+			Entry("object value", target, []XPathOperation{{Path: "/nvidia/pci", Values: map[string]any{"num-pfs": map[string]any{"value": 2}}}}, "string, boolean, or number"),
+			Entry("empty array", target, []XPathOperation{{Path: "/nvidia/pci", Values: map[string]any{"num-pfs": []int{}}}}, "at least one value"),
+			Entry("nested array", target, []XPathOperation{{Path: "/nvidia/pci", Values: map[string]any{"num-pfs": [][]int{{2}}}}}, "string, boolean, or number"),
+		)
+
+		It("rejects a nil command executor", func() {
+			result, err := SetXPaths(context.Background(), nil, target, []XPathOperation{
+				{Path: "/nvidia/pci", Values: map[string]any{"num-pfs": 2}},
+			})
+
+			Expect(result).To(BeNil())
+			Expect(err).To(MatchError("command executor must not be nil"))
+		})
+	})
+})

--- a/pkg/spectrumx/prepareplan.go
+++ b/pkg/spectrumx/prepareplan.go
@@ -55,9 +55,10 @@ const (
 
 // Plan is a generated doSPCX plan retrieved from the local plan store.
 type Plan struct {
-	Name  string
-	Stage PlanStage
-	JSON  json.RawMessage
+	Name     string
+	Stage    PlanStage
+	JSON     json.RawMessage
+	Semantic *SemanticPlan
 }
 
 // PlanManager owns doSPCX target-map construction, plan generation, caching,
@@ -216,7 +217,7 @@ func (m *spectrumXConfigManager) PreparePlan(
 	if err != nil {
 		return err
 	}
-	if err := validateGeneratedPlan(result.PlanJSON, generatedPlanName, config, string(stage)); err != nil {
+	if _, err := validateGeneratedPlan(result.PlanJSON, generatedPlanName, config, string(stage)); err != nil {
 		return err
 	}
 
@@ -334,11 +335,17 @@ func (m *spectrumXConfigManager) GetPreparedPlan(device *v1alpha1.NicDevice, sta
 		targetMap:     savedTargetMap,
 		selectedCount: len(savedTargetMap.PreBreakout.Targets),
 	}
-	if err := validateGeneratedPlan(planContent, generatedPlanName, savedConfig, string(stage)); err != nil {
+	semanticPlan, err := validateGeneratedPlan(planContent, generatedPlanName, savedConfig, string(stage))
+	if err != nil {
 		return nil, fmt.Errorf("validate cached doSPCX %s plan: %w", stage, err)
 	}
 
-	return &Plan{Name: generatedPlanName, Stage: stage, JSON: append(json.RawMessage(nil), planContent...)}, nil
+	return &Plan{
+		Name:     generatedPlanName,
+		Stage:    stage,
+		JSON:     append(json.RawMessage(nil), planContent...),
+		Semantic: semanticPlan,
+	}, nil
 }
 
 func planParameters(config *planConfig) ([]string, error) {
@@ -445,7 +452,7 @@ func reusablePlan(
 	if err != nil {
 		return false, fmt.Sprintf("read plan: %v", err)
 	}
-	if err := validateGeneratedPlan(planContent, expectedMetadata.PlanName, config, expectedMetadata.Stage); err != nil {
+	if _, err := validateGeneratedPlan(planContent, expectedMetadata.PlanName, config, expectedMetadata.Stage); err != nil {
 		return false, fmt.Sprintf("validate plan: %v", err)
 	}
 	return true, ""
@@ -639,7 +646,12 @@ func boundedPlanName(name string) string {
 	return strings.TrimRight(name[:prefixLength], ".-") + "-" + hash
 }
 
-func validateGeneratedPlan(planJSON []byte, expectedName string, config *planConfig, expectedStage string) error {
+func validateGeneratedPlan(
+	planJSON []byte,
+	expectedName string,
+	config *planConfig,
+	expectedStage string,
+) (*SemanticPlan, error) {
 	var document struct {
 		Plan struct {
 			Name    string `json:"name"`
@@ -666,46 +678,50 @@ func validateGeneratedPlan(planJSON []byte, expectedName string, config *planCon
 		} `json:"artifacts"`
 	}
 	if err := json.Unmarshal(planJSON, &document); err != nil {
-		return fmt.Errorf("decode generated doSPCX %s plan: %w", expectedStage, err)
+		return nil, fmt.Errorf("decode generated doSPCX %s plan: %w", expectedStage, err)
 	}
 	if document.Plan.Name != expectedName {
-		return fmt.Errorf("generated doSPCX plan name is %q, expected %q", document.Plan.Name, expectedName)
+		return nil, fmt.Errorf("generated doSPCX plan name is %q, expected %q", document.Plan.Name, expectedName)
 	}
 	if document.Plan.Family != "spcx" {
-		return fmt.Errorf("generated doSPCX plan family is %q, expected %q", document.Plan.Family, "spcx")
+		return nil, fmt.Errorf("generated doSPCX plan family is %q, expected %q", document.Plan.Family, "spcx")
 	}
 	if document.Plan.Profile != config.profile {
-		return fmt.Errorf("generated doSPCX plan profile is %q, expected %q", document.Plan.Profile, config.profile)
+		return nil, fmt.Errorf("generated doSPCX plan profile is %q, expected %q", document.Plan.Profile, config.profile)
 	}
 	if document.Plan.Stage != expectedStage {
-		return fmt.Errorf("generated doSPCX plan stage is %q, expected %q", document.Plan.Stage, expectedStage)
+		return nil, fmt.Errorf("generated doSPCX plan stage is %q, expected %q", document.Plan.Stage, expectedStage)
 	}
 	if document.Plan.Params.DeploymentMode != deploymentModeHostK8s {
-		return fmt.Errorf("generated doSPCX plan deployment mode is %q, expected %q", document.Plan.Params.DeploymentMode, deploymentModeHostK8s)
+		return nil, fmt.Errorf("generated doSPCX plan deployment mode is %q, expected %q", document.Plan.Params.DeploymentMode, deploymentModeHostK8s)
 	}
 	if document.Plan.Params.Planes != config.planes {
-		return fmt.Errorf("generated doSPCX plan plane count is %d, expected %d", document.Plan.Params.Planes, config.planes)
+		return nil, fmt.Errorf("generated doSPCX plan plane count is %d, expected %d", document.Plan.Params.Planes, config.planes)
 	}
 	if document.Plan.DetectedHW.PlatformType != config.platformType {
-		return fmt.Errorf("generated doSPCX plan platform type is %q, expected %q", document.Plan.DetectedHW.PlatformType, config.platformType)
+		return nil, fmt.Errorf("generated doSPCX plan platform type is %q, expected %q", document.Plan.DetectedHW.PlatformType, config.platformType)
 	}
 	if document.Plan.Semantic == nil || len(document.Plan.Semantic.Groups) == 0 {
-		return fmt.Errorf("generated doSPCX %s plan does not contain semantic groups", expectedStage)
+		return nil, fmt.Errorf("generated doSPCX %s plan does not contain semantic groups", expectedStage)
 	}
 	if document.Plan.BareMetal != nil && len(document.Plan.BareMetal.Groups) > 0 {
-		return fmt.Errorf("generated doSPCX %s plan unexpectedly contains bare-metal groups", expectedStage)
+		return nil, fmt.Errorf("generated doSPCX %s plan unexpectedly contains bare-metal groups", expectedStage)
 	}
 	if len(document.Artifacts.Manifest) > 0 {
-		return fmt.Errorf("generated doSPCX %s plan unexpectedly contains rendered artifacts", expectedStage)
+		return nil, fmt.Errorf("generated doSPCX %s plan unexpectedly contains rendered artifacts", expectedStage)
 	}
 	expectedDeviceCount := config.selectedCount
 	if expectedStage == string(PlanStageConfigure) {
 		expectedDeviceCount *= config.planes
 	}
 	if len(document.Plan.Devices) != expectedDeviceCount {
-		return fmt.Errorf("generated doSPCX %s plan has %d devices, expected %d", expectedStage, len(document.Plan.Devices), expectedDeviceCount)
+		return nil, fmt.Errorf("generated doSPCX %s plan has %d devices, expected %d", expectedStage, len(document.Plan.Devices), expectedDeviceCount)
 	}
-	return nil
+	semanticPlan, err := ParseSemanticPlan(planJSON, PlanStage(expectedStage))
+	if err != nil {
+		return nil, fmt.Errorf("validate generated doSPCX %s semantic plan: %w", expectedStage, err)
+	}
+	return semanticPlan, nil
 }
 
 func writeJSONFileAtomic(path string, value any) error {

--- a/pkg/spectrumx/prepareplan_test.go
+++ b/pkg/spectrumx/prepareplan_test.go
@@ -18,6 +18,7 @@ package spectrumx
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -155,7 +156,38 @@ var _ = Describe("doSPCX planning", func() {
 	planResponseForPlatform := func(name, profile, stage, platform string, planes, deviceCount int) []byte {
 		devices := make([]map[string]any, deviceCount)
 		for index := range devices {
-			devices[index] = map[string]any{"bdf": index}
+			bdf := fmt.Sprintf("0000:%02x:00.0", index+1)
+			devices[index] = map[string]any{
+				"bdf":        bdf,
+				"dms_target": "pci/" + bdf,
+				"network":    "ew",
+				"rail":       index,
+				"plane":      0,
+			}
+		}
+		groupName := "breakout"
+		groups := []any{}
+		if stage == configureStage {
+			groupName = "link-runtime"
+		}
+		operationID := "test." + groupName
+		groups = append(groups, map[string]any{
+			"name":           groupName,
+			"stage":          stage,
+			"order":          10,
+			"scope":          "per_device",
+			"operation_refs": []string{operationID},
+		})
+		if stage == prepareStage {
+			groups = append(groups, map[string]any{
+				"name":            "post-breakout",
+				"stage":           stage,
+				"order":           20,
+				"scope":           "mixed",
+				"device_view":     "post_breakout",
+				"requires_reboot": true,
+				"operation_refs":  []string{},
+			})
 		}
 		response, err := json.Marshal(map[string]any{
 			"plan":    name,
@@ -164,14 +196,27 @@ var _ = Describe("doSPCX planning", func() {
 			"stage":   stage,
 			"plan-json": map[string]any{
 				"plan": map[string]any{
-					"name":        name,
-					"family":      "spcx",
-					"profile":     profile,
-					"stage":       stage,
-					"params":      map[string]any{"deployment_mode": "host-k8s", "planes": planes},
-					"detected_hw": map[string]any{"platform_type": platform},
-					"devices":     devices,
-					"semantic":    map[string]any{"groups": []any{map[string]any{"name": stage}}},
+					"name":         name,
+					"family":       "spcx",
+					"profile":      profile,
+					"stage":        stage,
+					"path_dialect": semanticPathDialect,
+					"params":       map[string]any{"deployment_mode": "host-k8s", "planes": planes},
+					"detected_hw":  map[string]any{"platform_type": platform},
+					"devices":      devices,
+					"runtime_ctx":  map[string]any{"deployment_mode": "host-k8s", "rdma_topology": "per_pf"},
+					"operations": map[string]any{
+						operationID: map[string]any{
+							"path":            "/nvidia/test",
+							"values":          map[string]any{"enabled": true},
+							"source_feature":  "test",
+							"kind":            "set",
+							"target_class":    "pf_netdev_all",
+							"target_role":     "ew",
+							"execution_group": groupName,
+						},
+					},
+					"semantic": map[string]any{"groups": groups},
 				},
 				"artifacts": map[string]any{"manifest": []any{}},
 			},
@@ -203,6 +248,8 @@ var _ = Describe("doSPCX planning", func() {
 		Expect(plan.Name).To(Equal(planName))
 		Expect(plan.Stage).To(Equal(PlanStagePrepare))
 		Expect(plan.JSON).NotTo(BeEmpty())
+		Expect(plan.Semantic).NotTo(BeNil())
+		Expect(plan.Semantic.Groups).To(HaveLen(2))
 		planPath := filepath.Join(stateDir, "plans", planName, "plan.json")
 		planContent, err := os.ReadFile(planPath)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/spectrumx/semanticplan.go
+++ b/pkg/spectrumx/semanticplan.go
@@ -1,0 +1,730 @@
+/*
+Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spectrumx
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/go-logr/logr"
+
+	"github.com/Mellanox/nic-configuration-operator/pkg/dmscli"
+)
+
+const (
+	semanticPathDialect = "nvidia-t1"
+
+	targetClassPFNetdevAll   = "pf_netdev_all"
+	targetClassPFRDMAScope   = "pf_rdma_scope"
+	targetClassPerESwitch    = "per_eswitch"
+	targetClassVFRepresentor = "vf_rep"
+
+	rdmaTopologyPerPF       = "per_pf"
+	rdmaTopologyPerRailBond = "per_rail_bond"
+)
+
+// PlanDevice is one DMS-addressable device emitted by the doSPCX planner.
+type PlanDevice struct {
+	BDF            string   `json:"bdf"`
+	DeviceID       string   `json:"device_id"`
+	HCAType        string   `json:"hca_type"`
+	Netdev         string   `json:"netdev"`
+	RDMADevice     string   `json:"rdma_dev"`
+	DMSTarget      string   `json:"dms_target"`
+	PFIndex        int      `json:"pf_index"`
+	Rail           int      `json:"rail"`
+	Plane          int      `json:"plane"`
+	PlaneExplicit  bool     `json:"plane_explicit"`
+	Network        string   `json:"network"`
+	PhysicalLabel  string   `json:"physical_label"`
+	ResetDomain    string   `json:"reset_domain"`
+	EndpointLabels []string `json:"endpoint_labels"`
+	TargetID       string   `json:"target_id"`
+}
+
+// ExpectedRDMA identifies the control target selected for one rail.
+type ExpectedRDMA struct {
+	Rail          int    `json:"rail"`
+	RDMADevice    string `json:"rdma_dev"`
+	ControlBDF    string `json:"control_bdf"`
+	ControlTarget string `json:"control_target"`
+	Source        string `json:"source"`
+}
+
+// SemanticRuntimeContext contains topology needed to resolve semantic target
+// classes without interpreting rendered bare-metal artifacts.
+type SemanticRuntimeContext struct {
+	DeploymentMode   string         `json:"deployment_mode"`
+	MultiplaneMode   string         `json:"multiplane_mode"`
+	ESwitchMultiport bool           `json:"esw_multiport"`
+	NumVFs           int            `json:"num_vfs"`
+	PostBreakout     bool           `json:"post_breakout"`
+	RDMATopology     string         `json:"rdma_topology"`
+	ExpectedRDMA     []ExpectedRDMA `json:"expected_rdma"`
+}
+
+// ResetPolicy records the reset boundary associated with a semantic operation.
+type ResetPolicy struct {
+	Action        string `json:"action"`
+	Owner         string `json:"owner"`
+	Postcondition string `json:"postcondition"`
+}
+
+// SemanticOperation is one referenced typed operation from plan.operations.
+type SemanticOperation struct {
+	ID             string
+	Path           string
+	Values         map[string]any
+	SourceFeature  string
+	Kind           string
+	TargetClass    string
+	TargetRole     string
+	ExecutionGroup string
+	Scope          string
+	Lifecycle      string
+	Reset          *ResetPolicy
+	Condition      json.RawMessage
+	Context        json.RawMessage
+}
+
+// SemanticGroup preserves the planner's ordered semantic execution boundary.
+type SemanticGroup struct {
+	Name           string
+	Stage          PlanStage
+	Order          int
+	Scope          string
+	DeviceView     string
+	FanoutOrder    string
+	RequiresReboot bool
+	Operations     []SemanticOperation
+}
+
+// SemanticPlan is the NCO-facing doSPCX plan surface. It intentionally omits
+// bare-metal steps, services, and rendered artifacts.
+type SemanticPlan struct {
+	Name           string
+	Profile        string
+	Stage          PlanStage
+	PathDialect    string
+	Devices        []PlanDevice
+	RuntimeContext SemanticRuntimeContext
+	Groups         []SemanticGroup
+}
+
+// DMSOperationPlan contains ordered, target-resolved operations ready for the
+// generic dms-cli query/set transport. It does not execute any operation.
+type DMSOperationPlan struct {
+	Stage         PlanStage
+	Groups        []DMSOperationGroup
+	SkippedGroups []SkippedSemanticGroup
+}
+
+// DMSOperationGroup is one executable group or ordered phase marker.
+type DMSOperationGroup struct {
+	Name           string
+	Order          int
+	Scope          string
+	DeviceView     string
+	RequiresReboot bool
+	PhaseMarker    bool
+	Targets        []DMSTargetOperations
+}
+
+// DMSTargetOperations contains the ordered SET sequence and the final desired
+// values to query for one DMS target.
+type DMSTargetOperations struct {
+	Target     string
+	Queries    []dmscli.XPathQuery
+	Desired    []dmscli.XPathOperation
+	Operations []dmscli.XPathOperation
+}
+
+// SkippedSemanticGroup records an intentional execution-policy exclusion.
+type SkippedSemanticGroup struct {
+	Name   string
+	Order  int
+	Reason string
+}
+
+type semanticPlanDocument struct {
+	Plan struct {
+		Name        string `json:"name"`
+		Family      string `json:"family"`
+		Profile     string `json:"profile"`
+		Stage       string `json:"stage"`
+		PathDialect string `json:"path_dialect"`
+		Params      struct {
+			DeploymentMode string `json:"deployment_mode"`
+		} `json:"params"`
+		Devices        []PlanDevice                       `json:"devices"`
+		RuntimeContext SemanticRuntimeContext             `json:"runtime_ctx"`
+		Operations     map[string]semanticOperationRecord `json:"operations"`
+		Semantic       *struct {
+			Groups []semanticGroupRecord `json:"groups"`
+		} `json:"semantic"`
+	} `json:"plan"`
+}
+
+type semanticGroupRecord struct {
+	Name           string   `json:"name"`
+	Stage          string   `json:"stage"`
+	Order          int      `json:"order"`
+	Scope          string   `json:"scope"`
+	DeviceView     string   `json:"device_view"`
+	FanoutOrder    string   `json:"fanout_order"`
+	RequiresReboot bool     `json:"requires_reboot"`
+	OperationRefs  []string `json:"operation_refs"`
+}
+
+type semanticOperationRecord struct {
+	Path           string          `json:"path"`
+	Values         map[string]any  `json:"values"`
+	SourceFeature  string          `json:"source_feature"`
+	Kind           string          `json:"kind"`
+	TargetClass    string          `json:"target_class"`
+	TargetRole     string          `json:"target_role"`
+	ExecutionGroup string          `json:"execution_group"`
+	Scope          string          `json:"scope"`
+	Lifecycle      string          `json:"lifecycle"`
+	Reset          *ResetPolicy    `json:"reset"`
+	Condition      json.RawMessage `json:"condition"`
+	Context        json.RawMessage `json:"context"`
+}
+
+// ParseSemanticPlan parses and validates the semantic consumer surface of a
+// generated host-k8s doSPCX plan.
+func ParseSemanticPlan(planJSON json.RawMessage, expectedStage PlanStage) (*SemanticPlan, error) {
+	if err := validatePlanStage(expectedStage); err != nil {
+		return nil, err
+	}
+	if len(bytes.TrimSpace(planJSON)) == 0 {
+		return nil, fmt.Errorf("doSPCX plan must not be empty")
+	}
+
+	var document semanticPlanDocument
+	decoder := json.NewDecoder(bytes.NewReader(planJSON))
+	decoder.UseNumber()
+	if err := decoder.Decode(&document); err != nil {
+		return nil, fmt.Errorf("decode doSPCX semantic plan: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return nil, fmt.Errorf("decode doSPCX semantic plan: trailing JSON data")
+		}
+		return nil, fmt.Errorf("decode doSPCX semantic plan trailing data: %w", err)
+	}
+
+	if err := validateSemanticPlanHeader(&document, expectedStage); err != nil {
+		return nil, err
+	}
+	if err := validatePlanDevices(document.Plan.Devices); err != nil {
+		return nil, err
+	}
+
+	groups, err := resolveSemanticGroups(
+		document.Plan.Semantic.Groups,
+		document.Plan.Operations,
+		expectedStage,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SemanticPlan{
+		Name:           document.Plan.Name,
+		Profile:        document.Plan.Profile,
+		Stage:          expectedStage,
+		PathDialect:    document.Plan.PathDialect,
+		Devices:        append([]PlanDevice(nil), document.Plan.Devices...),
+		RuntimeContext: document.Plan.RuntimeContext,
+		Groups:         groups,
+	}, nil
+}
+
+// BuildDMSOperationPlan applies NCO execution policy and resolves semantic
+// target classes. The eswitch and vf-lifecycle groups are intentionally skipped
+// in this phase; unknown groups fail closed.
+func (p *SemanticPlan) BuildDMSOperationPlan(ctx context.Context) (*DMSOperationPlan, error) {
+	if p == nil {
+		return nil, fmt.Errorf("semantic plan must not be nil")
+	}
+	if err := validatePlanStage(p.Stage); err != nil {
+		return nil, err
+	}
+
+	result := &DMSOperationPlan{
+		Stage:         p.Stage,
+		Groups:        make([]DMSOperationGroup, 0, len(p.Groups)),
+		SkippedGroups: nil,
+	}
+	for _, group := range p.Groups {
+		disposition, reason, err := semanticGroupDisposition(p.Stage, group.Name)
+		if err != nil {
+			return nil, err
+		}
+		switch disposition {
+		case groupDispositionSkip:
+			skipped := SkippedSemanticGroup{Name: group.Name, Order: group.Order, Reason: reason}
+			result.SkippedGroups = append(result.SkippedGroups, skipped)
+			logr.FromContextOrDiscard(ctx).V(2).Info("skipping doSPCX semantic group",
+				"plan", p.Name,
+				"stage", p.Stage,
+				"group", group.Name,
+				"order", group.Order,
+				"reason", reason)
+			continue
+		case groupDispositionMarker:
+			if len(group.Operations) != 0 {
+				return nil, fmt.Errorf("doSPCX semantic phase marker %q unexpectedly contains operations", group.Name)
+			}
+			result.Groups = append(result.Groups, DMSOperationGroup{
+				Name:           group.Name,
+				Order:          group.Order,
+				Scope:          group.Scope,
+				DeviceView:     group.DeviceView,
+				RequiresReboot: group.RequiresReboot,
+				PhaseMarker:    true,
+				Targets:        nil,
+			})
+			continue
+		case groupDispositionExecute:
+			targets, err := p.resolveGroupTargets(group)
+			if err != nil {
+				return nil, fmt.Errorf("resolve doSPCX semantic group %q: %w", group.Name, err)
+			}
+			result.Groups = append(result.Groups, DMSOperationGroup{
+				Name:           group.Name,
+				Order:          group.Order,
+				Scope:          group.Scope,
+				DeviceView:     group.DeviceView,
+				RequiresReboot: group.RequiresReboot,
+				PhaseMarker:    false,
+				Targets:        targets,
+			})
+		default:
+			return nil, fmt.Errorf("unsupported doSPCX semantic group disposition %q", disposition)
+		}
+	}
+	return result, nil
+}
+
+func validateSemanticPlanHeader(document *semanticPlanDocument, expectedStage PlanStage) error {
+	if strings.TrimSpace(document.Plan.Name) == "" {
+		return fmt.Errorf("doSPCX semantic plan name must not be empty")
+	}
+	if document.Plan.Family != "spcx" {
+		return fmt.Errorf("doSPCX semantic plan family is %q, expected %q", document.Plan.Family, "spcx")
+	}
+	if strings.TrimSpace(document.Plan.Profile) == "" {
+		return fmt.Errorf("doSPCX semantic plan profile must not be empty")
+	}
+	if document.Plan.Stage != string(expectedStage) {
+		return fmt.Errorf("doSPCX semantic plan stage is %q, expected %q", document.Plan.Stage, expectedStage)
+	}
+	if document.Plan.Params.DeploymentMode != deploymentModeHostK8s {
+		return fmt.Errorf("doSPCX semantic plan deployment mode is %q, expected %q", document.Plan.Params.DeploymentMode, deploymentModeHostK8s)
+	}
+	if document.Plan.PathDialect != semanticPathDialect {
+		return fmt.Errorf("doSPCX semantic plan path dialect is %q, expected %q", document.Plan.PathDialect, semanticPathDialect)
+	}
+	if len(document.Plan.Devices) == 0 {
+		return fmt.Errorf("doSPCX semantic plan does not contain devices")
+	}
+	if document.Plan.Semantic == nil || len(document.Plan.Semantic.Groups) == 0 {
+		return fmt.Errorf("doSPCX semantic plan does not contain semantic groups")
+	}
+	return nil
+}
+
+func validatePlanDevices(devices []PlanDevice) error {
+	bdfs := make(map[string]struct{}, len(devices))
+	targets := make(map[string]struct{}, len(devices))
+	for index, device := range devices {
+		if strings.TrimSpace(device.BDF) == "" {
+			return fmt.Errorf("doSPCX plan device at index %d has no BDF", index)
+		}
+		if _, found := bdfs[device.BDF]; found {
+			return fmt.Errorf("doSPCX plan device BDF %q is duplicated", device.BDF)
+		}
+		bdfs[device.BDF] = struct{}{}
+		if !strings.HasPrefix(device.DMSTarget, "pci/") || strings.TrimPrefix(device.DMSTarget, "pci/") != device.BDF {
+			return fmt.Errorf("doSPCX plan device %q has invalid DMS target %q", device.BDF, device.DMSTarget)
+		}
+		if _, found := targets[device.DMSTarget]; found {
+			return fmt.Errorf("doSPCX plan DMS target %q is duplicated", device.DMSTarget)
+		}
+		targets[device.DMSTarget] = struct{}{}
+		if strings.TrimSpace(device.Network) == "" {
+			return fmt.Errorf("doSPCX plan device %q has no network role", device.BDF)
+		}
+	}
+	return nil
+}
+
+func resolveSemanticGroups(
+	records []semanticGroupRecord,
+	operations map[string]semanticOperationRecord,
+	expectedStage PlanStage,
+) ([]SemanticGroup, error) {
+	groups := make([]SemanticGroup, 0, len(records))
+	names := make(map[string]struct{}, len(records))
+	for groupIndex, record := range records {
+		if strings.TrimSpace(record.Name) == "" {
+			return nil, fmt.Errorf("doSPCX semantic group at index %d has no name", groupIndex)
+		}
+		if _, found := names[record.Name]; found {
+			return nil, fmt.Errorf("doSPCX semantic group %q is duplicated", record.Name)
+		}
+		names[record.Name] = struct{}{}
+		if record.Stage != string(expectedStage) {
+			return nil, fmt.Errorf("doSPCX semantic group %q stage is %q, expected %q", record.Name, record.Stage, expectedStage)
+		}
+
+		group := SemanticGroup{
+			Name:           record.Name,
+			Stage:          expectedStage,
+			Order:          record.Order,
+			Scope:          record.Scope,
+			DeviceView:     record.DeviceView,
+			FanoutOrder:    record.FanoutOrder,
+			RequiresReboot: record.RequiresReboot,
+			Operations:     make([]SemanticOperation, 0, len(record.OperationRefs)),
+		}
+		refs := make(map[string]struct{}, len(record.OperationRefs))
+		for refIndex, ref := range record.OperationRefs {
+			if strings.TrimSpace(ref) == "" {
+				return nil, fmt.Errorf("doSPCX semantic group %q operation reference at index %d is empty", record.Name, refIndex)
+			}
+			if _, found := refs[ref]; found {
+				return nil, fmt.Errorf("doSPCX semantic group %q operation reference %q is duplicated", record.Name, ref)
+			}
+			refs[ref] = struct{}{}
+			operation, found := operations[ref]
+			if !found {
+				return nil, fmt.Errorf("doSPCX semantic group %q references missing operation %q", record.Name, ref)
+			}
+			if operation.TargetClass == "" {
+				operation.TargetClass = targetClassPFNetdevAll
+			}
+			if err := validateSemanticOperation(ref, record.Name, operation); err != nil {
+				return nil, err
+			}
+			group.Operations = append(group.Operations, SemanticOperation{
+				ID:             ref,
+				Path:           operation.Path,
+				Values:         cloneValueMap(operation.Values),
+				SourceFeature:  operation.SourceFeature,
+				Kind:           operation.Kind,
+				TargetClass:    operation.TargetClass,
+				TargetRole:     operation.TargetRole,
+				ExecutionGroup: operation.ExecutionGroup,
+				Scope:          operation.Scope,
+				Lifecycle:      operation.Lifecycle,
+				Reset:          operation.Reset,
+				Condition:      append(json.RawMessage(nil), operation.Condition...),
+				Context:        append(json.RawMessage(nil), operation.Context...),
+			})
+		}
+		groups = append(groups, group)
+	}
+
+	sort.SliceStable(groups, func(left, right int) bool {
+		return groups[left].Order < groups[right].Order
+	})
+	return groups, nil
+}
+
+func validateSemanticOperation(id, group string, operation semanticOperationRecord) error {
+	if operation.Kind != "set" {
+		return fmt.Errorf("doSPCX semantic operation %q has unsupported kind %q", id, operation.Kind)
+	}
+	if operation.ExecutionGroup != group {
+		return fmt.Errorf("doSPCX semantic operation %q belongs to group %q, not %q", id, operation.ExecutionGroup, group)
+	}
+	if !strings.HasPrefix(operation.Path, "/nvidia/") || strings.ContainsAny(operation.Path, " \t\r\n;") {
+		return fmt.Errorf("doSPCX semantic operation %q has invalid path %q", id, operation.Path)
+	}
+	if len(operation.Values) == 0 {
+		return fmt.Errorf("doSPCX semantic operation %q has no values", id)
+	}
+	for leaf, value := range operation.Values {
+		if strings.TrimSpace(leaf) == "" || strings.ContainsAny(leaf, "/=; \t\r\n") {
+			return fmt.Errorf("doSPCX semantic operation %q has invalid leaf %q", id, leaf)
+		}
+		if !validSemanticValue(value) {
+			return fmt.Errorf("doSPCX semantic operation %q leaf %q has an unsupported value", id, leaf)
+		}
+	}
+	switch operation.TargetClass {
+	case targetClassPFNetdevAll, targetClassPFRDMAScope, targetClassPerESwitch, targetClassVFRepresentor:
+	default:
+		return fmt.Errorf("doSPCX semantic operation %q has unsupported target class %q", id, operation.TargetClass)
+	}
+	if operation.TargetClass != targetClassVFRepresentor && strings.TrimSpace(operation.TargetRole) == "" {
+		return fmt.Errorf("doSPCX semantic operation %q has no target role", id)
+	}
+	return nil
+}
+
+func validSemanticValue(value any) bool {
+	if value == nil {
+		return false
+	}
+	if _, ok := value.(json.Number); ok {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.String, reflect.Bool,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
+		reflect.Float32, reflect.Float64:
+		return true
+	case reflect.Array, reflect.Slice:
+		for index := 0; index < reflected.Len(); index++ {
+			item := reflected.Index(index).Interface()
+			if item == nil {
+				return false
+			}
+			kind := reflect.ValueOf(item).Kind()
+			if kind == reflect.Array || kind == reflect.Slice || kind == reflect.Map || kind == reflect.Struct || kind == reflect.Pointer {
+				return false
+			}
+			if !validSemanticValue(item) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+type groupDisposition string
+
+const (
+	groupDispositionExecute groupDisposition = "execute"
+	groupDispositionMarker  groupDisposition = "marker"
+	groupDispositionSkip    groupDisposition = "skip"
+)
+
+func semanticGroupDisposition(stage PlanStage, name string) (groupDisposition, string, error) {
+	switch stage {
+	case PlanStagePrepare:
+		switch name {
+		case "breakout":
+			return groupDispositionExecute, "", nil
+		case "post-breakout":
+			return groupDispositionMarker, "", nil
+		}
+	case PlanStageConfigure:
+		switch name {
+		case "link-runtime", "cc", "link-event":
+			return groupDispositionExecute, "", nil
+		case "eswitch":
+			return groupDispositionSkip, "eSwitch lifecycle is outside the current NCO plan execution scope", nil
+		case "vf-lifecycle":
+			return groupDispositionSkip, "VF representor lifecycle is outside the current NCO plan execution scope", nil
+		}
+	}
+	return "", "", fmt.Errorf("unsupported doSPCX semantic group %q for stage %q", name, stage)
+}
+
+func (p *SemanticPlan) resolveGroupTargets(group SemanticGroup) ([]DMSTargetOperations, error) {
+	targetOrder := make([]string, 0, len(p.Devices))
+	operationsByTarget := make(map[string][]dmscli.XPathOperation, len(p.Devices))
+	for _, operation := range group.Operations {
+		targets, err := p.resolveOperationTargets(operation)
+		if err != nil {
+			return nil, fmt.Errorf("operation %q: %w", operation.ID, err)
+		}
+		for _, target := range targets {
+			if _, found := operationsByTarget[target]; !found {
+				targetOrder = append(targetOrder, target)
+			}
+			operationsByTarget[target] = append(operationsByTarget[target], dmscli.XPathOperation{
+				Path:   operation.Path,
+				Values: cloneValueMap(operation.Values),
+			})
+		}
+	}
+
+	if len(group.Operations) > 0 && len(targetOrder) == 0 {
+		return nil, fmt.Errorf("no DMS targets resolved")
+	}
+	result := make([]DMSTargetOperations, 0, len(targetOrder))
+	for _, target := range targetOrder {
+		operations := operationsByTarget[target]
+		desired := finalDesiredState(operations)
+		result = append(result, DMSTargetOperations{
+			Target:     target,
+			Queries:    queriesForDesiredState(desired, p.Stage == PlanStagePrepare),
+			Desired:    desired,
+			Operations: operations,
+		})
+	}
+	return result, nil
+}
+
+func (p *SemanticPlan) resolveOperationTargets(operation SemanticOperation) ([]string, error) {
+	eligible := make([]PlanDevice, 0, len(p.Devices))
+	for _, device := range p.Devices {
+		if device.Network != operation.TargetRole {
+			continue
+		}
+		eligible = append(eligible, device)
+	}
+	if len(eligible) == 0 {
+		return nil, fmt.Errorf("no plan devices match target role %q", operation.TargetRole)
+	}
+
+	switch operation.TargetClass {
+	case targetClassPFNetdevAll:
+		result := make([]string, 0, len(eligible))
+		for _, device := range eligible {
+			result = append(result, device.DMSTarget)
+		}
+		return result, nil
+	case targetClassPFRDMAScope:
+		switch p.RuntimeContext.RDMATopology {
+		case rdmaTopologyPerPF:
+			result := make([]string, 0, len(eligible))
+			for _, device := range eligible {
+				result = append(result, device.DMSTarget)
+			}
+			return result, nil
+		case rdmaTopologyPerRailBond:
+			expected := append([]ExpectedRDMA(nil), p.RuntimeContext.ExpectedRDMA...)
+			sort.SliceStable(expected, func(left, right int) bool {
+				return expected[left].Rail < expected[right].Rail
+			})
+			if len(expected) == 0 {
+				return nil, fmt.Errorf("per-rail-bond topology does not define expected RDMA controls")
+			}
+			seenTargets := make(map[string]struct{}, len(expected))
+			seenRails := make(map[int]struct{}, len(expected))
+			eligibleDevices := make(map[string]PlanDevice, len(eligible))
+			for _, device := range eligible {
+				eligibleDevices[device.DMSTarget] = device
+			}
+			result := make([]string, 0, len(expected))
+			for _, control := range expected {
+				if _, found := seenRails[control.Rail]; found {
+					return nil, fmt.Errorf("RDMA control rail %d is duplicated", control.Rail)
+				}
+				seenRails[control.Rail] = struct{}{}
+				if strings.TrimSpace(control.ControlTarget) == "" {
+					return nil, fmt.Errorf("rail %d has no RDMA control target", control.Rail)
+				}
+				device, found := eligibleDevices[control.ControlTarget]
+				if !found {
+					return nil, fmt.Errorf("RDMA control target %q is not a plan device for role %q", control.ControlTarget, operation.TargetRole)
+				}
+				if control.ControlBDF == "" || control.ControlTarget != "pci/"+control.ControlBDF {
+					return nil, fmt.Errorf("RDMA control target %q does not match control BDF %q", control.ControlTarget, control.ControlBDF)
+				}
+				if device.Rail != control.Rail {
+					return nil, fmt.Errorf("RDMA control target %q belongs to rail %d, not rail %d", control.ControlTarget, device.Rail, control.Rail)
+				}
+				if _, found := seenTargets[control.ControlTarget]; found {
+					return nil, fmt.Errorf("RDMA control target %q is duplicated", control.ControlTarget)
+				}
+				seenTargets[control.ControlTarget] = struct{}{}
+				result = append(result, control.ControlTarget)
+			}
+			return result, nil
+		default:
+			return nil, fmt.Errorf("unsupported RDMA topology %q", p.RuntimeContext.RDMATopology)
+		}
+	default:
+		return nil, fmt.Errorf("target class %q is not executable in this phase", operation.TargetClass)
+	}
+}
+
+func finalDesiredState(operations []dmscli.XPathOperation) []dmscli.XPathOperation {
+	pathOrder := make([]string, 0, len(operations))
+	byPath := make(map[string]map[string]any, len(operations))
+	for _, operation := range operations {
+		values, found := byPath[operation.Path]
+		if !found {
+			values = map[string]any{}
+			byPath[operation.Path] = values
+			pathOrder = append(pathOrder, operation.Path)
+		}
+		for leaf, value := range operation.Values {
+			values[leaf] = cloneSemanticValue(value)
+		}
+	}
+
+	result := make([]dmscli.XPathOperation, 0, len(pathOrder))
+	for _, path := range pathOrder {
+		result = append(result, dmscli.XPathOperation{Path: path, Values: byPath[path]})
+	}
+	return result
+}
+
+func queriesForDesiredState(desired []dmscli.XPathOperation, includePending bool) []dmscli.XPathQuery {
+	result := make([]dmscli.XPathQuery, 0, len(desired))
+	for _, operation := range desired {
+		leafCapacity := len(operation.Values)
+		if includePending {
+			leafCapacity *= 2
+		}
+		leaves := make([]string, 0, leafCapacity)
+		for leaf := range operation.Values {
+			leaves = append(leaves, leaf)
+			if includePending {
+				leaves = append(leaves, leaf+"-pending")
+			}
+		}
+		sort.Strings(leaves)
+		result = append(result, dmscli.XPathQuery{Path: operation.Path, Leaves: leaves})
+	}
+	return result
+}
+
+func cloneValueMap(values map[string]any) map[string]any {
+	if values == nil {
+		return nil
+	}
+	result := make(map[string]any, len(values))
+	for key, value := range values {
+		result[key] = cloneSemanticValue(value)
+	}
+	return result
+}
+
+func cloneSemanticValue(value any) any {
+	if value == nil {
+		return nil
+	}
+	reflected := reflect.ValueOf(value)
+	if reflected.Kind() != reflect.Array && reflected.Kind() != reflect.Slice {
+		return value
+	}
+	result := make([]any, reflected.Len())
+	for index := 0; index < reflected.Len(); index++ {
+		result[index] = cloneSemanticValue(reflected.Index(index).Interface())
+	}
+	return result
+}

--- a/pkg/spectrumx/semanticplan_test.go
+++ b/pkg/spectrumx/semanticplan_test.go
@@ -1,0 +1,339 @@
+/*
+Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spectrumx
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/Mellanox/nic-configuration-operator/pkg/dmscli"
+)
+
+var _ = Describe("doSPCX semantic plans", func() {
+	readFixture := func(name string) []byte {
+		content, err := os.ReadFile(filepath.Join("testdata", "semantic", name))
+		Expect(err).NotTo(HaveOccurred())
+		return content
+	}
+
+	parseFixture := func(name string, stage PlanStage) *SemanticPlan {
+		plan, err := ParseSemanticPlan(readFixture(name), stage)
+		Expect(err).NotTo(HaveOccurred())
+		return plan
+	}
+
+	Describe("ParseSemanticPlan", func() {
+		It("parses the generated host-k8s prepare semantic surface", func() {
+			plan := parseFixture("prepare-plan.json", PlanStagePrepare)
+
+			Expect(plan.Name).To(Equal("nco-parser-semantic-prepare"))
+			Expect(plan.Profile).To(Equal("hwmp"))
+			Expect(plan.PathDialect).To(Equal(semanticPathDialect))
+			Expect(plan.Devices).To(HaveLen(2))
+			Expect(plan.RuntimeContext.RDMATopology).To(Equal(rdmaTopologyPerPF))
+			Expect(plan.Groups).To(HaveLen(2))
+			Expect(plan.Groups[0].Name).To(Equal("breakout"))
+			Expect(plan.Groups[0].Operations).To(HaveLen(15))
+			Expect(plan.Groups[0].Operations[0].ID).To(Equal("spcx-base-nvconfig.roce.adaptive-routing-cc-steering-ext-tx-sched-locality-mode"))
+			Expect(plan.Groups[0].Operations[0].Path).To(Equal("/nvidia/roce"))
+			Expect(plan.Groups[1].Name).To(Equal("post-breakout"))
+			Expect(plan.Groups[1].Operations).To(BeEmpty())
+			Expect(plan.Groups[1].RequiresReboot).To(BeTrue())
+		})
+
+		It("parses all generated configure groups before applying execution policy", func() {
+			plan := parseFixture("configure-plan.json", PlanStageConfigure)
+
+			Expect(plan.Devices).To(HaveLen(4))
+			Expect(plan.RuntimeContext.RDMATopology).To(Equal(rdmaTopologyPerRailBond))
+			Expect(plan.Groups).To(HaveLen(5))
+			Expect(groupNames(plan.Groups)).To(Equal([]string{
+				"link-runtime", "eswitch", "vf-lifecycle", "cc", "link-event",
+			}))
+			Expect(plan.Groups[0].Operations).To(HaveLen(4))
+			Expect(plan.Groups[0].Operations[1].Values).To(HaveKeyWithValue("admin-status", "down"))
+			Expect(plan.Groups[0].Operations[2].Values).To(HaveKeyWithValue("admin-status", "up"))
+			Expect(plan.Groups[1].FanoutOrder).To(Equal("per_step_barrier"))
+			Expect(plan.Groups[2].Operations[0].TargetClass).To(Equal(targetClassVFRepresentor))
+		})
+
+		DescribeTable("rejects malformed semantic contracts",
+			func(mutate func(map[string]any), expected string) {
+				var document map[string]any
+				Expect(json.Unmarshal(readFixture("prepare-plan.json"), &document)).To(Succeed())
+				mutate(document)
+				content, err := json.Marshal(document)
+				Expect(err).NotTo(HaveOccurred())
+
+				plan, err := ParseSemanticPlan(content, PlanStagePrepare)
+
+				Expect(plan).To(BeNil())
+				Expect(err).To(MatchError(ContainSubstring(expected)))
+			},
+			Entry("missing semantic groups", func(document map[string]any) {
+				delete(document["plan"].(map[string]any), "semantic")
+			}, "semantic groups"),
+			Entry("wrong path dialect", func(document map[string]any) {
+				document["plan"].(map[string]any)["path_dialect"] = "legacy"
+			}, "path dialect"),
+			Entry("missing operation reference", func(document map[string]any) {
+				groups := document["plan"].(map[string]any)["semantic"].(map[string]any)["groups"].([]any)
+				groups[0].(map[string]any)["operation_refs"] = []any{"missing-operation"}
+			}, "references missing operation"),
+			Entry("operation in another group", func(document map[string]any) {
+				operations := document["plan"].(map[string]any)["operations"].(map[string]any)
+				for _, value := range operations {
+					value.(map[string]any)["execution_group"] = "other"
+					break
+				}
+			}, "belongs to group"),
+			Entry("unsupported operation kind", func(document map[string]any) {
+				operations := document["plan"].(map[string]any)["operations"].(map[string]any)
+				for _, value := range operations {
+					value.(map[string]any)["kind"] = "delete"
+					break
+				}
+			}, "unsupported kind"),
+			Entry("unsupported target class", func(document map[string]any) {
+				operations := document["plan"].(map[string]any)["operations"].(map[string]any)
+				for _, value := range operations {
+					value.(map[string]any)["target_class"] = "host_global"
+					break
+				}
+			}, "unsupported target class"),
+			Entry("duplicated group", func(document map[string]any) {
+				semantic := document["plan"].(map[string]any)["semantic"].(map[string]any)
+				groups := semantic["groups"].([]any)
+				semantic["groups"] = append(groups, groups[0])
+			}, "group \"breakout\" is duplicated"),
+			Entry("invalid device target", func(document map[string]any) {
+				devices := document["plan"].(map[string]any)["devices"].([]any)
+				devices[0].(map[string]any)["dms_target"] = "pci/0000:ff:00.0"
+			}, "invalid DMS target"),
+		)
+
+		It("rejects a stage mismatch", func() {
+			plan, err := ParseSemanticPlan(readFixture("configure-plan.json"), PlanStagePrepare)
+
+			Expect(plan).To(BeNil())
+			Expect(err).To(MatchError(ContainSubstring(`stage is "configure", expected "prepare"`)))
+		})
+
+		It("uses the documented pf_netdev_all default when target_class is omitted", func() {
+			var document map[string]any
+			Expect(json.Unmarshal(readFixture("prepare-plan.json"), &document)).To(Succeed())
+			planObject := document["plan"].(map[string]any)
+			firstRef := planObject["semantic"].(map[string]any)["groups"].([]any)[0].(map[string]any)["operation_refs"].([]any)[0].(string)
+			delete(planObject["operations"].(map[string]any)[firstRef].(map[string]any), "target_class")
+			content, err := json.Marshal(document)
+			Expect(err).NotTo(HaveOccurred())
+
+			plan, err := ParseSemanticPlan(content, PlanStagePrepare)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(plan.Groups[0].Operations[0].TargetClass).To(Equal(targetClassPFNetdevAll))
+		})
+
+		It("sorts semantic groups by their declared order", func() {
+			var document map[string]any
+			Expect(json.Unmarshal(readFixture("prepare-plan.json"), &document)).To(Succeed())
+			semantic := document["plan"].(map[string]any)["semantic"].(map[string]any)
+			groups := semantic["groups"].([]any)
+			semantic["groups"] = []any{groups[1], groups[0]}
+			content, err := json.Marshal(document)
+			Expect(err).NotTo(HaveOccurred())
+
+			plan, err := ParseSemanticPlan(content, PlanStagePrepare)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(groupNames(plan.Groups)).To(Equal([]string{"breakout", "post-breakout"}))
+		})
+
+		It("rejects nil input without panicking", func() {
+			plan, err := ParseSemanticPlan(nil, PlanStagePrepare)
+
+			Expect(plan).To(BeNil())
+			Expect(err).To(MatchError("doSPCX plan must not be empty"))
+		})
+	})
+
+	Describe("BuildDMSOperationPlan", func() {
+		It("builds prepare batches and retains the post-breakout phase marker", func() {
+			semantic := parseFixture("prepare-plan.json", PlanStagePrepare)
+
+			plan, err := semantic.BuildDMSOperationPlan(context.Background())
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(plan.Stage).To(Equal(PlanStagePrepare))
+			Expect(plan.SkippedGroups).To(BeEmpty())
+			Expect(plan.Groups).To(HaveLen(2))
+			Expect(plan.Groups[0].Name).To(Equal("breakout"))
+			Expect(plan.Groups[0].Targets).To(HaveLen(2))
+			for _, target := range plan.Groups[0].Targets {
+				Expect(target.Operations).To(HaveLen(15))
+				Expect(target.Desired).To(HaveLen(12))
+				Expect(target.Queries).To(HaveLen(12))
+				for _, query := range target.Queries {
+					desired := findDesiredOperation(target.Desired, query.Path)
+					Expect(desired.Path).To(Equal(query.Path))
+					Expect(query.Leaves).To(HaveLen(2 * len(desired.Values)))
+					for _, leaf := range query.Leaves {
+						if strings.HasSuffix(leaf, "-pending") {
+							continue
+						}
+						Expect(query.Leaves).To(ContainElement(leaf + "-pending"))
+					}
+				}
+			}
+			Expect(plan.Groups[1].Name).To(Equal("post-breakout"))
+			Expect(plan.Groups[1].PhaseMarker).To(BeTrue())
+			Expect(plan.Groups[1].Targets).To(BeEmpty())
+		})
+
+		It("skips eswitch and vf-lifecycle while compiling the remaining configure groups", func() {
+			semantic := parseFixture("configure-plan.json", PlanStageConfigure)
+
+			plan, err := semantic.BuildDMSOperationPlan(context.Background())
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(groupOperationNames(plan.Groups)).To(Equal([]string{"link-runtime", "cc", "link-event"}))
+			Expect(plan.SkippedGroups).To(Equal([]SkippedSemanticGroup{
+				{Name: "eswitch", Order: 40, Reason: "eSwitch lifecycle is outside the current NCO plan execution scope"},
+				{Name: "vf-lifecycle", Order: 60, Reason: "VF representor lifecycle is outside the current NCO plan execution scope"},
+			}))
+		})
+
+		It("preserves ordered SET transitions but queries only the final desired state", func() {
+			semantic := parseFixture("configure-plan.json", PlanStageConfigure)
+			plan, err := semantic.BuildDMSOperationPlan(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+
+			linkRuntime := plan.Groups[0]
+			Expect(linkRuntime.Name).To(Equal("link-runtime"))
+			Expect(linkRuntime.Targets).To(HaveLen(4))
+			batch := linkRuntime.Targets[0]
+			Expect(batch.Operations).To(HaveLen(4))
+			Expect(batch.Operations[1].Values).To(HaveKeyWithValue("admin-status", "down"))
+			Expect(batch.Operations[2].Values).To(HaveKeyWithValue("admin-status", "up"))
+			Expect(batch.Desired).To(HaveLen(3))
+			Expect(batch.Desired[1].Path).To(Equal("/nvidia/link/physical"))
+			Expect(batch.Desired[1].Values).To(HaveKeyWithValue("admin-status", "up"))
+			Expect(batch.Queries[1]).To(Equal(dmsQuery("/nvidia/link/physical", "admin-status")))
+		})
+
+		It("resolves bonded RDMA operations only to the per-rail control targets", func() {
+			semantic := parseFixture("configure-plan.json", PlanStageConfigure)
+			plan, err := semantic.BuildDMSOperationPlan(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+
+			cc := plan.Groups[1]
+			Expect(cc.Name).To(Equal("cc"))
+			Expect(cc.Targets).To(HaveLen(2))
+			Expect([]string{cc.Targets[0].Target, cc.Targets[1].Target}).To(Equal([]string{
+				"pci/0000:64:00.0", "pci/0001:15:00.0",
+			}))
+			Expect(cc.Targets[0].Operations).To(HaveLen(24))
+		})
+
+		It("combines per-device and RDMA-scoped operations without widening bonded targets", func() {
+			semantic := parseFixture("configure-plan.json", PlanStageConfigure)
+			plan, err := semantic.BuildDMSOperationPlan(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+
+			linkEvent := plan.Groups[2]
+			Expect(linkEvent.Name).To(Equal("link-event"))
+			Expect(linkEvent.Targets).To(HaveLen(4))
+			Expect(linkEvent.Targets[0].Operations).To(HaveLen(21))
+			Expect(linkEvent.Targets[1].Operations).To(HaveLen(2))
+			Expect(linkEvent.Targets[2].Operations).To(HaveLen(21))
+			Expect(linkEvent.Targets[3].Operations).To(HaveLen(2))
+		})
+
+		It("fails closed for an unknown semantic group", func() {
+			semantic := parseFixture("configure-plan.json", PlanStageConfigure)
+			semantic.Groups[0].Name = "new-runtime-phase"
+
+			plan, err := semantic.BuildDMSOperationPlan(context.Background())
+
+			Expect(plan).To(BeNil())
+			Expect(err).To(MatchError(ContainSubstring(`unsupported doSPCX semantic group "new-runtime-phase"`)))
+		})
+
+		It("rejects a missing bonded RDMA control target", func() {
+			semantic := parseFixture("configure-plan.json", PlanStageConfigure)
+			semantic.RuntimeContext.ExpectedRDMA[0].ControlTarget = ""
+
+			plan, err := semantic.BuildDMSOperationPlan(context.Background())
+
+			Expect(plan).To(BeNil())
+			Expect(err).To(MatchError(ContainSubstring("rail 0 has no RDMA control target")))
+		})
+
+		It("rejects duplicated bonded RDMA rails", func() {
+			semantic := parseFixture("configure-plan.json", PlanStageConfigure)
+			semantic.RuntimeContext.ExpectedRDMA[1].Rail = 0
+
+			plan, err := semantic.BuildDMSOperationPlan(context.Background())
+
+			Expect(plan).To(BeNil())
+			Expect(err).To(MatchError(ContainSubstring("RDMA control rail 0 is duplicated")))
+		})
+
+		It("rejects a nil semantic plan", func() {
+			var semantic *SemanticPlan
+
+			plan, err := semantic.BuildDMSOperationPlan(context.Background())
+
+			Expect(plan).To(BeNil())
+			Expect(err).To(MatchError("semantic plan must not be nil"))
+		})
+	})
+})
+
+func groupNames(groups []SemanticGroup) []string {
+	result := make([]string, 0, len(groups))
+	for _, group := range groups {
+		result = append(result, group.Name)
+	}
+	return result
+}
+
+func groupOperationNames(groups []DMSOperationGroup) []string {
+	result := make([]string, 0, len(groups))
+	for _, group := range groups {
+		result = append(result, group.Name)
+	}
+	return result
+}
+
+func dmsQuery(path string, leaves ...string) dmscli.XPathQuery {
+	return dmscli.XPathQuery{Path: path, Leaves: leaves}
+}
+
+func findDesiredOperation(operations []dmscli.XPathOperation, path string) dmscli.XPathOperation {
+	for _, operation := range operations {
+		if operation.Path == path {
+			return operation
+		}
+	}
+	return dmscli.XPathOperation{}
+}

--- a/pkg/spectrumx/testdata/semantic/configure-plan.json
+++ b/pkg/spectrumx/testdata/semantic/configure-plan.json
@@ -1,0 +1,941 @@
+{
+  "plan": {
+    "name": "nco-parser-semantic-configure",
+    "family": "spcx",
+    "profile": "hwmp",
+    "stage": "configure",
+    "params": {
+      "deployment_mode": "host-k8s",
+      "planes": 2,
+      "xgs": false
+    },
+    "detected_hw": {
+      "hca_type": "ConnectX-8",
+      "nic_count": 4,
+      "platform_type": "gb300",
+      "total_bw": 800,
+      "source": "file",
+      "target_map": {
+        "type": "target-map",
+        "platform_type": "gb300",
+        "inventory_stage": "post_breakout",
+        "post_breakout_source": "inferred-pre-breakout",
+        "class": "external",
+        "source": null,
+        "digest": "f817b16cf02534c07ef92510a7e992c81a0df50f764294806ff55938471d2d25"
+      },
+      "topology": {
+        "expansion": "contiguous",
+        "ports_per_target": 1
+      }
+    },
+    "devices": [
+      {
+        "bdf": "0000:64:00.0",
+        "device_id": "0x1023",
+        "hca_type": "ConnectX-8",
+        "netdev": "eth_r0_p0",
+        "rdma_dev": "mlx5_0",
+        "dms_target": "pci/0000:64:00.0",
+        "pf_index": 0,
+        "rail": 0,
+        "plane": 0,
+        "plane_explicit": true,
+        "network": "ew",
+        "physical_label": "",
+        "reset_domain": "pci-slot:0000:64:00",
+        "endpoint_labels": [],
+        "target_id": "0000:64:00.0-r0-plane0"
+      },
+      {
+        "bdf": "0000:64:00.1",
+        "device_id": "0x1023",
+        "hca_type": "ConnectX-8",
+        "netdev": "eth_r0_p1",
+        "rdma_dev": "mlx5_1",
+        "dms_target": "pci/0000:64:00.1",
+        "pf_index": 1,
+        "rail": 0,
+        "plane": 1,
+        "plane_explicit": true,
+        "network": "ew",
+        "physical_label": "",
+        "reset_domain": "pci-slot:0000:64:00",
+        "endpoint_labels": [],
+        "target_id": "0000:64:00.0-r0-plane1"
+      },
+      {
+        "bdf": "0001:15:00.0",
+        "device_id": "0x1023",
+        "hca_type": "ConnectX-8",
+        "netdev": "eth_r1_p0",
+        "rdma_dev": "mlx5_2",
+        "dms_target": "pci/0001:15:00.0",
+        "pf_index": 0,
+        "rail": 1,
+        "plane": 0,
+        "plane_explicit": true,
+        "network": "ew",
+        "physical_label": "",
+        "reset_domain": "pci-slot:0001:15:00",
+        "endpoint_labels": [],
+        "target_id": "0001:15:00.0-r1-plane0"
+      },
+      {
+        "bdf": "0001:15:00.1",
+        "device_id": "0x1023",
+        "hca_type": "ConnectX-8",
+        "netdev": "eth_r1_p1",
+        "rdma_dev": "mlx5_3",
+        "dms_target": "pci/0001:15:00.1",
+        "pf_index": 1,
+        "rail": 1,
+        "plane": 1,
+        "plane_explicit": true,
+        "network": "ew",
+        "physical_label": "",
+        "reset_domain": "pci-slot:0001:15:00",
+        "endpoint_labels": [],
+        "target_id": "0001:15:00.0-r1-plane1"
+      }
+    ],
+    "runtime_ctx": {
+      "deployment_mode": "host-k8s",
+      "multiplane_mode": "hwmp",
+      "esw_multiport": true,
+      "num_vfs": 1,
+      "post_breakout": true,
+      "rdma_topology": "per_rail_bond",
+      "effect_sources": [
+        "spcx-eswitch"
+      ],
+      "expected_rdma": [
+        {
+          "rail": 0,
+          "rdma_dev": "roce_r0",
+          "control_bdf": "0000:64:00.0",
+          "control_target": "pci/0000:64:00.0",
+          "source": "endpoint_contract"
+        },
+        {
+          "rail": 1,
+          "rdma_dev": "roce_r1",
+          "control_bdf": "0001:15:00.0",
+          "control_target": "pci/0001:15:00.0",
+          "source": "endpoint_contract"
+        }
+      ],
+      "expected_names": {
+        "0000:64:00.0": {
+          "netdev": "eth_r0_p0",
+          "rdma": "roce_r0_p0"
+        },
+        "0000:64:00.1": {
+          "netdev": "eth_r0_p1",
+          "rdma": "roce_r0_p1"
+        },
+        "0001:15:00.0": {
+          "netdev": "eth_r1_p0",
+          "rdma": "roce_r1_p0"
+        },
+        "0001:15:00.1": {
+          "netdev": "eth_r1_p1",
+          "rdma": "roce_r1_p1"
+        }
+      },
+      "vf_endpoints": [
+        {
+          "control_bdf": "0000:64:00.0",
+          "vf_netdev": "eth_vf_r0",
+          "vf_rdma": "roce_vf_r0",
+          "vf_rep": "eth_vf_rep_r0"
+        },
+        {
+          "control_bdf": "0001:15:00.0",
+          "vf_netdev": "eth_vf_r1",
+          "vf_rdma": "roce_vf_r1",
+          "vf_rep": "eth_vf_rep_r1"
+        }
+      ]
+    },
+    "path_dialect": "nvidia-t1",
+    "profile_metadata": {
+      "deployable": true,
+      "family": "spcx",
+      "ra_version": "2.2",
+      "recipe_version": "RA2.2",
+      "profile_digest": "f2bb4e7a0f1100450a84e29b45bce66747c387fbb28f90015d00d68ad52b9846",
+      "maturity": "production",
+      "resolved_variant": "gb300-hwmp",
+      "platform_type": "gb300",
+      "target_binding": {
+        "network_role": "ew"
+      },
+      "platform": {
+        "allowed": [
+          "gb300"
+        ]
+      }
+    },
+    "operations": {
+      "spcx-ipg-runtime.link-ipg.admin": {
+        "path": "/nvidia/link/ipg",
+        "values": {
+          "admin": 25
+        },
+        "source_feature": "spcx-ipg-runtime",
+        "kind": "set",
+        "target_class": "pf_netdev_all",
+        "execution_group": "link-runtime",
+        "target_role": "ew"
+      },
+      "spcx-ipg-runtime.link-physical.admin-status": {
+        "path": "/nvidia/link/physical",
+        "values": {
+          "admin-status": "down"
+        },
+        "source_feature": "spcx-ipg-runtime",
+        "kind": "set",
+        "target_class": "pf_netdev_all",
+        "execution_group": "link-runtime",
+        "target_role": "ew"
+      },
+      "spcx-ipg-runtime.link-physical.admin-status.2": {
+        "path": "/nvidia/link/physical",
+        "values": {
+          "admin-status": "up"
+        },
+        "source_feature": "spcx-ipg-runtime",
+        "kind": "set",
+        "target_class": "pf_netdev_all",
+        "execution_group": "link-runtime",
+        "target_role": "ew"
+      },
+      "spcx-pf-mtu.link-netdev.mtu": {
+        "path": "/nvidia/link/netdev",
+        "values": {
+          "mtu": 9216
+        },
+        "source_feature": "spcx-pf-mtu",
+        "kind": "set",
+        "target_class": "pf_netdev_all",
+        "execution_group": "link-runtime",
+        "target_role": "ew"
+      },
+      "spcx-eswitch.eswitch.mode": {
+        "path": "/nvidia/eswitch",
+        "values": {
+          "mode": "legacy"
+        },
+        "source_feature": "spcx-eswitch",
+        "kind": "set",
+        "execution_group": "eswitch",
+        "target_role": "ew",
+        "target_class": "pf_netdev_all"
+      },
+      "spcx-eswitch.eswitch.flow-steering-mode": {
+        "path": "/nvidia/eswitch",
+        "values": {
+          "flow-steering-mode": "hmfs"
+        },
+        "source_feature": "spcx-eswitch",
+        "kind": "set",
+        "execution_group": "eswitch",
+        "target_role": "ew",
+        "target_class": "pf_netdev_all"
+      },
+      "spcx-eswitch.eswitch.mode.2": {
+        "path": "/nvidia/eswitch",
+        "values": {
+          "mode": "switchdev"
+        },
+        "source_feature": "spcx-eswitch",
+        "kind": "set",
+        "execution_group": "eswitch",
+        "target_role": "ew",
+        "target_class": "pf_netdev_all"
+      },
+      "spcx-eswitch.eswitch.multiport": {
+        "path": "/nvidia/eswitch",
+        "values": {
+          "multiport": true
+        },
+        "source_feature": "spcx-eswitch",
+        "kind": "set",
+        "target_class": "per_eswitch",
+        "execution_group": "eswitch",
+        "condition": {
+          "knob": "@params.multiport == True"
+        },
+        "context": {
+          "hca_type": "ConnectX-8",
+          "device_hca_types": [
+            "ConnectX-8"
+          ],
+          "platform_type": "gb300"
+        },
+        "target_role": "ew"
+      },
+      "ra22-cc-runtime.cc-algo-slot-15.enabled": {
+        "path": "/nvidia/cc/algo/slot/[15]",
+        "values": {
+          "enabled": false
+        },
+        "source_feature": "ra22-cc-runtime",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "cc",
+        "target_role": "ew"
+      },
+      "ra22-cc-runtime.cc-algo-slot-0-param-0.value": {
+        "path": "/nvidia/cc/algo/slot/[0]/param/[0]",
+        "values": {
+          "value": 400
+        },
+        "source_feature": "ra22-cc-runtime",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "cc",
+        "condition": {
+          "knob": "@params.nic_type == '1023' and @params.planes == 2"
+        },
+        "context": {
+          "hca_type": "ConnectX-8",
+          "device_hca_types": [
+            "ConnectX-8"
+          ],
+          "platform_type": "gb300"
+        },
+        "target_role": "ew"
+      },
+      "ra22-cc-runtime.cc-algo-slot-0-param-1.value": {
+        "path": "/nvidia/cc/algo/slot/[0]/param/[1]",
+        "values": {
+          "value": 6553
+        },
+        "source_feature": "ra22-cc-runtime",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "cc",
+        "target_role": "ew"
+      },
+      "ra22-cc-runtime.cc-algo-slot-0-param-2.value": {
+        "path": "/nvidia/cc/algo/slot/[0]/param/[2]",
+        "values": {
+          "value": 63570
+        },
+        "source_feature": "ra22-cc-runtime",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "cc",
+        "target_role": "ew"
+      },
+      "ra22-cc-runtime.cc-algo-slot-0-param-3.value": {
+        "path": "/nvidia/cc/algo/slot/[0]/param/[3]",
+        "values": {
+          "value": 69468
+        },
+        "source_feature": "ra22-cc-runtime",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "cc",
+        "target_role": "ew"
+      },
+      "ra22-cc-runtime.cc-algo-slot-0-param-4.value": {
+        "path": "/nvidia/cc/algo/slot/[0]/param/[4]",
+        "values": {
+          "value": 36
+        },
+        "source_feature": "ra22-cc-runtime",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "cc",
+        "target_role": "ew"
+      },
+      "ra22-cc-runtime.cc-algo-slot-0-param-5.value": {
+        "path": "/nvidia/cc/algo/slot/[0]/param/[5]",
+        "values": {
+          "value": 1200
+        },
+        "source_feature": "ra22-cc-runtime",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "cc",
+        "target_role": "ew"
+      },
+      "ra22-cc-runtime.cc-algo-slot-0-param-6.value": {
+        "path": "/nvidia/cc/algo/slot/[0]/param/[6]",
+        "values": {
+          "value": 7000000
+        },
+        "source_feature": "ra22-cc-runtime",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "cc",
+        "target_role": "ew"
+      },
+      "ra22-cc-runtime.cc-algo-slot-0-param-7.value": {
+        "path": "/nvidia/cc/algo/slot/[0]/param/[7]",
+        "values": {
+          "value": 15000
+        },
+        "source_feature": "ra22-cc-runtime",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "cc",
+        "target_role": "ew"
+      },
+      "ra22-cc-runtime.cc-algo-slot-0-param-8.value": {
+        "path": "/nvidia/cc/algo/slot/[0]/param/[8]",
+        "values": {
+          "value": 250000
+        },
+        "source_feature": "ra22-cc-runtime",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "cc",
+        "target_role": "ew"
+      },
+      "ra22-cc-runtime.cc-algo-slot-0-param-9.value": {
+        "path": "/nvidia/cc/algo/slot/[0]/param/[9]",
+        "values": {
+          "value": 524288
+        },
+        "source_feature": "ra22-cc-runtime",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "cc",
+        "target_role": "ew"
+      },
+      "ra22-cc-runtime.cc-algo-slot-0-param-10.value": {
+        "path": "/nvidia/cc/algo/slot/[0]/param/[10]",
+        "values": {
+          "value": 0
+        },
+        "source_feature": "ra22-cc-runtime",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "cc",
+        "target_role": "ew"
+      },
+      "ra22-cc-runtime.cc-algo-slot-0-param-11.value": {
+        "path": "/nvidia/cc/algo/slot/[0]/param/[11]",
+        "values": {
+          "value": 1
+        },
+        "source_feature": "ra22-cc-runtime",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "cc",
+        "target_role": "ew"
+      },
+      "ra22-cc-runtime.cc-algo-slot-0-param-12.value": {
+        "path": "/nvidia/cc/algo/slot/[0]/param/[12]",
+        "values": {
+          "value": 0
+        },
+        "source_feature": "ra22-cc-runtime",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "cc",
+        "target_role": "ew"
+      },
+      "ra22-cc-runtime.cc-algo-slot-0-param-13.value": {
+        "path": "/nvidia/cc/algo/slot/[0]/param/[13]",
+        "values": {
+          "value": 0
+        },
+        "source_feature": "ra22-cc-runtime",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "cc",
+        "target_role": "ew"
+      },
+      "ra22-cc-runtime.cc-algo-slot-0-param-14.value": {
+        "path": "/nvidia/cc/algo/slot/[0]/param/[14]",
+        "values": {
+          "value": 2097152
+        },
+        "source_feature": "ra22-cc-runtime",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "cc",
+        "target_role": "ew"
+      },
+      "ra22-cc-runtime.cc-algo-slot-0-param-15.value": {
+        "path": "/nvidia/cc/algo/slot/[0]/param/[15]",
+        "values": {
+          "value": 2
+        },
+        "source_feature": "ra22-cc-runtime",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "cc",
+        "target_role": "ew"
+      },
+      "ra22-cc-runtime.cc-algo-slot-0-param-16.value": {
+        "path": "/nvidia/cc/algo/slot/[0]/param/[16]",
+        "values": {
+          "value": 1
+        },
+        "source_feature": "ra22-cc-runtime",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "cc",
+        "target_role": "ew"
+      },
+      "ra22-cc-runtime.cc-algo-slot-0-param-17.value": {
+        "path": "/nvidia/cc/algo/slot/[0]/param/[17]",
+        "values": {
+          "value": 0
+        },
+        "source_feature": "ra22-cc-runtime",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "cc",
+        "target_role": "ew"
+      },
+      "ra22-cc-runtime.cc-algo-slot-0-param-18.value": {
+        "path": "/nvidia/cc/algo/slot/[0]/param/[18]",
+        "values": {
+          "value": 0
+        },
+        "source_feature": "ra22-cc-runtime",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "cc",
+        "target_role": "ew"
+      },
+      "ra22-cc-runtime.cc-algo-slot-0-param-22.value": {
+        "path": "/nvidia/cc/algo/slot/[0]/param/[22]",
+        "values": {
+          "value": 1
+        },
+        "source_feature": "ra22-cc-runtime",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "cc",
+        "target_role": "ew"
+      },
+      "ra22-cc-runtime.cc-algo-slot-0-param-23.value": {
+        "path": "/nvidia/cc/algo/slot/[0]/param/[23]",
+        "values": {
+          "value": 3
+        },
+        "source_feature": "ra22-cc-runtime",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "cc",
+        "target_role": "ew"
+      },
+      "ra22-cc-runtime.cc-algo-slot-0-param-24.value": {
+        "path": "/nvidia/cc/algo/slot/[0]/param/[24]",
+        "values": {
+          "value": 1
+        },
+        "source_feature": "ra22-cc-runtime",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "cc",
+        "target_role": "ew"
+      },
+      "ra22-cc-runtime.cc-algo-slot-0.counters-enabled-enabled": {
+        "path": "/nvidia/cc/algo/slot/[0]",
+        "values": {
+          "enabled": true,
+          "counters-enabled": true
+        },
+        "source_feature": "ra22-cc-runtime",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "cc",
+        "target_role": "ew"
+      },
+      "spcx-base-linkup.qos.trust-mode": {
+        "path": "/nvidia/qos",
+        "values": {
+          "trust-mode": "dscp"
+        },
+        "source_feature": "spcx-base-linkup",
+        "kind": "set",
+        "target_class": "pf_netdev_all",
+        "execution_group": "link-event",
+        "scope": "per_device",
+        "target_role": "ew"
+      },
+      "spcx-base-linkup.qos-pfc.enabled-priorities": {
+        "path": "/nvidia/qos/pfc",
+        "values": {
+          "enabled-priorities": "3"
+        },
+        "source_feature": "spcx-base-linkup",
+        "kind": "set",
+        "target_class": "pf_netdev_all",
+        "execution_group": "link-event",
+        "scope": "per_device",
+        "target_role": "ew"
+      },
+      "spcx-base-linkup.cc-np.cnp-dscp": {
+        "path": "/nvidia/cc/np",
+        "values": {
+          "cnp-dscp": 48
+        },
+        "source_feature": "spcx-base-linkup",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "link-event",
+        "scope": "per_device",
+        "target_role": "ew"
+      },
+      "spcx-base-linkup.roce-tos.traffic-class": {
+        "path": "/nvidia/roce/tos",
+        "values": {
+          "traffic-class": 96
+        },
+        "source_feature": "spcx-base-linkup",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "link-event",
+        "scope": "per_device",
+        "target_role": "ew"
+      },
+      "spcx-base-linkup.roce-accl.adaptive-retransmission-adaptive-routing-force-slow-restart-slow-restart-idle-tx-window": {
+        "path": "/nvidia/roce/accl",
+        "values": {
+          "adaptive-retransmission": true,
+          "tx-window": true,
+          "slow-restart": false,
+          "slow-restart-idle": false,
+          "adaptive-routing-force": true
+        },
+        "source_feature": "spcx-base-linkup",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "link-event",
+        "scope": "per_device",
+        "target_role": "ew"
+      },
+      "ra22-cc-global-status.cc-global-status-rp-0.enabled": {
+        "path": "/nvidia/cc/global-status/[rp,0]",
+        "values": {
+          "enabled": true
+        },
+        "source_feature": "ra22-cc-global-status",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "link-event",
+        "scope": "per_device",
+        "target_role": "ew"
+      },
+      "ra22-cc-global-status.cc-global-status-rp-1.enabled": {
+        "path": "/nvidia/cc/global-status/[rp,1]",
+        "values": {
+          "enabled": true
+        },
+        "source_feature": "ra22-cc-global-status",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "link-event",
+        "scope": "per_device",
+        "target_role": "ew"
+      },
+      "ra22-cc-global-status.cc-global-status-rp-2.enabled": {
+        "path": "/nvidia/cc/global-status/[rp,2]",
+        "values": {
+          "enabled": true
+        },
+        "source_feature": "ra22-cc-global-status",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "link-event",
+        "scope": "per_device",
+        "target_role": "ew"
+      },
+      "ra22-cc-global-status.cc-global-status-rp-3.enabled": {
+        "path": "/nvidia/cc/global-status/[rp,3]",
+        "values": {
+          "enabled": true
+        },
+        "source_feature": "ra22-cc-global-status",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "link-event",
+        "scope": "per_device",
+        "target_role": "ew"
+      },
+      "ra22-cc-global-status.cc-global-status-rp-4.enabled": {
+        "path": "/nvidia/cc/global-status/[rp,4]",
+        "values": {
+          "enabled": true
+        },
+        "source_feature": "ra22-cc-global-status",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "link-event",
+        "scope": "per_device",
+        "target_role": "ew"
+      },
+      "ra22-cc-global-status.cc-global-status-rp-5.enabled": {
+        "path": "/nvidia/cc/global-status/[rp,5]",
+        "values": {
+          "enabled": true
+        },
+        "source_feature": "ra22-cc-global-status",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "link-event",
+        "scope": "per_device",
+        "target_role": "ew"
+      },
+      "ra22-cc-global-status.cc-global-status-rp-6.enabled": {
+        "path": "/nvidia/cc/global-status/[rp,6]",
+        "values": {
+          "enabled": true
+        },
+        "source_feature": "ra22-cc-global-status",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "link-event",
+        "scope": "per_device",
+        "target_role": "ew"
+      },
+      "ra22-cc-global-status.cc-global-status-rp-7.enabled": {
+        "path": "/nvidia/cc/global-status/[rp,7]",
+        "values": {
+          "enabled": true
+        },
+        "source_feature": "ra22-cc-global-status",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "link-event",
+        "scope": "per_device",
+        "target_role": "ew"
+      },
+      "ra22-cc-global-status.cc-global-status-np-0.enabled": {
+        "path": "/nvidia/cc/global-status/[np,0]",
+        "values": {
+          "enabled": true
+        },
+        "source_feature": "ra22-cc-global-status",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "link-event",
+        "scope": "per_device",
+        "target_role": "ew"
+      },
+      "ra22-cc-global-status.cc-global-status-np-1.enabled": {
+        "path": "/nvidia/cc/global-status/[np,1]",
+        "values": {
+          "enabled": true
+        },
+        "source_feature": "ra22-cc-global-status",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "link-event",
+        "scope": "per_device",
+        "target_role": "ew"
+      },
+      "ra22-cc-global-status.cc-global-status-np-2.enabled": {
+        "path": "/nvidia/cc/global-status/[np,2]",
+        "values": {
+          "enabled": true
+        },
+        "source_feature": "ra22-cc-global-status",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "link-event",
+        "scope": "per_device",
+        "target_role": "ew"
+      },
+      "ra22-cc-global-status.cc-global-status-np-3.enabled": {
+        "path": "/nvidia/cc/global-status/[np,3]",
+        "values": {
+          "enabled": true
+        },
+        "source_feature": "ra22-cc-global-status",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "link-event",
+        "scope": "per_device",
+        "target_role": "ew"
+      },
+      "ra22-cc-global-status.cc-global-status-np-4.enabled": {
+        "path": "/nvidia/cc/global-status/[np,4]",
+        "values": {
+          "enabled": true
+        },
+        "source_feature": "ra22-cc-global-status",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "link-event",
+        "scope": "per_device",
+        "target_role": "ew"
+      },
+      "ra22-cc-global-status.cc-global-status-np-5.enabled": {
+        "path": "/nvidia/cc/global-status/[np,5]",
+        "values": {
+          "enabled": true
+        },
+        "source_feature": "ra22-cc-global-status",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "link-event",
+        "scope": "per_device",
+        "target_role": "ew"
+      },
+      "ra22-cc-global-status.cc-global-status-np-6.enabled": {
+        "path": "/nvidia/cc/global-status/[np,6]",
+        "values": {
+          "enabled": true
+        },
+        "source_feature": "ra22-cc-global-status",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "link-event",
+        "scope": "per_device",
+        "target_role": "ew"
+      },
+      "ra22-cc-global-status.cc-global-status-np-7.enabled": {
+        "path": "/nvidia/cc/global-status/[np,7]",
+        "values": {
+          "enabled": true
+        },
+        "source_feature": "ra22-cc-global-status",
+        "kind": "set",
+        "target_class": "pf_rdma_scope",
+        "execution_group": "link-event",
+        "scope": "per_device",
+        "target_role": "ew"
+      },
+      "ra22-hwmp-data-direct.data-direct.enabled": {
+        "path": "/nvidia/data-direct",
+        "values": {
+          "enabled": true
+        },
+        "source_feature": "ra22-hwmp-data-direct",
+        "kind": "set",
+        "target_class": "vf_rep",
+        "lifecycle": "pre-vf-bind",
+        "scope": "per_vf",
+        "execution_group": "vf-lifecycle",
+        "condition": {
+          "feature": "@params.multiplane_mode == 'hwmp' and @params.nic_type == '1023' and @params.data_direct == True"
+        },
+        "context": {
+          "hca_type": "ConnectX-8",
+          "device_hca_types": [
+            "ConnectX-8"
+          ],
+          "platform_type": "gb300"
+        }
+      }
+    },
+    "semantic": {
+      "groups": [
+        {
+          "name": "link-runtime",
+          "stage": "configure",
+          "order": 30,
+          "scope": "per_device",
+          "operation_refs": [
+            "spcx-ipg-runtime.link-ipg.admin",
+            "spcx-ipg-runtime.link-physical.admin-status",
+            "spcx-ipg-runtime.link-physical.admin-status.2",
+            "spcx-pf-mtu.link-netdev.mtu"
+          ]
+        },
+        {
+          "name": "eswitch",
+          "stage": "configure",
+          "order": 40,
+          "scope": "per_device",
+          "fanout_order": "per_step_barrier",
+          "operation_refs": [
+            "spcx-eswitch.eswitch.mode",
+            "spcx-eswitch.eswitch.flow-steering-mode",
+            "spcx-eswitch.eswitch.mode.2",
+            "spcx-eswitch.eswitch.multiport"
+          ]
+        },
+        {
+          "name": "vf-lifecycle",
+          "stage": "configure",
+          "order": 60,
+          "scope": "per_rail",
+          "operation_refs": [
+            "ra22-hwmp-data-direct.data-direct.enabled"
+          ]
+        },
+        {
+          "name": "cc",
+          "stage": "configure",
+          "order": 90,
+          "scope": "per_rdma_bond",
+          "operation_refs": [
+            "ra22-cc-runtime.cc-algo-slot-15.enabled",
+            "ra22-cc-runtime.cc-algo-slot-0-param-0.value",
+            "ra22-cc-runtime.cc-algo-slot-0-param-1.value",
+            "ra22-cc-runtime.cc-algo-slot-0-param-2.value",
+            "ra22-cc-runtime.cc-algo-slot-0-param-3.value",
+            "ra22-cc-runtime.cc-algo-slot-0-param-4.value",
+            "ra22-cc-runtime.cc-algo-slot-0-param-5.value",
+            "ra22-cc-runtime.cc-algo-slot-0-param-6.value",
+            "ra22-cc-runtime.cc-algo-slot-0-param-7.value",
+            "ra22-cc-runtime.cc-algo-slot-0-param-8.value",
+            "ra22-cc-runtime.cc-algo-slot-0-param-9.value",
+            "ra22-cc-runtime.cc-algo-slot-0-param-10.value",
+            "ra22-cc-runtime.cc-algo-slot-0-param-11.value",
+            "ra22-cc-runtime.cc-algo-slot-0-param-12.value",
+            "ra22-cc-runtime.cc-algo-slot-0-param-13.value",
+            "ra22-cc-runtime.cc-algo-slot-0-param-14.value",
+            "ra22-cc-runtime.cc-algo-slot-0-param-15.value",
+            "ra22-cc-runtime.cc-algo-slot-0-param-16.value",
+            "ra22-cc-runtime.cc-algo-slot-0-param-17.value",
+            "ra22-cc-runtime.cc-algo-slot-0-param-18.value",
+            "ra22-cc-runtime.cc-algo-slot-0-param-22.value",
+            "ra22-cc-runtime.cc-algo-slot-0-param-23.value",
+            "ra22-cc-runtime.cc-algo-slot-0-param-24.value",
+            "ra22-cc-runtime.cc-algo-slot-0.counters-enabled-enabled"
+          ]
+        },
+        {
+          "name": "link-event",
+          "stage": "configure",
+          "order": 100,
+          "scope": "per_device",
+          "operation_refs": [
+            "spcx-base-linkup.qos.trust-mode",
+            "spcx-base-linkup.qos-pfc.enabled-priorities",
+            "spcx-base-linkup.cc-np.cnp-dscp",
+            "spcx-base-linkup.roce-tos.traffic-class",
+            "spcx-base-linkup.roce-accl.adaptive-retransmission-adaptive-routing-force-slow-restart-slow-restart-idle-tx-window",
+            "ra22-cc-global-status.cc-global-status-rp-0.enabled",
+            "ra22-cc-global-status.cc-global-status-rp-1.enabled",
+            "ra22-cc-global-status.cc-global-status-rp-2.enabled",
+            "ra22-cc-global-status.cc-global-status-rp-3.enabled",
+            "ra22-cc-global-status.cc-global-status-rp-4.enabled",
+            "ra22-cc-global-status.cc-global-status-rp-5.enabled",
+            "ra22-cc-global-status.cc-global-status-rp-6.enabled",
+            "ra22-cc-global-status.cc-global-status-rp-7.enabled",
+            "ra22-cc-global-status.cc-global-status-np-0.enabled",
+            "ra22-cc-global-status.cc-global-status-np-1.enabled",
+            "ra22-cc-global-status.cc-global-status-np-2.enabled",
+            "ra22-cc-global-status.cc-global-status-np-3.enabled",
+            "ra22-cc-global-status.cc-global-status-np-4.enabled",
+            "ra22-cc-global-status.cc-global-status-np-5.enabled",
+            "ra22-cc-global-status.cc-global-status-np-6.enabled",
+            "ra22-cc-global-status.cc-global-status-np-7.enabled"
+          ]
+        }
+      ]
+    },
+    "metadata": {
+      "substrate_version": "1.0",
+      "schema_version": "3.0",
+      "created_at": "2026-08-13T08:01:43.358059+00:00"
+    }
+  },
+  "artifacts": {
+    "manifest": []
+  }
+}

--- a/pkg/spectrumx/testdata/semantic/prepare-plan.json
+++ b/pkg/spectrumx/testdata/semantic/prepare-plan.json
@@ -1,0 +1,546 @@
+{
+  "plan": {
+    "name": "nco-parser-semantic-prepare",
+    "family": "spcx",
+    "profile": "hwmp",
+    "stage": "prepare",
+    "params": {
+      "deployment_mode": "host-k8s",
+      "planes": 2,
+      "xgs": false
+    },
+    "detected_hw": {
+      "hca_type": "ConnectX-8",
+      "nic_count": 2,
+      "platform_type": "gb300",
+      "total_bw": 800,
+      "source": "file",
+      "target_map": {
+        "type": "target-map",
+        "platform_type": "gb300",
+        "inventory_stage": "pre_breakout",
+        "post_breakout_source": "inferred-pre-breakout",
+        "class": "external",
+        "source": null,
+        "digest": "f817b16cf02534c07ef92510a7e992c81a0df50f764294806ff55938471d2d25"
+      },
+      "topology": {
+        "expansion": "contiguous",
+        "ports_per_target": 1
+      }
+    },
+    "devices": [
+      {
+        "bdf": "0000:64:00.0",
+        "device_id": "0x1023",
+        "hca_type": "ConnectX-8",
+        "netdev": "eth0",
+        "rdma_dev": "mlx5_0",
+        "dms_target": "pci/0000:64:00.0",
+        "pf_index": 0,
+        "rail": 0,
+        "plane": 0,
+        "plane_explicit": true,
+        "network": "ew",
+        "physical_label": "",
+        "reset_domain": "pci-slot:0000:64:00",
+        "endpoint_labels": [],
+        "target_id": "0000:64:00.0"
+      },
+      {
+        "bdf": "0001:15:00.0",
+        "device_id": "0x1023",
+        "hca_type": "ConnectX-8",
+        "netdev": "eth1",
+        "rdma_dev": "mlx5_1",
+        "dms_target": "pci/0001:15:00.0",
+        "pf_index": 0,
+        "rail": 1,
+        "plane": 0,
+        "plane_explicit": true,
+        "network": "ew",
+        "physical_label": "",
+        "reset_domain": "pci-slot:0001:15:00",
+        "endpoint_labels": [],
+        "target_id": "0001:15:00.0"
+      }
+    ],
+    "post_breakout_devices": [
+      {
+        "bdf": "0000:64:00.0",
+        "device_id": "",
+        "hca_type": "",
+        "netdev": null,
+        "rdma_dev": null,
+        "dms_target": "pci/0000:64:00.0",
+        "pf_index": 0,
+        "rail": 0,
+        "plane": 0,
+        "plane_explicit": true,
+        "network": "ew",
+        "physical_label": "",
+        "reset_domain": "pci-slot:0000:64:00",
+        "endpoint_labels": [],
+        "target_id": "0000:64:00.0-r0-plane0"
+      },
+      {
+        "bdf": "0000:64:00.1",
+        "device_id": "",
+        "hca_type": "",
+        "netdev": null,
+        "rdma_dev": null,
+        "dms_target": "pci/0000:64:00.1",
+        "pf_index": 0,
+        "rail": 0,
+        "plane": 1,
+        "plane_explicit": true,
+        "network": "ew",
+        "physical_label": "",
+        "reset_domain": "pci-slot:0000:64:00",
+        "endpoint_labels": [],
+        "target_id": "0000:64:00.0-r0-plane1"
+      },
+      {
+        "bdf": "0001:15:00.0",
+        "device_id": "",
+        "hca_type": "",
+        "netdev": null,
+        "rdma_dev": null,
+        "dms_target": "pci/0001:15:00.0",
+        "pf_index": 0,
+        "rail": 1,
+        "plane": 0,
+        "plane_explicit": true,
+        "network": "ew",
+        "physical_label": "",
+        "reset_domain": "pci-slot:0001:15:00",
+        "endpoint_labels": [],
+        "target_id": "0001:15:00.0-r1-plane0"
+      },
+      {
+        "bdf": "0001:15:00.1",
+        "device_id": "",
+        "hca_type": "",
+        "netdev": null,
+        "rdma_dev": null,
+        "dms_target": "pci/0001:15:00.1",
+        "pf_index": 0,
+        "rail": 1,
+        "plane": 1,
+        "plane_explicit": true,
+        "network": "ew",
+        "physical_label": "",
+        "reset_domain": "pci-slot:0001:15:00",
+        "endpoint_labels": [],
+        "target_id": "0001:15:00.0-r1-plane1"
+      }
+    ],
+    "runtime_ctx": {
+      "deployment_mode": "host-k8s",
+      "multiplane_mode": "hwmp",
+      "esw_multiport": false,
+      "num_vfs": 1,
+      "post_breakout": true,
+      "rdma_topology": "per_pf",
+      "expected_rdma": [
+        {
+          "rail": 0,
+          "rdma_dev": "roce_r0",
+          "control_bdf": "0000:64:00.0",
+          "control_target": "pci/0000:64:00.0",
+          "source": "endpoint_contract"
+        },
+        {
+          "rail": 1,
+          "rdma_dev": "roce_r1",
+          "control_bdf": "0001:15:00.0",
+          "control_target": "pci/0001:15:00.0",
+          "source": "endpoint_contract"
+        }
+      ],
+      "expected_names": {
+        "0000:64:00.0": {
+          "netdev": "eth_r0_p0",
+          "rdma": "roce_r0_p0"
+        },
+        "0000:64:00.1": {
+          "netdev": "eth_r0_p1",
+          "rdma": "roce_r0_p1"
+        },
+        "0001:15:00.0": {
+          "netdev": "eth_r1_p0",
+          "rdma": "roce_r1_p0"
+        },
+        "0001:15:00.1": {
+          "netdev": "eth_r1_p1",
+          "rdma": "roce_r1_p1"
+        }
+      },
+      "vf_endpoints": [
+        {
+          "control_bdf": "0000:64:00.0",
+          "vf_netdev": "eth_vf_r0",
+          "vf_rdma": "roce_vf_r0",
+          "vf_rep": "eth_vf_rep_r0"
+        },
+        {
+          "control_bdf": "0001:15:00.0",
+          "vf_netdev": "eth_vf_r1",
+          "vf_rdma": "roce_vf_r1",
+          "vf_rep": "eth_vf_rep_r1"
+        }
+      ]
+    },
+    "path_dialect": "nvidia-t1",
+    "profile_metadata": {
+      "deployable": true,
+      "family": "spcx",
+      "ra_version": "2.2",
+      "recipe_version": "RA2.2",
+      "profile_digest": "f2bb4e7a0f1100450a84e29b45bce66747c387fbb28f90015d00d68ad52b9846",
+      "maturity": "production",
+      "resolved_variant": "gb300-hwmp",
+      "platform_type": "gb300",
+      "target_binding": {
+        "network_role": "ew"
+      },
+      "platform": {
+        "allowed": [
+          "gb300"
+        ]
+      }
+    },
+    "operations": {
+      "spcx-base-nvconfig.roce.adaptive-routing-cc-steering-ext-tx-sched-locality-mode": {
+        "path": "/nvidia/roce",
+        "values": {
+          "adaptive-routing": true,
+          "tx-sched-locality-mode": "accumulative",
+          "cc-steering-ext": "enabled"
+        },
+        "source_feature": "spcx-base-nvconfig",
+        "kind": "set",
+        "target_class": "pf_netdev_all",
+        "execution_group": "breakout",
+        "reset": {
+          "action": "host-reboot",
+          "owner": "host-operator",
+          "postcondition": "all pending Spectrum-X NVConfig values become current"
+        },
+        "target_role": "ew"
+      },
+      "spcx-base-nvconfig.cc-config.user-programmable": {
+        "path": "/nvidia/cc/config",
+        "values": {
+          "user-programmable": true
+        },
+        "source_feature": "spcx-base-nvconfig",
+        "kind": "set",
+        "target_class": "pf_netdev_all",
+        "execution_group": "breakout",
+        "reset": {
+          "action": "host-reboot",
+          "owner": "host-operator",
+          "postcondition": "all pending Spectrum-X NVConfig values become current"
+        },
+        "target_role": "ew"
+      },
+      "ra22-hwmp-breakout-delta.pci.num-pfs": {
+        "path": "/nvidia/pci",
+        "values": {
+          "num-pfs": 2
+        },
+        "source_feature": "ra22-hwmp-breakout-delta",
+        "kind": "set",
+        "target_class": "pf_netdev_all",
+        "execution_group": "breakout",
+        "reset": {
+          "action": "host-reboot",
+          "owner": "host-operator",
+          "postcondition": "post-breakout PF topology and XPlane NVConfig become current"
+        },
+        "target_role": "ew"
+      },
+      "ra22-hwmp-breakout-delta.multiplane.num-planes": {
+        "path": "/nvidia/multiplane",
+        "values": {
+          "num-planes": 2
+        },
+        "source_feature": "ra22-hwmp-breakout-delta",
+        "kind": "set",
+        "target_class": "pf_netdev_all",
+        "execution_group": "breakout",
+        "reset": {
+          "action": "host-reboot",
+          "owner": "host-operator",
+          "postcondition": "post-breakout PF topology and XPlane NVConfig become current"
+        },
+        "target_role": "ew"
+      },
+      "ra22-hwmp-breakout-delta.link-breakout-module-0-port-1.lanes": {
+        "path": "/nvidia/link/breakout/module/[0]/port/[1]",
+        "values": {
+          "lanes": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ]
+        },
+        "source_feature": "ra22-hwmp-breakout-delta",
+        "kind": "set",
+        "target_class": "pf_netdev_all",
+        "execution_group": "breakout",
+        "reset": {
+          "action": "host-reboot",
+          "owner": "host-operator",
+          "postcondition": "post-breakout PF topology and XPlane NVConfig become current"
+        },
+        "condition": {
+          "knob": "@params.nic_type == '1023'"
+        },
+        "context": {
+          "hca_type": "ConnectX-8",
+          "device_hca_types": [
+            "ConnectX-8"
+          ],
+          "platform_type": "gb300"
+        },
+        "target_role": "ew"
+      },
+      "ra22-hwmp-breakout-delta.link-breakout-module-0-port-255.lanes": {
+        "path": "/nvidia/link/breakout/module/[0]/port/[255]",
+        "values": {
+          "lanes": [
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15
+          ]
+        },
+        "source_feature": "ra22-hwmp-breakout-delta",
+        "kind": "set",
+        "target_class": "pf_netdev_all",
+        "execution_group": "breakout",
+        "reset": {
+          "action": "host-reboot",
+          "owner": "host-operator",
+          "postcondition": "post-breakout PF topology and XPlane NVConfig become current"
+        },
+        "condition": {
+          "knob": "@params.nic_type == '1023'"
+        },
+        "context": {
+          "hca_type": "ConnectX-8",
+          "device_hca_types": [
+            "ConnectX-8"
+          ],
+          "platform_type": "gb300"
+        },
+        "target_role": "ew"
+      },
+      "ra22-hwmp-prepare-delta.link-policy.keep-eth-link-up": {
+        "path": "/nvidia/link/policy",
+        "values": {
+          "keep-eth-link-up": false
+        },
+        "source_feature": "ra22-hwmp-prepare-delta",
+        "kind": "set",
+        "target_class": "pf_netdev_all",
+        "execution_group": "breakout",
+        "reset": {
+          "action": "device-reset",
+          "owner": "DMS-or-operator",
+          "postcondition": "pending value becomes current"
+        },
+        "target_role": "ew"
+      },
+      "ra22-hwmp-prepare-delta.multiplane.load-balance-mode": {
+        "path": "/nvidia/multiplane",
+        "values": {
+          "load-balance-mode": "transport"
+        },
+        "source_feature": "ra22-hwmp-prepare-delta",
+        "kind": "set",
+        "target_class": "pf_netdev_all",
+        "execution_group": "breakout",
+        "reset": {
+          "action": "device-reset",
+          "owner": "DMS-or-operator",
+          "postcondition": "pending value becomes current"
+        },
+        "target_role": "ew"
+      },
+      "ra22-hwmp-prepare-delta.lag.resource-allocation": {
+        "path": "/nvidia/lag",
+        "values": {
+          "resource-allocation": "pre-allocation"
+        },
+        "source_feature": "ra22-hwmp-prepare-delta",
+        "kind": "set",
+        "target_class": "pf_netdev_all",
+        "execution_group": "breakout",
+        "reset": {
+          "action": "device-reset",
+          "owner": "DMS-or-operator",
+          "postcondition": "pending value becomes current"
+        },
+        "target_role": "ew"
+      },
+      "spcx-hwmp-sriov-nvconfig.pci-sriov.enabled-max-vfs": {
+        "path": "/nvidia/pci/sriov",
+        "values": {
+          "enabled": true,
+          "max-vfs": 1
+        },
+        "source_feature": "spcx-hwmp-sriov-nvconfig",
+        "kind": "set",
+        "target_class": "pf_netdev_all",
+        "execution_group": "breakout",
+        "reset": {
+          "action": "device-reset",
+          "owner": "DMS-or-operator",
+          "postcondition": "pending value becomes current"
+        },
+        "target_role": "ew"
+      },
+      "ra22-hwmp-nvconfig-delta.link-type.value": {
+        "path": "/nvidia/link/type",
+        "values": {
+          "value": "ETH"
+        },
+        "source_feature": "ra22-hwmp-nvconfig-delta",
+        "kind": "set",
+        "execution_group": "breakout",
+        "reset": {
+          "action": "device-reset",
+          "owner": "DMS-or-operator",
+          "postcondition": "pending value becomes current"
+        },
+        "target_role": "ew",
+        "target_class": "pf_netdev_all"
+      },
+      "ra22-hwmp-nvconfig-delta.roce-rtt.dscp-dscp-mode": {
+        "path": "/nvidia/roce/rtt",
+        "values": {
+          "dscp": 48,
+          "dscp-mode": "fixed"
+        },
+        "source_feature": "ra22-hwmp-nvconfig-delta",
+        "kind": "set",
+        "execution_group": "breakout",
+        "reset": {
+          "action": "device-reset",
+          "owner": "DMS-or-operator",
+          "postcondition": "pending value becomes current"
+        },
+        "target_role": "ew",
+        "target_class": "pf_netdev_all"
+      },
+      "ra22-hwmp-nvconfig-delta.misc-parser.flex-parser-profile": {
+        "path": "/nvidia/misc/parser",
+        "values": {
+          "flex-parser-profile": 10
+        },
+        "source_feature": "ra22-hwmp-nvconfig-delta",
+        "kind": "set",
+        "execution_group": "breakout",
+        "reset": {
+          "action": "device-reset",
+          "owner": "DMS-or-operator",
+          "postcondition": "pending value becomes current"
+        },
+        "target_role": "ew",
+        "target_class": "pf_netdev_all"
+      },
+      "ra22-hwmp-nvconfig-delta.pci.rde-disable": {
+        "path": "/nvidia/pci",
+        "values": {
+          "rde-disable": true
+        },
+        "source_feature": "ra22-hwmp-nvconfig-delta",
+        "kind": "set",
+        "execution_group": "breakout",
+        "reset": {
+          "action": "device-reset",
+          "owner": "DMS-or-operator",
+          "postcondition": "pending value becomes current"
+        },
+        "target_role": "ew",
+        "target_class": "pf_netdev_all"
+      },
+      "ra22-hwmp-nvconfig-delta.pci-sriov.vf-log-bar-size": {
+        "path": "/nvidia/pci/sriov",
+        "values": {
+          "vf-log-bar-size": 5
+        },
+        "source_feature": "ra22-hwmp-nvconfig-delta",
+        "kind": "set",
+        "execution_group": "breakout",
+        "reset": {
+          "action": "device-reset",
+          "owner": "DMS-or-operator",
+          "postcondition": "pending value becomes current"
+        },
+        "target_role": "ew",
+        "target_class": "pf_netdev_all"
+      }
+    },
+    "semantic": {
+      "groups": [
+        {
+          "name": "breakout",
+          "stage": "prepare",
+          "order": 10,
+          "scope": "per_device",
+          "device_view": "pre_breakout",
+          "requires_reboot": true,
+          "operation_refs": [
+            "spcx-base-nvconfig.roce.adaptive-routing-cc-steering-ext-tx-sched-locality-mode",
+            "spcx-base-nvconfig.cc-config.user-programmable",
+            "ra22-hwmp-breakout-delta.pci.num-pfs",
+            "ra22-hwmp-breakout-delta.multiplane.num-planes",
+            "ra22-hwmp-breakout-delta.link-breakout-module-0-port-1.lanes",
+            "ra22-hwmp-breakout-delta.link-breakout-module-0-port-255.lanes",
+            "ra22-hwmp-prepare-delta.link-policy.keep-eth-link-up",
+            "ra22-hwmp-prepare-delta.multiplane.load-balance-mode",
+            "ra22-hwmp-prepare-delta.lag.resource-allocation",
+            "spcx-hwmp-sriov-nvconfig.pci-sriov.enabled-max-vfs",
+            "ra22-hwmp-nvconfig-delta.link-type.value",
+            "ra22-hwmp-nvconfig-delta.roce-rtt.dscp-dscp-mode",
+            "ra22-hwmp-nvconfig-delta.misc-parser.flex-parser-profile",
+            "ra22-hwmp-nvconfig-delta.pci.rde-disable",
+            "ra22-hwmp-nvconfig-delta.pci-sriov.vf-log-bar-size"
+          ]
+        },
+        {
+          "name": "post-breakout",
+          "stage": "prepare",
+          "order": 20,
+          "scope": "mixed",
+          "device_view": "post_breakout",
+          "requires_reboot": true,
+          "semantic_visible": true,
+          "description": "Post-breakout reset barrier. SWMP: physical-port NVConfig on derived PFs. HWMP: host reboot prerequisites (boot-policy/ACS); SuperNIC NVConfig stays on master PFs in breakout.",
+          "operation_refs": []
+        }
+      ]
+    },
+    "metadata": {
+      "substrate_version": "1.0",
+      "schema_version": "3.0",
+      "created_at": "2026-08-13T08:01:37.227834+00:00"
+    }
+  },
+  "artifacts": {
+    "manifest": []
+  }
+}


### PR DESCRIPTION
## Summary

- parse and validate cached host-k8s doSPCX semantic groups and operation references
- resolve supported prepare and configure operations into target-specific dms-cli query and SET batches without executing them
- add generic typed XPath GET and SET helpers, including pending-value queries and repeated leaf-list assignments
- explicitly report `eswitch` and `vf-lifecycle` as skipped and fail closed on unknown groups
- cover translation with actual generated host-k8s prepare and configure plans

## Scope

This PR does not execute generated plan operations. It exposes the parsed semantic plan and execution-free DMS batches for the next integration stage.

## Testing

- `go test ./pkg/dmscli/... -count=1`
- `go test ./pkg/spectrumx/... -count=1 -timeout 5m`
- `go build ./...`
- `bin/golangci-lint-v2.11.4 run`

`make test` passes all non-controller packages. The controller suite still fails the existing `PendingFirmwareUpdate` condition assertion; the focused test reproduces unchanged on `upstream/main`.