### PR TITLE
fix: handle with-default no-op apply status

### DIFF
--- a/docs/nic-configuration-library.md
+++ b/docs/nic-configuration-library.md
@@ -166,13 +166,13 @@ func NewConfigurationManager(
 1. **Query** current NV config via `nvConfigUtils.QueryNvConfig()`
 2. **Network Bay `set_system_conf` (baseline, applied first)** — for ConnectX-9 Network Bay devices (`template.networkBay` set and `status.networkBay` detected), the per-ASIC `set_system_conf <conf>[<asic>]` is applied **before** the regular / Spectrum-X params so those layer on top of it (override priority: `rawNvConfig` > Spectrum-X > system_conf). Drift is detected per-param via `nvconfig.ValidateSystemConf()`, which returns the overall match bit plus the names of the mismatched params; the manager ignores MISMATCH rows for params owned by a higher-priority layer (matched by exact per-index key — `rawNvConfig` index-range syntax like `MODULE_SPLIT_M0[0..3]` is rejected by CRD validation, so keys are always concrete); a change requires a reboot. Skipped for devices with `ResetToDefault`
 3. **Diff** desired vs current parameters. Params not present in the device's next-boot config are unsupported on this device (e.g. hidden because `ADVANCED_PCI_SETTINGS` is off) and are skipped — the operator does **not** auto-manage `ADVANCED_PCI_SETTINGS`; drive it explicitly via `template.rawNvConfig` if needed
-4. **Batch set** via `nvConfigUtils.SetNvConfigParametersBatch()` — single `mlxconfig set` call (`--force` added when `ConfigurationOptions.Force=true`). Apply reports `ApplyStatusPartiallyApplied` when any desired param was skipped as unsupported
+4. **Batch set** via `nvConfigUtils.SetNvConfigParametersBatch()` — single `mlxconfig set` call (`--force` added when `ConfigurationOptions.Force=true`). Apply reports `ApplyStatusPartiallyApplied` when any desired param was skipped as unsupported. With `ConfigurationOptions.WithDefault=true`, the batch setter parses `mlxconfig` output and returns `ApplyStatusNothingToDo` when the command succeeds but no params are changed.
 5. **Optional reset** — `mlxfwreset` unless `ConfigurationOptions.SkipReset=true`
 
 **`ConfigurationOptions`:**
 - `SkipReset` — skip `mlxfwreset` after applying NV config
 - `WithDefault` — add `--with_default` to `mlxconfig set`
-- `Force` — add `--force` to `mlxconfig set` and `set_system_conf` (lets mlxconfig accept a batch it would otherwise refuse due to implicit parameter dependencies)
+- `Force` — add `--force` to `mlxconfig set` and `set_system_conf` (lets mlxconfig accept a batch it would otherwise refuse due to implicit parameter dependencies). When `NUM_OF_PF` and a `_P1` value are present, force mode copies that value to missing higher ports up to the requested PF count before applying; explicit per-port values are preserved.
 
 #### Runtime Configuration Flow
 
@@ -366,7 +366,7 @@ type NVConfigUtils interface {
     // params: map of paramName → paramValue
     // withDefault: add --with_default flag
     // force: add --force flag
-    SetNvConfigParametersBatch(port v1alpha1.NicDevicePortSpec, params map[string]string, withDefault bool, force bool) error
+    SetNvConfigParametersBatch(port v1alpha1.NicDevicePortSpec, params map[string]string, withDefault bool, force bool) (types.ApplyStatus, error)
 
     // ResetNvConfig resets NIC's NV config to defaults
     ResetNvConfig(port v1alpha1.NicDevicePortSpec) error
@@ -389,7 +389,8 @@ func NewNVConfigUtils() NVConfigUtils
 
 **Batch command format:**
 ```
-mlxconfig -d <device> --yes [--with_default] [--force] set PARAM1=VAL1 PARAM2=VAL2 ...
+mlxconfig -d <device> --yes [--force] set PARAM1=VAL1 PARAM2=VAL2 ...
+mlxconfig -d <device> -e --with_default -y [--force] set PARAM1=VAL1 PARAM2=VAL2 ...
 ```
 Parameter names are sorted for deterministic command generation.
 `<device>` is `port.FwctlDevice` when discovered, otherwise `port.PCI`.

--- a/pkg/configuration/manager.go
+++ b/pkg/configuration/manager.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 
 	"k8s.io/client-go/tools/record"
@@ -223,6 +224,9 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 		log.Log.Error(err, "failed to calculate desired nvconfig parameters", "device", device.Name)
 		return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
 	}
+	if options.Force {
+		extrapolatePortParamsFromNumOfPF(desiredParams)
+	}
 	log.Log.V(2).Info("combined desired nv config built", "device", device.Name, "params", desiredParams, "force", options.Force)
 
 	// 5. set_system_conf baseline: if the combined params do not cover all mismatched profile params
@@ -272,7 +276,9 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 					hasUnsupportedParams = true
 					continue
 				}
-				if !slices.Contains(nextValues, value) {
+				// WithDefault still requires the param to exist in the query, but applies it even
+				// when next-boot already contains the desired value.
+				if options.WithDefault || !slices.Contains(nextValues, value) {
 					batch[param] = value
 				}
 			}
@@ -281,11 +287,14 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 			continue
 		}
 		log.Log.V(2).Info("applying nv config to device", "device", device.Name, "pci", port.PCI, "fwctlDevice", port.FwctlDevice, "config", batch, "force", options.Force)
-		if err := h.nvConfigUtils.SetNvConfigParametersBatch(port, batch, options.WithDefault, options.Force); err != nil {
+		applyStatus, err := h.nvConfigUtils.SetNvConfigParametersBatch(port, batch, options.WithDefault, options.Force)
+		if err != nil {
 			log.Log.Error(err, "Failed to apply nv config parameters", "device", device.Name, "params", batch)
 			return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
 		}
-		anyParamsApplied = true
+		if applyStatus == types.ApplyStatusSuccess {
+			anyParamsApplied = true
+		}
 	}
 
 	if !anyParamsApplied && !hasUnsupportedParams && !systemConfApplied {
@@ -301,6 +310,35 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 	log.Log.Info("nv config applied", "device", device.Name, "status", status, "rebootRequired", rebootRequired)
 
 	return &types.ConfigurationApplyResult{Status: status, RebootRequired: rebootRequired}, nil
+}
+
+func extrapolatePortParamsFromNumOfPF(params map[string]string) {
+	value, ok := params[consts.NumOfPfParam]
+	if !ok {
+		return
+	}
+	portCount, err := strconv.Atoi(value)
+	if err != nil || portCount < 2 {
+		return
+	}
+
+	baseValues := map[string]string{}
+	for param, value := range params {
+		portNum, ok := consts.PortSuffixNum(param)
+		if !ok || portNum != 1 {
+			continue
+		}
+		base := param[:len(param)-len(strconv.Itoa(portNum))-2]
+		baseValues[base] = value
+	}
+	for base, baseValue := range baseValues {
+		for portNum := 1; portNum <= portCount; portNum++ {
+			param := consts.PortParam(base, portNum)
+			if _, exists := params[param]; !exists {
+				params[param] = baseValue
+			}
+		}
+	}
 }
 
 // setSystemConf stages the requested Network Bay set_system_conf for the device's ASIC (the

--- a/pkg/configuration/manager_test.go
+++ b/pkg/configuration/manager_test.go
@@ -51,6 +51,26 @@ func mismatchSystemConf(mismatchedParams ...string) []interface{} {
 }
 
 var _ = Describe("ConfigurationManager", func() {
+	Describe("extrapolatePortParamsFromNumOfPF", func() {
+		It("copies P1 values to missing ports while preserving explicit overrides", func() {
+			params := map[string]string{"NUM_OF_PF": "3", "LINK_TYPE_P1": "2", "LINK_TYPE_P3": "1"}
+
+			extrapolatePortParamsFromNumOfPF(params)
+
+			Expect(params).To(Equal(map[string]string{
+				"NUM_OF_PF": "3", "LINK_TYPE_P1": "2", "LINK_TYPE_P2": "2", "LINK_TYPE_P3": "1",
+			}))
+		})
+
+		It("does not extrapolate from a higher port when P1 is absent", func() {
+			params := map[string]string{"NUM_OF_PF": "3", "LINK_TYPE_P2": "2"}
+
+			extrapolatePortParamsFromNumOfPF(params)
+
+			Expect(params).To(Equal(map[string]string{"NUM_OF_PF": "3", "LINK_TYPE_P2": "2"}))
+		})
+	})
+
 	Describe("configurationManager.ValidateDeviceNvSpec", func() {
 		var (
 			mockHostUtils        mocks.ConfigurationUtils
@@ -654,7 +674,7 @@ var _ = Describe("ConfigurationManager", func() {
 						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 							Return(desiredConfig, nil)
 						mockNV.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"param1": "value2"}, false, false).
-							Return(nil)
+							Return(types.ApplyStatusSuccess, nil)
 
 						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 						Expect(result.RebootRequired).To(BeTrue())
@@ -721,7 +741,7 @@ var _ = Describe("ConfigurationManager", func() {
 							Return(desiredConfig, nil)
 						setParamErr := errors.New("failed to set param1")
 						mockNV.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"param1": "value3"}, false, false).
-							Return(setParamErr)
+							Return(types.ApplyStatusFailed, setParamErr)
 
 						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 						Expect(result.RebootRequired).To(BeFalse())
@@ -752,7 +772,8 @@ var _ = Describe("ConfigurationManager", func() {
 						mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress2), []string(nil)).Return(nvConfig1, nil)
 						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig0).Return(map[string]string{"TRACER_ENABLED": "1"}, nil)
 						// Only port2 should be updated
-						mockNV.On("SetNvConfigParametersBatch", portSpec(pciAddress2), map[string]string{"TRACER_ENABLED": "1"}, false, false).Return(nil)
+						mockNV.On("SetNvConfigParametersBatch", portSpec(pciAddress2), map[string]string{"TRACER_ENABLED": "1"}, false, false).
+							Return(types.ApplyStatusSuccess, nil)
 
 						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 						Expect(err).To(BeNil())
@@ -805,7 +826,7 @@ var _ = Describe("ConfigurationManager", func() {
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 						Return(desiredConfig, nil)
 					mockNV.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"param1": "newValue3", "param2": "newValue3"}, false, false).
-						Return(nil)
+						Return(types.ApplyStatusSuccess, nil)
 
 					result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 					Expect(result.RebootRequired).To(BeTrue())
@@ -1371,7 +1392,8 @@ var _ = Describe("ConfigurationManager", func() {
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(map[string]string{"NUM_OF_PF": "2", "LINK_TYPE_P1": "2"}, nil)
 				// NUM_OF_PF differs (1 != 2) and is applied; LINK_TYPE_P1 already matches and is skipped.
-				mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, false, false).Return(nil)
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, false, false).
+					Return(types.ApplyStatusSuccess, nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 				Expect(err).NotTo(HaveOccurred())
@@ -1383,7 +1405,7 @@ var _ = Describe("ConfigurationManager", func() {
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(map[string]string{"NUM_OF_PF": "2", "LINK_TYPE_P1": "2"}, nil)
 				mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress),
-					map[string]string{"NUM_OF_PF": "2", "LINK_TYPE_P1": "2"}, false, true).Return(nil)
+					map[string]string{"NUM_OF_PF": "2", "LINK_TYPE_P1": "2", "LINK_TYPE_P2": "2"}, false, true).Return(types.ApplyStatusSuccess, nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{Force: true})
 				Expect(err).NotTo(HaveOccurred())
@@ -1396,8 +1418,10 @@ var _ = Describe("ConfigurationManager", func() {
 				mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress2), []string(nil)).Return(types.NvConfigQuery{}, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(map[string]string{"NUM_OF_PF": "2"}, nil)
-				mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, false, true).Return(nil)
-				mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress2), map[string]string{"NUM_OF_PF": "2"}, false, true).Return(nil)
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, false, true).
+					Return(types.ApplyStatusSuccess, nil)
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress2), map[string]string{"NUM_OF_PF": "2"}, false, true).
+					Return(types.ApplyStatusSuccess, nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{Force: true})
 				Expect(err).NotTo(HaveOccurred())
@@ -1410,11 +1434,39 @@ var _ = Describe("ConfigurationManager", func() {
 					types.NvConfigQuery{NextBootConfig: map[string][]string{"NUM_OF_PF": {"1"}}}, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(map[string]string{"NUM_OF_PF": "2"}, nil)
-				mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, true, false).Return(nil)
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, true, false).
+					Return(types.ApplyStatusSuccess, nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{WithDefault: true})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.RebootRequired).To(BeTrue())
+			})
+
+			It("returns NothingToDo when WithDefault=true but mlxconfig reports no changed params", func() {
+				mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(
+					types.NvConfigQuery{NextBootConfig: map[string][]string{"NUM_OF_PF": {"2"}}}, nil)
+				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
+					Return(map[string]string{"NUM_OF_PF": "2"}, nil)
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, true, false).
+					Return(types.ApplyStatusNothingToDo, nil)
+
+				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{WithDefault: true})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Status).To(Equal(types.ApplyStatusNothingToDo))
+				Expect(result.RebootRequired).To(BeFalse())
+			})
+
+			It("returns NothingToDo when Force and WithDefault are true but mlxconfig reports no changed params", func() {
+				mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(types.NvConfigQuery{}, nil)
+				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
+					Return(map[string]string{"NUM_OF_PF": "2"}, nil)
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, true, true).
+					Return(types.ApplyStatusNothingToDo, nil)
+
+				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{Force: true, WithDefault: true})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Status).To(Equal(types.ApplyStatusNothingToDo))
+				Expect(result.RebootRequired).To(BeFalse())
 			})
 
 			It("returns NothingToDo when the combined params already match", func() {
@@ -1452,7 +1504,8 @@ var _ = Describe("ConfigurationManager", func() {
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 						Return(map[string]string{"NUM_OF_PF": "2"}, nil)
 					mockNVConfigUtils.On("SetSystemConf", ctx, portSpec(pciAddress), "conf3", 0, true).Return(nil)
-					mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, false, true).Return(nil)
+					mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, false, true).
+						Return(types.ApplyStatusSuccess, nil)
 
 					result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{Force: true})
 					Expect(err).NotTo(HaveOccurred())
@@ -1465,7 +1518,8 @@ var _ = Describe("ConfigurationManager", func() {
 						Return(mismatchSystemConf("NUM_OF_PF")...)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 						Return(map[string]string{"NUM_OF_PF": "2"}, nil)
-					mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, false, true).Return(nil)
+					mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, false, true).
+						Return(types.ApplyStatusSuccess, nil)
 					mockNVConfigUtils.AssertNotCalled(GinkgoT(), "SetSystemConf", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 
 					result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{Force: true})
@@ -1639,7 +1693,7 @@ var _ = Describe("ConfigurationManager", func() {
 				setSystemConfCall := mockNV.On("SetSystemConf", ctx, portSpec(pciAddress), "conf3", 0, false).Return(nil)
 				// set_system_conf is the baseline and must be staged before the override batch.
 				mockNV.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"param1": "value2"}, false, false).
-					Return(nil).NotBefore(setSystemConfCall)
+					Return(types.ApplyStatusSuccess, nil).NotBefore(setSystemConfCall)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 				Expect(err).NotTo(HaveOccurred())
@@ -1782,7 +1836,8 @@ var _ = Describe("ConfigurationManager", func() {
 					types.NvConfigQuery{NextBootConfig: staged, CurrentConfig: staged}, nil)
 				fullFlowNV.On("ValidateSystemConf", fullFlowCtx, portSpec(pciAddress), "conf3", 0).
 					Return(mismatchSystemConf("NUM_OF_PF")...)
-				fullFlowNV.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "8"}, false, false).Return(nil)
+				fullFlowNV.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "8"}, false, false).
+					Return(types.ApplyStatusSuccess, nil)
 
 				updateNeeded, rebootNeeded, _, err := fullFlowManager.ValidateDeviceNvSpec(fullFlowCtx, fullFlowDevice)
 				Expect(err).NotTo(HaveOccurred())
@@ -1836,7 +1891,8 @@ var _ = Describe("ConfigurationManager", func() {
 				fullFlowNV.On("ValidateSystemConf", fullFlowCtx, portSpec(pciAddress), "conf3", 0).
 					Return(mismatchSystemConf("NUM_OF_PF", "LINK_TYPE_P1")...)
 				// Only LINK_TYPE_P1 differs from next boot; the raw value 2 wins over the Spectrum-X value 1.
-				fullFlowNV.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"LINK_TYPE_P1": "2"}, false, false).Return(nil)
+				fullFlowNV.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"LINK_TYPE_P1": "2"}, false, false).
+					Return(types.ApplyStatusSuccess, nil)
 
 				updateNeeded, rebootNeeded, _, err := fullFlowManager.ValidateDeviceNvSpec(fullFlowCtx, fullFlowDevice)
 				Expect(err).NotTo(HaveOccurred())
@@ -1874,7 +1930,7 @@ var _ = Describe("ConfigurationManager", func() {
 					Return(mismatchSystemConf("NUM_OF_PF", "LINK_TYPE_P1")...)
 				// Raw wins on both: LINK_TYPE_P1 over Spectrum-X (1→2) and NUM_OF_VFS over template (4→16).
 				fullFlowNV.On("SetNvConfigParametersBatch", portSpec(pciAddress),
-					map[string]string{"LINK_TYPE_P1": "2", consts.SriovNumOfVfsParam: "16"}, false, false).Return(nil)
+					map[string]string{"LINK_TYPE_P1": "2", consts.SriovNumOfVfsParam: "16"}, false, false).Return(types.ApplyStatusSuccess, nil)
 
 				updateNeeded, rebootNeeded, _, err := fullFlowManager.ValidateDeviceNvSpec(fullFlowCtx, fullFlowDevice)
 				Expect(err).NotTo(HaveOccurred())

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -91,6 +91,7 @@ const (
 
 	SriovEnabledParam        = "SRIOV_EN"
 	SriovNumOfVfsParam       = "NUM_OF_VFS"
+	NumOfPfParam             = "NUM_OF_PF"
 	LinkTypeP1Param          = "LINK_TYPE_P1"
 	LinkTypeP2Param          = "LINK_TYPE_P2"
 	MaxAccOutReadParam       = "MAX_ACC_OUT_READ"

--- a/pkg/nvconfig/mocks/NVConfigUtils.go
+++ b/pkg/nvconfig/mocks/NVConfigUtils.go
@@ -81,21 +81,31 @@ func (_m *NVConfigUtils) SetNvConfigParameter(port v1alpha1.NicDevicePortSpec, p
 }
 
 // SetNvConfigParametersBatch provides a mock function with given fields: port, params, withDefault, force
-func (_m *NVConfigUtils) SetNvConfigParametersBatch(port v1alpha1.NicDevicePortSpec, params map[string]string, withDefault bool, force bool) error {
+func (_m *NVConfigUtils) SetNvConfigParametersBatch(port v1alpha1.NicDevicePortSpec, params map[string]string, withDefault bool, force bool) (types.ApplyStatus, error) {
 	ret := _m.Called(port, params, withDefault, force)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SetNvConfigParametersBatch")
 	}
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(v1alpha1.NicDevicePortSpec, map[string]string, bool, bool) error); ok {
+	var r0 types.ApplyStatus
+	var r1 error
+	if rf, ok := ret.Get(0).(func(v1alpha1.NicDevicePortSpec, map[string]string, bool, bool) (types.ApplyStatus, error)); ok {
+		return rf(port, params, withDefault, force)
+	}
+	if rf, ok := ret.Get(0).(func(v1alpha1.NicDevicePortSpec, map[string]string, bool, bool) types.ApplyStatus); ok {
 		r0 = rf(port, params, withDefault, force)
 	} else {
-		r0 = ret.Error(0)
+		r0 = ret.Get(0).(types.ApplyStatus)
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(v1alpha1.NicDevicePortSpec, map[string]string, bool, bool) error); ok {
+		r1 = rf(port, params, withDefault, force)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // SetSystemConf provides a mock function with given fields: ctx, port, conf, asic, force

--- a/pkg/nvconfig/utils.go
+++ b/pkg/nvconfig/utils.go
@@ -57,7 +57,7 @@ type NVConfigUtils interface {
 	// SetNvConfigParametersBatch sets multiple nv config parameters for a mellanox device in a single mlxconfig call
 	// When force is true, --force is passed to mlxconfig so it accepts a batch it would otherwise refuse
 	// due to implicit parameter dependencies.
-	SetNvConfigParametersBatch(port v1alpha1.NicDevicePortSpec, params map[string]string, withDefault bool, force bool) error
+	SetNvConfigParametersBatch(port v1alpha1.NicDevicePortSpec, params map[string]string, withDefault bool, force bool) (types.ApplyStatus, error)
 	// ResetNvConfig resets NIC's nv config
 	ResetNvConfig(port v1alpha1.NicDevicePortSpec) error
 	// SetSystemConf applies a ConnectX-9 Network Bay system configuration for a single ASIC via
@@ -208,13 +208,23 @@ func (h *nvConfigUtils) SetNvConfigParameter(port v1alpha1.NicDevicePortSpec, pa
 	return nil
 }
 
+func parseSetNvConfigParametersBatchStatus(output []byte, withDefault bool) types.ApplyStatus {
+	if strings.Contains(string(output), "Configurations:") {
+		return types.ApplyStatusSuccess
+	}
+	if withDefault {
+		return types.ApplyStatusNothingToDo
+	}
+	return types.ApplyStatusSuccess
+}
+
 // SetNvConfigParametersBatch sets multiple nv config parameters for a mellanox device in a single mlxconfig call
-func (h *nvConfigUtils) SetNvConfigParametersBatch(port v1alpha1.NicDevicePortSpec, params map[string]string, withDefault bool, force bool) error {
+func (h *nvConfigUtils) SetNvConfigParametersBatch(port v1alpha1.NicDevicePortSpec, params map[string]string, withDefault bool, force bool) (types.ApplyStatus, error) {
 	targetDevice := resolveDevice(port)
 	log.Log.Info("ConfigurationUtils.SetNvConfigParametersBatch()", "pciAddr", port.PCI, "targetDevice", targetDevice, "params", params, "withDefault", withDefault, "force", force)
 
 	if len(params) == 0 {
-		return nil
+		return types.ApplyStatusNothingToDo, nil
 	}
 
 	// Build sorted param list for deterministic command
@@ -229,9 +239,11 @@ func (h *nvConfigUtils) SetNvConfigParametersBatch(port v1alpha1.NicDevicePortSp
 		paramArgs = append(paramArgs, name+"="+params[name])
 	}
 
-	args := []string{"-d", targetDevice, "--yes"}
+	args := []string{"-d", targetDevice}
 	if withDefault {
-		args = append(args, "--with_default")
+		args = append(args, "-e", "--with_default", "-y")
+	} else {
+		args = append(args, "--yes")
 	}
 	if force {
 		args = append(args, "--force")
@@ -240,12 +252,13 @@ func (h *nvConfigUtils) SetNvConfigParametersBatch(port v1alpha1.NicDevicePortSp
 	args = append(args, paramArgs...)
 
 	cmd := h.execInterface.Command("mlxconfig", args...)
-	output, err := utils.RunCommand(cmd)
+	output, err := cmd.CombinedOutput()
+	log.Log.V(2).Info("command output", "output", string(output))
 	if err != nil {
-		log.Log.Error(err, "SetNvConfigParametersBatch(): Failed to run mlxconfig", "output", string(output))
-		return err
+		log.Log.Error(err, "SetNvConfigParametersBatch(): Failed to run mlxconfig")
+		return types.ApplyStatusFailed, fmt.Errorf("failed to run mlxconfig: %w: %s", err, strings.TrimSpace(string(output)))
 	}
-	return nil
+	return parseSetNvConfigParametersBatchStatus(output, withDefault), nil
 }
 
 // systemConfToken builds the `<conf>[<asic>]` argument for set/validate_system_conf, e.g. conf3[0].

--- a/pkg/nvconfig/utils_test.go
+++ b/pkg/nvconfig/utils_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/Mellanox/nic-configuration-operator/api/v1alpha1"
 	"github.com/Mellanox/nic-configuration-operator/pkg/consts"
+	"github.com/Mellanox/nic-configuration-operator/pkg/types"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/exec"
@@ -615,7 +616,7 @@ Result: Device configuration does NOT match the system configuration.
 
 		It("appends --force when force is true", func() {
 			cmd := &execTesting.FakeCmd{}
-			cmd.OutputScript = append(cmd.OutputScript, func() ([]byte, []byte, error) {
+			cmd.CombinedOutputScript = append(cmd.CombinedOutputScript, func() ([]byte, []byte, error) {
 				return []byte("ok"), nil, nil
 			})
 			fakeExec.CommandScript = []execTesting.FakeCommandAction{
@@ -625,12 +626,14 @@ Result: Device configuration does NOT match the system configuration.
 					return cmd
 				},
 			}
-			Expect(h.SetNvConfigParametersBatch(nvconfigPort(pciAddress), map[string]string{"PARAM": "1"}, false, true)).To(Succeed())
+			status, err := h.SetNvConfigParametersBatch(nvconfigPort(pciAddress), map[string]string{"PARAM": "1"}, false, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).To(Equal(types.ApplyStatusSuccess))
 		})
 
 		It("omits --force when force is false", func() {
 			cmd := &execTesting.FakeCmd{}
-			cmd.OutputScript = append(cmd.OutputScript, func() ([]byte, []byte, error) {
+			cmd.CombinedOutputScript = append(cmd.CombinedOutputScript, func() ([]byte, []byte, error) {
 				return []byte("ok"), nil, nil
 			})
 			fakeExec.CommandScript = []execTesting.FakeCommandAction{
@@ -639,12 +642,30 @@ Result: Device configuration does NOT match the system configuration.
 					return cmd
 				},
 			}
-			Expect(h.SetNvConfigParametersBatch(nvconfigPort(pciAddress), map[string]string{"PARAM": "1"}, false, false)).To(Succeed())
+			status, err := h.SetNvConfigParametersBatch(nvconfigPort(pciAddress), map[string]string{"PARAM": "1"}, false, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).To(Equal(types.ApplyStatusSuccess))
+		})
+
+		It("includes mlxconfig output when the command fails", func() {
+			cmd := &execTesting.FakeCmd{}
+			cmd.CombinedOutputScript = append(cmd.CombinedOutputScript, func() ([]byte, []byte, error) {
+				return []byte("invalid parameter"), nil, fmt.Errorf("exit status 1")
+			})
+			fakeExec.CommandScript = []execTesting.FakeCommandAction{
+				func(name string, args ...string) exec.Cmd { return cmd },
+			}
+
+			status, err := h.SetNvConfigParametersBatch(nvconfigPort(pciAddress), map[string]string{"PARAM": "1"}, false, false)
+
+			Expect(status).To(Equal(types.ApplyStatusFailed))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(And(ContainSubstring("exit status 1"), ContainSubstring("invalid parameter")))
 		})
 
 		It("uses fwctl device when present", func() {
 			cmd := &execTesting.FakeCmd{}
-			cmd.OutputScript = append(cmd.OutputScript, func() ([]byte, []byte, error) {
+			cmd.CombinedOutputScript = append(cmd.CombinedOutputScript, func() ([]byte, []byte, error) {
 				return []byte("ok"), nil, nil
 			})
 			fakeExec.CommandScript = []execTesting.FakeCommandAction{
@@ -654,7 +675,62 @@ Result: Device configuration does NOT match the system configuration.
 				},
 			}
 			port := v1alpha1.NicDevicePortSpec{PCI: pciAddress, FwctlDevice: "/dev/fwctl/fwctl3"}
-			Expect(h.SetNvConfigParametersBatch(port, map[string]string{"PARAM": "1"}, false, false)).To(Succeed())
+			status, err := h.SetNvConfigParametersBatch(port, map[string]string{"PARAM": "1"}, false, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).To(Equal(types.ApplyStatusSuccess))
+		})
+
+		It("passes -y with --with_default and --force and returns nothing-to-do when output has no configurations section", func() {
+			output := `Param SAFE_MODE_ENABLE is not going to be set since value matches next value
+Param SAFE_MODE_THRESHOLD is not going to be set since value matches next value
+
+ Apply reset and set? (y/n) [n] : y
+Done!
+-I- Please reboot machine to load new configurations.
+`
+			cmd := &execTesting.FakeCmd{}
+			cmd.CombinedOutputScript = append(cmd.CombinedOutputScript, func() ([]byte, []byte, error) {
+				return []byte(output), nil, nil
+			})
+			fakeExec.CommandScript = []execTesting.FakeCommandAction{
+				func(name string, args ...string) exec.Cmd {
+					Expect(args).To(Equal([]string{"-d", pciAddress, "-e", "--with_default", "-y", "--force", "set", "SAFE_MODE_ENABLE=1", "SAFE_MODE_THRESHOLD=10"}))
+					return cmd
+				},
+			}
+			status, err := h.SetNvConfigParametersBatch(nvconfigPort(pciAddress), map[string]string{"SAFE_MODE_ENABLE": "1", "SAFE_MODE_THRESHOLD": "10"}, true, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).To(Equal(types.ApplyStatusNothingToDo))
+		})
+
+		It("returns success with --with_default when output has a configurations section", func() {
+			output := `Param SAFE_MODE_ENABLE is not going to be set since value matches next value
+Param SAFE_MODE_THRESHOLD is not going to be set since value matches next value
+
+ Apply reset and set? (y/n) [n] : y
+
+Device #1:
+----------
+
+Configurations:                                         Default                           Current                           Next Boot                         New
+*       SRIOV_EN                                        True(1)                           False(0)                          True(1)                           False(0)
+The '*' shows parameters with next value different from default/current value.
+Applying... Done!
+-I- Please reboot machine to load new configurations.
+`
+			cmd := &execTesting.FakeCmd{}
+			cmd.CombinedOutputScript = append(cmd.CombinedOutputScript, func() ([]byte, []byte, error) {
+				return []byte(output), nil, nil
+			})
+			fakeExec.CommandScript = []execTesting.FakeCommandAction{
+				func(name string, args ...string) exec.Cmd {
+					Expect(args).To(Equal([]string{"-d", pciAddress, "-e", "--with_default", "-y", "set", "SAFE_MODE_ENABLE=1", "SAFE_MODE_THRESHOLD=10", "SRIOV_EN=0"}))
+					return cmd
+				},
+			}
+			status, err := h.SetNvConfigParametersBatch(nvconfigPort(pciAddress), map[string]string{"SAFE_MODE_ENABLE": "1", "SAFE_MODE_THRESHOLD": "10", "SRIOV_EN": "0"}, true, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).To(Equal(types.ApplyStatusSuccess))
 		})
 	})
 })


### PR DESCRIPTION
## Summary

- report whether a `--with_default` NVConfig batch actually changed parameters
- avoid false reboot requirements when mlxconfig reports a no-op
- copy `_P1` values to missing higher ports through `NUM_OF_PF` for forced batches while preserving explicit per-port values
- preserve fwctl device targeting on the 26.7 release branch
- preserve combined mlxconfig diagnostics in returned command errors

## Verification

- `go test ./pkg/nvconfig/... ./pkg/configuration/... -count=1 -timeout 10m`
- `go build ./...`
- `make lint`
- `make test`

This is the `network-operator-26.7.x` backport of #403.
