### PR TITLE
fix: use absolute path for dms-cli executable

### DIFF
--- a/Dockerfile.nic-configuration-daemon
+++ b/Dockerfile.nic-configuration-daemon
@@ -30,8 +30,6 @@ FROM ${BASE_IMAGE_DOCA_FULL_RT_HOST:-nvcr.io/nvstaging/doca/doca:full-rt-3.5.0-h
 
 ARG TARGETARCH
 
-ENV PATH="/opt/mellanox/doca/services/dms:${PATH}"
-
 ARG PACKAGES="dpkg-dev libusb-1.0-0 ipmitool rshim curl systemd-sysv mstflint"
 
 # enable deb-src repos

--- a/docs/nic-configuration-library.md
+++ b/docs/nic-configuration-library.md
@@ -361,10 +361,6 @@ through a `logr.Logger` carried by the context. The command shape is:
 dms-cli --json -t pci/<BDF> --input <payload-json> /nvidia/nvconfig/apply
 ```
 
-`dms-cli` must be available on the caller's `PATH`. The daemon image adds the
-standard DOCA installation directory, `/opt/mellanox/doca/services/dms`, to its
-runtime `PATH`.
-
 The payload supports `ports`, `typed`, `raw`, `with-default`, and `force`.
 `Target` is carried by `-t` and is not serialized. The operator currently
 populates only `Raw`, `WithDefault`, and `Force`; `ports` and `typed` are omitted

--- a/pkg/dmscli/nvconfig.go
+++ b/pkg/dmscli/nvconfig.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	dmsCLIExecutable  = "dms-cli"
+	dmsCLIExecutable  = "/opt/mellanox/doca/services/dms/dms-cli"
 	nvConfigApplyPath = "/nvidia/nvconfig/apply"
 )
 

--- a/pkg/nvconfig/utils_test.go
+++ b/pkg/nvconfig/utils_test.go
@@ -640,7 +640,7 @@ Result: Device configuration does NOT match the system configuration.
 				"A_PARAM": "1",
 			}, true, true)).To(Succeed())
 
-			Expect(commandName).To(Equal("dms-cli"))
+			Expect(commandName).To(Equal("/opt/mellanox/doca/services/dms/dms-cli"))
 			Expect(commandArgs[0:4]).To(Equal([]string{"--json", "-t", "pci/" + pciAddress, "--input"}))
 			Expect(commandArgs[5]).To(Equal("/nvidia/nvconfig/apply"))
 

--- a/pkg/spectrumx/prepareplan_test.go
+++ b/pkg/spectrumx/prepareplan_test.go
@@ -233,7 +233,7 @@ var _ = Describe("doSPCX planning", func() {
 		Expect(string(targetMapContent)).NotTo(ContainSubstring("nic_index_in_rail"))
 
 		Expect(commands).To(HaveLen(1))
-		Expect(commands[0].executable).To(Equal("dms-cli"))
+		Expect(commands[0].executable).To(Equal("/opt/mellanox/doca/services/dms/dms-cli"))
 		Expect(commands[0].args).To(ContainElements(
 			"profile=hwmp",
 			"name="+planName,


### PR DESCRIPTION
Replace the bare 'dms-cli' name with its full path /opt/mellanox/doca/services/dms-cli so the binary is found regardless of PATH, and remove the now-stale doc note about PATH configuration.