### PR TITLE
fix: allow Spectrum-X on standalone ConnectX-7

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ spec:
   * Requires `linkType=Ethernet` and `numVfs=1`
   * Cannot be combined with `roceOptimized` (RoCE settings are included automatically)
   * Can be combined with `rawNvConfig` — raw params are merged as overrides on top of Spectrum-X calculated params
-  * Only supported on ConnectX-8 (`nicType: 1023`), ConnectX-9 (`nicType: 1025`) and BlueField-3 SuperNIC (`nicType: a2dc`)
+  * Only supported on ConnectX-7 (`nicType: 1021`), ConnectX-8 (`nicType: 1023`), ConnectX-9 (`nicType: 1025`) and BlueField-3 SuperNIC (`nicType: a2dc`)
   * `version`: Required. Must match the name of a Spectrum-X profile ConfigMap
   * `overlay`: Optional, default `none`. Set to `l3` for L3 EVPN overlay
   * `multiplaneMode`: Optional, default `none`. Options: `none`, `swplb`, `hwplb`, `uniplane`
@@ -176,6 +176,7 @@ spectrumXOptimized:
 ```
 
 Supported NIC types for Spectrum-X:
+* ConnectX-7 (device ID `1021`) -- supports `none` only (single-plane)
 * ConnectX-8 (device ID `1023`) -- supports all multiplane modes
 * ConnectX-9 (device ID `1025`) -- supports all multiplane modes (same configuration as ConnectX-8)
 * BlueField-3 SuperNIC (device ID `a2dc`) -- supports all multiplane modes except `hwplb`
@@ -184,7 +185,7 @@ Spectrum-X profiles can configure NICs with multiple data planes. Available mode
 
 | Mode | Description | Supported NICs | Planes |
 |------|-------------|----------------|--------|
-| `none` | Single plane (default) | ConnectX-8, ConnectX-9, BF3 SuperNIC | 1 |
+| `none` | Single plane (default) | ConnectX-7, ConnectX-8, ConnectX-9, BF3 SuperNIC | 1 |
 | `swplb` | Software Packet Load Balancing | ConnectX-8, ConnectX-9, BF3 SuperNIC | 2, 4 |
 | `hwplb` | Hardware Packet Load Balancing | ConnectX-8, ConnectX-9 only | 2, 4 |
 | `uniplane` | Uniplane mode | ConnectX-8, ConnectX-9, BF3 SuperNIC | 2 |
@@ -201,7 +202,7 @@ spec:
   nodeSelector:
       feature.node.kubernetes.io/network-sriov.capable: "true"
   nicSelector:
-      nicType: "1023" # ConnectX-8. Use "1025" for ConnectX-9, or "a2dc" for BlueField-3 SuperNIC (hwplb not supported on BF3)
+      nicType: "1023" # ConnectX-8. Use "1025" for ConnectX-9, or "a2dc" for BlueField-3 SuperNIC (hwplb not supported on BF3). ConnectX-7 (`1021`) is single-plane only.
       # partNumbers:
       #   - "MCX713106AEHEA_QP1"
   template:

--- a/api/v1alpha1/nicconfigurationtemplate_types.go
+++ b/api/v1alpha1/nicconfigurationtemplate_types.go
@@ -209,7 +209,8 @@ type ConfigurationTemplateSpec struct {
 }
 
 // NicConfigurationTemplateSpec defines the desired state of NicConfigurationTemplate
-// +kubebuilder:validation:XValidation:rule="!(has(self.template.spectrumXOptimized) && self.template.spectrumXOptimized.enabled) || (self.nicSelector.nicType == '1023' || self.nicSelector.nicType == '1025' || self.nicSelector.nicType == 'a2dc')",message="spectrumXOptimized can be enabled only for ConnectX-8, ConnectX-9 or BlueField-3 SuperNICs"
+// +kubebuilder:validation:XValidation:rule="!(has(self.template.spectrumXOptimized) && self.template.spectrumXOptimized.enabled) || (self.nicSelector.nicType == '1021' || self.nicSelector.nicType == '1023' || self.nicSelector.nicType == '1025' || self.nicSelector.nicType == 'a2dc')",message="spectrumXOptimized can be enabled only for ConnectX-7, ConnectX-8, ConnectX-9 or BlueField-3 SuperNICs"
+// +kubebuilder:validation:XValidation:rule="!has(self.template.spectrumXOptimized) || !has(self.template.spectrumXOptimized.multiplaneMode) || self.nicSelector.nicType != '1021' || self.template.spectrumXOptimized.multiplaneMode == 'none'",message="ConnectX-7 (NicType 1021) supports only single-plane Spectrum-X (multiplaneMode none)"
 // +kubebuilder:validation:XValidation:rule="!has(self.template.spectrumXOptimized) || !has(self.template.spectrumXOptimized.multiplaneMode) || self.template.spectrumXOptimized.multiplaneMode != 'hwplb' || self.nicSelector.nicType == '1023' || self.nicSelector.nicType == '1025'",message="hwplb MultiplaneMode can only be enabled for ConnectX-8 (NicType 1023) or ConnectX-9 (NicType 1025)"
 // +kubebuilder:validation:XValidation:rule="!has(self.template.networkBay) || self.nicSelector.nicType == '1025'",message="networkBay can only be configured for ConnectX-9 (NicType 1025)"
 type NicConfigurationTemplateSpec struct {

--- a/api/v1alpha1/validation_test.go
+++ b/api/v1alpha1/validation_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 const (
+	nicTypeConnectX7   = "1021"
 	nicTypeConnectX8   = "1023"
 	nicTypeConnectX9   = "1025"
 	nicTypeBlueField3  = "a2dc"
@@ -165,6 +166,13 @@ var _ = Describe("NicConfigurationTemplate CEL validation", func() {
 		err := k8sClient.Create(ctx, obj)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("index-range syntax"))
+	})
+
+	It("allows SpectrumXOptimized enabled for ConnectX-7 (NicType 1021)", func() {
+		obj := newNicConfigurationTemplate("spcx-allow-1021", "Ethernet", 1, &SpectrumXOptimizedSpec{Enabled: true, Version: "RA2.0"})
+		obj.Spec.NicSelector.NicType = nicTypeConnectX7
+		err := k8sClient.Create(ctx, obj)
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("allows SpectrumXOptimized enabled for ConnectX-8 (NicType 1023)", func() {
@@ -374,6 +382,19 @@ var _ = Describe("NicConfigurationTemplate CEL validation", func() {
 			Expect(k8sClient.Create(ctx, obj)).To(Succeed())
 		})
 
+		It("rejects hwplb with NicType 1021 (ConnectX-7)", func() {
+			obj := newNicConfigurationTemplate("hwplb-cx7-invalid", "Ethernet", 1, &SpectrumXOptimizedSpec{
+				Enabled:        true,
+				Version:        "RA2.1",
+				MultiplaneMode: "hwplb",
+				NumberOfPlanes: 4,
+			})
+			obj.Spec.NicSelector.NicType = nicTypeConnectX7
+			err := k8sClient.Create(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("ConnectX-7 (NicType 1021) supports only single-plane Spectrum-X (multiplaneMode none)"))
+		})
+
 		It("rejects hwplb with NicType a2dc (BlueField-3)", func() {
 			obj := newNicConfigurationTemplate("hwplb-bf3-invalid", "Ethernet", 1, &SpectrumXOptimizedSpec{
 				Enabled:        true,
@@ -385,6 +406,19 @@ var _ = Describe("NicConfigurationTemplate CEL validation", func() {
 			err := k8sClient.Create(ctx, obj)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("hwplb MultiplaneMode can only be enabled for ConnectX-8 (NicType 1023) or ConnectX-9 (NicType 1025)"))
+		})
+
+		It("rejects swplb with NicType 1021 (ConnectX-7)", func() {
+			obj := newNicConfigurationTemplate("swplb-cx7-invalid", "Ethernet", 1, &SpectrumXOptimizedSpec{
+				Enabled:        true,
+				Version:        "RA2.1",
+				MultiplaneMode: "swplb",
+				NumberOfPlanes: 2,
+			})
+			obj.Spec.NicSelector.NicType = nicTypeConnectX7
+			err := k8sClient.Create(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("ConnectX-7 (NicType 1021) supports only single-plane Spectrum-X (multiplaneMode none)"))
 		})
 
 		It("allows swplb with NicType a2dc (BlueField-3)", func() {
@@ -406,6 +440,17 @@ var _ = Describe("NicConfigurationTemplate CEL validation", func() {
 				NumberOfPlanes: 2,
 			})
 			obj.Spec.NicSelector.NicType = nicTypeBlueField3
+			Expect(k8sClient.Create(ctx, obj)).To(Succeed())
+		})
+
+		It("allows none with NicType 1021 (ConnectX-7)", func() {
+			obj := newNicConfigurationTemplate("none-cx7-valid", "Ethernet", 1, &SpectrumXOptimizedSpec{
+				Enabled:        true,
+				Version:        "RA2.1",
+				MultiplaneMode: "none",
+				NumberOfPlanes: 1,
+			})
+			obj.Spec.NicSelector.NicType = nicTypeConnectX7
 			Expect(k8sClient.Create(ctx, obj)).To(Succeed())
 		})
 
@@ -431,7 +476,7 @@ var _ = Describe("NicConfigurationTemplate CEL validation", func() {
 			err := k8sClient.Create(ctx, obj)
 			Expect(err).To(HaveOccurred())
 			// Should fail on the spectrumXOptimized device type check first
-			Expect(err.Error()).To(ContainSubstring("spectrumXOptimized can be enabled only for ConnectX-8, ConnectX-9 or BlueField-3 SuperNICs"))
+			Expect(err.Error()).To(ContainSubstring("spectrumXOptimized can be enabled only for ConnectX-7, ConnectX-8, ConnectX-9 or BlueField-3 SuperNICs"))
 		})
 	})
 })

--- a/config/crd/bases/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
+++ b/config/crd/bases/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
@@ -355,11 +355,17 @@ spec:
             - template
             type: object
             x-kubernetes-validations:
-            - message: spectrumXOptimized can be enabled only for ConnectX-8, ConnectX-9
-                or BlueField-3 SuperNICs
+            - message: spectrumXOptimized can be enabled only for ConnectX-7, ConnectX-8,
+                ConnectX-9 or BlueField-3 SuperNICs
               rule: '!(has(self.template.spectrumXOptimized) && self.template.spectrumXOptimized.enabled)
-                || (self.nicSelector.nicType == ''1023'' || self.nicSelector.nicType
-                == ''1025'' || self.nicSelector.nicType == ''a2dc'')'
+                || (self.nicSelector.nicType == ''1021'' || self.nicSelector.nicType
+                == ''1023'' || self.nicSelector.nicType == ''1025'' || self.nicSelector.nicType
+                == ''a2dc'')'
+            - message: ConnectX-7 (NicType 1021) supports only single-plane Spectrum-X
+                (multiplaneMode none)
+              rule: '!has(self.template.spectrumXOptimized) || !has(self.template.spectrumXOptimized.multiplaneMode)
+                || self.nicSelector.nicType != ''1021'' || self.template.spectrumXOptimized.multiplaneMode
+                == ''none'''
             - message: hwplb MultiplaneMode can only be enabled for ConnectX-8 (NicType
                 1023) or ConnectX-9 (NicType 1025)
               rule: '!has(self.template.spectrumXOptimized) || !has(self.template.spectrumXOptimized.multiplaneMode)

--- a/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
+++ b/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
@@ -355,11 +355,17 @@ spec:
             - template
             type: object
             x-kubernetes-validations:
-            - message: spectrumXOptimized can be enabled only for ConnectX-8, ConnectX-9
-                or BlueField-3 SuperNICs
+            - message: spectrumXOptimized can be enabled only for ConnectX-7, ConnectX-8,
+                ConnectX-9 or BlueField-3 SuperNICs
               rule: '!(has(self.template.spectrumXOptimized) && self.template.spectrumXOptimized.enabled)
-                || (self.nicSelector.nicType == ''1023'' || self.nicSelector.nicType
-                == ''1025'' || self.nicSelector.nicType == ''a2dc'')'
+                || (self.nicSelector.nicType == ''1021'' || self.nicSelector.nicType
+                == ''1023'' || self.nicSelector.nicType == ''1025'' || self.nicSelector.nicType
+                == ''a2dc'')'
+            - message: ConnectX-7 (NicType 1021) supports only single-plane Spectrum-X
+                (multiplaneMode none)
+              rule: '!has(self.template.spectrumXOptimized) || !has(self.template.spectrumXOptimized.multiplaneMode)
+                || self.nicSelector.nicType != ''1021'' || self.template.spectrumXOptimized.multiplaneMode
+                == ''none'''
             - message: hwplb MultiplaneMode can only be enabled for ConnectX-8 (NicType
                 1023) or ConnectX-9 (NicType 1025)
               rule: '!has(self.template.spectrumXOptimized) || !has(self.template.spectrumXOptimized.multiplaneMode)

--- a/docs/examples/spectrum-x/example-nicconfigurationtemplate-spectrum-x-multiplane.yaml
+++ b/docs/examples/spectrum-x/example-nicconfigurationtemplate-spectrum-x-multiplane.yaml
@@ -24,7 +24,7 @@ spec:
   nodeSelector:
       feature.node.kubernetes.io/network-sriov.capable: "true"
   nicSelector:
-      nicType: "1023" # ConnectX-8. Use "1025" for ConnectX-9, or "a2dc" for BlueField-3 SuperNIC (hwplb not supported on BF3)
+      nicType: "1023" # ConnectX-8. Use "1025" for ConnectX-9, or "a2dc" for BlueField-3 SuperNIC (hwplb not supported on BF3). ConnectX-7 (`1021`) is single-plane only.
       # partNumbers:
       #   - "MCX713106AEHEA_QP1"
   template:

--- a/docs/examples/spectrum-x/example-nicconfigurationtemplate-spectrum-x.yaml
+++ b/docs/examples/spectrum-x/example-nicconfigurationtemplate-spectrum-x.yaml
@@ -24,7 +24,7 @@ spec:
   nodeSelector:
       feature.node.kubernetes.io/network-sriov.capable: "true"
   nicSelector:
-      nicType: a2dc # BlueField-3 SuperNIC, Can also be "1023" for ConnectX-8 or "1025" for ConnectX-9
+      nicType: a2dc # BlueField-3 SuperNIC. Can also be "1021" for ConnectX-7 (single-plane only), "1023" for ConnectX-8, or "1025" for ConnectX-9.
       # partNumbers:
       #   - "MCX713106AEHEA_QP1"
   template:

--- a/docs/examples/spectrum-x/example-nicfirmwaretemplate-spectrum-x.yaml
+++ b/docs/examples/spectrum-x/example-nicfirmwaretemplate-spectrum-x.yaml
@@ -22,7 +22,7 @@ metadata:
   namespace: nvidia-network-operator
 spec:
   nicSelector:
-    nicType: "a2dc" # BlueField-3 SuperNIC, Can also be "1023" for ConnectX-8 or "1025" for ConnectX-9
+    nicType: "a2dc" # BlueField-3 SuperNIC. Can also be "1021" for ConnectX-7, "1023" for ConnectX-8, or "1025" for ConnectX-9
     # partNumbers:
     #   - "MCX713106AEHEA_QP1"
   template:

--- a/docs/examples/spectrum-x/example-spectrum-x-profile-configmap.yaml
+++ b/docs/examples/spectrum-x/example-spectrum-x-profile-configmap.yaml
@@ -29,6 +29,9 @@ data:
     docaCCVersion: "example-version"
     mlxConfig:
       none:
+        "1021":
+          postBreakout:
+            EXAMPLE_NVCONFIG_PARAMETER: "example-value"
         "1023":
           postBreakout:
             EXAMPLE_NVCONFIG_PARAMETER: "example-value"

--- a/docs/nic-configuration-library.md
+++ b/docs/nic-configuration-library.md
@@ -339,7 +339,7 @@ func NewSpectrumXConfigManager(
 2. **NV config** → filter by `DeviceId`, `Breakout`, `Multiplane` → split into MLXConfig params (`SetNvConfigParametersBatch`) and DMS params (`SetParameters`) → apply in batch → reboot
 3. **Runtime** → RoCE, Adaptive Routing, Congestion Control, InterPacketGap settings applied via DMS and sysfs — no reboot
 
-**Parameter filtering:** each `ConfigurationParameter` can be filtered by `DeviceId` (e.g., `"1023"` for CX8, `"1025"` for CX9, `"a2dc"` for BF3), `Breakout` (plane count), and `Multiplane` mode.
+**Parameter filtering:** each `ConfigurationParameter` can be filtered by `DeviceId` (e.g., `"1021"` for CX7, `"1023"` for CX8, `"1025"` for CX9, `"a2dc"` for BF3), `Breakout` (plane count), and `Multiplane` mode.
 
 #### CC Process Lifecycle
 
@@ -477,7 +477,7 @@ type ConfigurationParameter struct {
     DMSPath            string           // DMS path (e.g., "/interfaces/interface/nvidia/qos/config/trust-mode")
     MlxReg             *MlxRegParameter // Optional mlxreg runtime parameter
     AlternativeValue   string           // Alternative value representation accepted during checks
-    DeviceId           string           // Device ID filter (e.g., "1023", "a2dc")
+    DeviceId           string           // Device ID filter (e.g., "1021", "1023", "a2dc")
     Breakout           int              // Plane count filter (1, 2, 4)
     Multiplane         string           // Multiplane mode filter (none, swplb, hwplb, uniplane)
     IgnoreError        bool             // Suppress errors for this parameter in batch operations


### PR DESCRIPTION
RA already supports CX7 for single-plane Spectrum-X; the CEL allowlist incorrectly excluded nicType 1021. Multiplane modes remain rejected for CX7.