### PR TITLE
devicediscovery: fall back to devlink for firmware info

### DIFF
--- a/pkg/devicediscovery/utils.go
+++ b/pkg/devicediscovery/utils.go
@@ -29,6 +29,7 @@ import (
 	"github.com/Mellanox/rdmamap"
 	"github.com/jaypipes/ghw"
 	"github.com/jaypipes/ghw/pkg/pci"
+	"github.com/vishvananda/netlink"
 	execUtils "k8s.io/utils/exec"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -77,7 +78,7 @@ type DeviceDiscoveryUtils interface {
 	// GetVPD uses mlxvpd util to retrieve Part Number, Serial Number, Model Name of the PCI device
 	GetVPD(pciAddr string) (*types.VPD, error)
 
-	// GetFirmwareVersionAndPSID uses flint tool to retrieve FW version and PSID of the device
+	// GetFirmwareVersionAndPSID retrieves the FW version and PSID of the device
 	GetFirmwareVersionAndPSID(pciAddr string) (string, string, error)
 
 	// GetRDMADeviceName returns a RDMA device name for the given PCI address
@@ -105,7 +106,8 @@ type DeviceDiscoveryUtils interface {
 }
 
 type deviceDiscoveryUtils struct {
-	execInterface execUtils.Interface
+	execInterface  execUtils.Interface
+	getDevlinkInfo func(bus, device string) (map[string]string, error)
 }
 
 // GetPCIDevices returns a list of PCI devices on the host
@@ -208,19 +210,33 @@ func parseVPDOutput(output []byte, p vpdOutputPatterns) (*types.VPD, error) {
 	}, nil
 }
 
-// GetFirmwareVersionAndPSID uses flint tool to retrieve FW version and PSID of the device
+// GetFirmwareVersionAndPSID uses flint to retrieve the FW version and PSID of the device.
+// If flint cannot query the device, it falls back to the kernel devlink interface.
 func (d *deviceDiscoveryUtils) GetFirmwareVersionAndPSID(pciAddr string) (string, string, error) {
 	log.Log.Info("HostUtils.GetFirmwareVersionAndPSID()", "pciAddr", pciAddr)
+	firmwareVersion, psid, flintErr := d.getFirmwareVersionAndPSIDViaFlint(pciAddr)
+	if flintErr == nil {
+		return firmwareVersion, psid, nil
+	}
+
+	log.Log.Info("GetFirmwareVersionAndPSID(): flint failed, falling back to devlink", "pciAddr", pciAddr, "error", flintErr.Error())
+	firmwareVersion, psid, devlinkErr := d.getFirmwareVersionAndPSIDViaDevlink(pciAddr)
+	if devlinkErr != nil {
+		return "", "", fmt.Errorf("failed to get firmware version and PSID: flint: %w; devlink: %w", flintErr, devlinkErr)
+	}
+
+	return firmwareVersion, psid, nil
+}
+
+func (d *deviceDiscoveryUtils) getFirmwareVersionAndPSIDViaFlint(pciAddr string) (string, string, error) {
 	cmd := d.execInterface.Command("flint", "-d", pciAddr, "q")
 	output, err := utils.RunCommand(cmd)
 	if err != nil {
-		log.Log.Error(err, "GetFirmwareVersionAndPSID(): Failed to run flint")
-		return "", "", err
+		return "", "", fmt.Errorf("failed to run flint: %w", err)
 	}
 
-	// Parse the output for PN and SN
 	scanner := bufio.NewScanner(strings.NewReader(string(output)))
-	var firmwareVersion, PSID string
+	var firmwareVersion, psid string
 
 	for scanner.Scan() {
 		line := strings.ToLower(scanner.Text())
@@ -229,20 +245,42 @@ func (d *deviceDiscoveryUtils) GetFirmwareVersionAndPSID(pciAddr string) (string
 			firmwareVersion = strings.TrimSpace(strings.TrimPrefix(line, consts.FirmwareVersionPrefix))
 		}
 		if strings.HasPrefix(line, consts.PSIDPrefix) {
-			PSID = strings.TrimSpace(strings.TrimPrefix(line, consts.PSIDPrefix))
+			psid = strings.TrimSpace(strings.TrimPrefix(line, consts.PSIDPrefix))
 		}
 	}
 
 	if err := scanner.Err(); err != nil {
-		log.Log.Error(err, "GetFirmwareVersionAndPSID(): Error reading flint output")
-		return "", "", err
+		return "", "", fmt.Errorf("failed to read flint output: %w", err)
 	}
 
-	if firmwareVersion == "" || PSID == "" {
-		return "", "", fmt.Errorf("GetFirmwareVersionAndPSID(): firmware version (%v) or PSID (%v) is empty", firmwareVersion, PSID)
+	if firmwareVersion == "" || psid == "" {
+		return "", "", fmt.Errorf("flint output has empty firmware version (%q) or PSID (%q)", firmwareVersion, psid)
 	}
 
-	return firmwareVersion, PSID, nil
+	return firmwareVersion, psid, nil
+}
+
+func (d *deviceDiscoveryUtils) getFirmwareVersionAndPSIDViaDevlink(pciAddr string) (string, string, error) {
+	getDevlinkInfo := d.getDevlinkInfo
+	if getDevlinkInfo == nil {
+		getDevlinkInfo = netlink.DevlinkGetDeviceInfoByNameAsMap
+	}
+
+	info, err := getDevlinkInfo("pci", pciAddr)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to query devlink device pci/%s: %w", pciAddr, err)
+	}
+
+	firmwareVersion := strings.TrimSpace(info["fw.version"])
+	if firmwareVersion == "" {
+		firmwareVersion = strings.TrimSpace(info["fw"])
+	}
+	psid := strings.TrimSpace(info["fw.psid"])
+	if firmwareVersion == "" || psid == "" {
+		return "", "", fmt.Errorf("devlink info has empty firmware version (%q) or PSID (%q)", firmwareVersion, psid)
+	}
+
+	return strings.ToLower(firmwareVersion), strings.ToLower(psid), nil
 }
 
 // GetRDMADeviceName returns a RDMA device name for the given PCI address
@@ -455,5 +493,8 @@ func getFwctlDeviceFromPath(pciDevicesBasePath, pciAddr string) (string, error) 
 
 // NewDeviceDiscoveryUtils creates a new DeviceDiscoveryUtils instance
 func NewDeviceDiscoveryUtils() DeviceDiscoveryUtils {
-	return &deviceDiscoveryUtils{execInterface: execUtils.New()}
+	return &deviceDiscoveryUtils{
+		execInterface:  execUtils.New(),
+		getDevlinkInfo: netlink.DevlinkGetDeviceInfoByNameAsMap,
+	}
 }

--- a/pkg/devicediscovery/utils_test.go
+++ b/pkg/devicediscovery/utils_test.go
@@ -360,9 +360,10 @@ var _ = Describe("HostUtils", func() {
 	})
 	//nolint:dupl
 	Describe("GetFirmwareVersionAndPSID", func() {
-		It("should return lowercased firmware version and psid", func() {
+		It("should return lowercased firmware version and PSID from flint", func() {
 			fwVersion := "VeRsIoN"
-			PSID := "PSID"
+			psid := "PSID"
+			devlinkCalled := false
 
 			fakeExec := &execTesting.FakeExec{}
 
@@ -383,54 +384,133 @@ var _ = Describe("HostUtils", func() {
 
 			h := &deviceDiscoveryUtils{
 				execInterface: fakeExec,
+				getDevlinkInfo: func(_, _ string) (map[string]string, error) {
+					devlinkCalled = true
+					return nil, errors.New("devlink should not be called")
+				},
 			}
 
-			part, serial, err := h.GetFirmwareVersionAndPSID(pciAddress)
+			firmwareVersion, actualPSID, err := h.GetFirmwareVersionAndPSID(pciAddress)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(part).To(Equal(strings.ToLower(fwVersion)))
-			Expect(serial).To(Equal(strings.ToLower(PSID)))
+			Expect(firmwareVersion).To(Equal(strings.ToLower(fwVersion)))
+			Expect(actualPSID).To(Equal(strings.ToLower(psid)))
+			Expect(devlinkCalled).To(BeFalse())
 		})
-		It("should return empty string for both numbers if one is empty", func() {
+
+		It("should fall back to devlink when flint fails", func() {
 			fakeExec := &execTesting.FakeExec{}
 
 			fakeCmd := &execTesting.FakeCmd{}
 			fakeCmd.OutputScript = append(fakeCmd.OutputScript, func() ([]byte, []byte, error) {
-				return []byte("FW Version: VeRsIoN"), nil, nil
+				return nil, []byte("ICMD failed"), errors.New("exit status 1")
 			})
 
 			fakeExec.CommandScript = append(fakeExec.CommandScript, func(cmd string, args ...string) exec.Cmd {
 				Expect(cmd).To(Equal("flint"))
-				Expect(args[1]).To(Equal(pciAddress))
+				Expect(args).To(Equal([]string{"-d", pciAddress, "q"}))
 				return fakeCmd
 			})
 
 			h := &deviceDiscoveryUtils{
 				execInterface: fakeExec,
+				getDevlinkInfo: func(bus, device string) (map[string]string, error) {
+					Expect(bus).To(Equal("pci"))
+					Expect(device).To(Equal(pciAddress))
+					return map[string]string{
+						"fw.version": "32.43.2026",
+						"fw.psid":    "MT_0000000742",
+					}, nil
+				},
 			}
 
-			part, serial, err := h.GetFirmwareVersionAndPSID(pciAddress)
+			firmwareVersion, actualPSID, err := h.GetFirmwareVersionAndPSID(pciAddress)
 
-			Expect(err).To(HaveOccurred())
-			Expect(part).To(Equal(""))
-			Expect(serial).To(Equal(""))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(firmwareVersion).To(Equal("32.43.2026"))
+			Expect(actualPSID).To(Equal("mt_0000000742"))
+		})
 
-			fakeCmd = &execTesting.FakeCmd{}
+		It("should fall back to the generic devlink FW key when flint output is incomplete", func() {
+			fakeExec := &execTesting.FakeExec{}
+
+			fakeCmd := &execTesting.FakeCmd{}
 			fakeCmd.OutputScript = append(fakeCmd.OutputScript, func() ([]byte, []byte, error) {
-				return []byte("PSID: PSID"), nil, nil
+				return []byte("FW Version: ignored-without-psid"), nil, nil
 			})
 
 			fakeExec.CommandScript = append(fakeExec.CommandScript, func(cmd string, args ...string) exec.Cmd {
 				Expect(cmd).To(Equal("flint"))
-				Expect(args[1]).To(Equal(pciAddress))
+				Expect(args).To(Equal([]string{"-d", pciAddress, "q"}))
 				return fakeCmd
 			})
 
-			part, serial, err = h.GetFirmwareVersionAndPSID(pciAddress)
+			h := &deviceDiscoveryUtils{
+				execInterface: fakeExec,
+				getDevlinkInfo: func(_, _ string) (map[string]string, error) {
+					return map[string]string{
+						"fw":      "32.43.2026",
+						"fw.psid": "MT_0000000742",
+					}, nil
+				},
+			}
 
-			Expect(err).To(HaveOccurred())
-			Expect(part).To(Equal(""))
-			Expect(serial).To(Equal(""))
+			firmwareVersion, actualPSID, err := h.GetFirmwareVersionAndPSID(pciAddress)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(firmwareVersion).To(Equal("32.43.2026"))
+			Expect(actualPSID).To(Equal("mt_0000000742"))
+		})
+
+		It("should return an error when both flint and devlink fail", func() {
+			fakeExec := &execTesting.FakeExec{}
+			fakeCmd := &execTesting.FakeCmd{}
+			fakeCmd.OutputScript = append(fakeCmd.OutputScript, func() ([]byte, []byte, error) {
+				return nil, nil, errors.New("flint failure")
+			})
+			fakeExec.CommandScript = append(fakeExec.CommandScript, func(_ string, _ ...string) exec.Cmd {
+				return fakeCmd
+			})
+
+			h := &deviceDiscoveryUtils{
+				execInterface: fakeExec,
+				getDevlinkInfo: func(_, _ string) (map[string]string, error) {
+					return nil, errors.New("devlink failure")
+				},
+			}
+
+			firmwareVersion, actualPSID, err := h.GetFirmwareVersionAndPSID(pciAddress)
+
+			Expect(err).To(MatchError(And(
+				ContainSubstring("flint failure"),
+				ContainSubstring("devlink failure"),
+			)))
+			Expect(firmwareVersion).To(BeEmpty())
+			Expect(actualPSID).To(BeEmpty())
+		})
+
+		It("should return an error when devlink omits the PSID", func() {
+			fakeExec := &execTesting.FakeExec{}
+			fakeCmd := &execTesting.FakeCmd{}
+			fakeCmd.OutputScript = append(fakeCmd.OutputScript, func() ([]byte, []byte, error) {
+				return nil, nil, errors.New("flint failure")
+			})
+			fakeExec.CommandScript = append(fakeExec.CommandScript, func(_ string, _ ...string) exec.Cmd {
+				return fakeCmd
+			})
+
+			h := &deviceDiscoveryUtils{
+				execInterface: fakeExec,
+				getDevlinkInfo: func(_, _ string) (map[string]string, error) {
+					return map[string]string{"fw.version": "32.43.2026"}, nil
+				},
+			}
+
+			firmwareVersion, actualPSID, err := h.GetFirmwareVersionAndPSID(pciAddress)
+
+			Expect(err).To(MatchError(ContainSubstring("devlink info has empty firmware version")))
+			Expect(firmwareVersion).To(BeEmpty())
+			Expect(actualPSID).To(BeEmpty())
 		})
 	})
 


### PR DESCRIPTION
## Summary

- keep `flint` as the primary firmware version and PSID discovery mechanism
- fall back to the kernel devlink interface through the existing Go netlink dependency when `flint` execution or parsing fails
- preserve the current discovery error and `SKIP_DEVICE_ON_DISCOVERY_ERROR` behavior when neither source returns complete firmware information

## Motivation

Some mlx5 devices expose firmware information through `devlink dev info` even when `flint` cannot query the PCI function. Using devlink as a fallback allows those devices to remain discoverable without changing the normal `flint` path or downstream firmware flows.

## Testing

- on a local cluster:

```
devicediscovery/utils.go:216    HostUtils.GetFirmwareVersionAndPSID()   {"pciAddr": "0000:64:00.0"}
devicediscovery/utils.go:222    GetFirmwareVersionAndPSID(): flint failed, falling back to devlink      {"pciAddr": "0000:64:00.0", "error": "failed to run flint: exit status 1: injected flint failure for devlink fallback test"}
devicediscovery/devicediscovery.go:178  Discovered NIC device   {"address": "0000:64:00.0", "status": {"node":"netop-setup1-worker01","type":"1023","serialNumber":"MT2617J02HFP","partNumber":"900-9X81E-00EX-STB","psid":"mt_0000001172","firmwareVersion":"40.50.0426","dpu":false,"modelName":"NVIDIA ConnectX-8 C8180","superNIC":false,"ports":[]}}
```
