### PR TITLE
fix: apply Spectrum-X runtime parameters separately

### DIFF
--- a/docs/nic-configuration-library.md
+++ b/docs/nic-configuration-library.md
@@ -496,7 +496,7 @@ type MlxRegField struct {
 }
 ```
 
-A parameter with `MlxConfig` set is applied via `nvconfig.SetNvConfigParametersBatch()`. Runtime profile parameters with `DMSPath` set are applied via `dms.DMSClient.SetParameters()`. Runtime profile parameters with `MlxReg` set are applied with `mlxreg`; they preserve profile order and split surrounding DMS parameters into separate batches.
+A parameter with `MlxConfig` set is applied via `nvconfig.SetNvConfigParametersBatch()`. Runtime profile parameters are applied individually in profile order: parameters with `DMSPath` use `dms.DMSClient.SetParameters()`, while parameters with `MlxReg` use `mlxreg`. A failed runtime set of either type is retried with a one-second delay for up to 10 total attempts before runtime application returns an error. A single DMS profile parameter can still expand to multiple concrete interface or priority updates within its DMS call. For `mlxreg` sets, each port's `FwctlDevice` is preferred when available, with its PCI address used as the fallback target. Runtime DMS reads remain batched around `mlxreg` parameters.
 
 #### Spectrum-X Config Types
 
@@ -724,6 +724,7 @@ All external commands use `cmd.CombinedOutput()` (not `cmd.Output()`) and log un
 
 - **mlxconfig**: `SetNvConfigParametersBatch()` applies multiple params in single `mlxconfig set` call
 - **DMS**: `GetParameters()` batches `--path` entries per concrete interface (with a separate global batch), and `SetParameters()` sends all `--update` entries in a single `dmsc set` command with `--timeout 5m`
+- **Spectrum-X runtime application**: reads use batched `GetParameters()` calls; DMS and `mlxreg` writes are applied one profile parameter at a time, and returned errors are retried up to 10 total attempts
 - **IgnoreError**: per-parameter flag; in batch mode, errors are suppressed only if ALL params have `IgnoreError=true`
 
 ### Channel-Based Notifications

--- a/pkg/spectrumx/spectrumx.go
+++ b/pkg/spectrumx/spectrumx.go
@@ -41,6 +41,11 @@ var cnpDscpSysfsPathTemplate = "/sys/class/net/%s/ecn/roce_np/cnp_dscp"
 // cnpDscpExpectedValue is the expected value for CNP DSCP
 const cnpDscpExpectedValue = "48"
 
+const setParamMaxAttempts = 10
+
+// setParamRetryInterval is a var to allow substitution in tests.
+var setParamRetryInterval = time.Second
+
 // mlxregBinary is the path to the mlxreg binary. This is a var to allow substitution in tests.
 var mlxregBinary = "/usr/bin/mlxreg"
 
@@ -332,6 +337,13 @@ func mlxRegSetValue(param types.ConfigurationParameter) string {
 	return strings.Join(fields, ",")
 }
 
+func resolveMlxRegTarget(port v1alpha1.NicDevicePortSpec) string {
+	if port.FwctlDevice != "" {
+		return port.FwctlDevice
+	}
+	return port.PCI
+}
+
 func (m *spectrumXConfigManager) checkMlxRegParamApplied(device *v1alpha1.NicDevice, param types.ConfigurationParameter) (bool, error) {
 	if err := validateMlxRegParam(param); err != nil {
 		return false, err
@@ -383,21 +395,25 @@ func (m *spectrumXConfigManager) setMlxRegParam(device *v1alpha1.NicDevice, para
 
 	log.Log.V(2).Info("SpectrumXConfigManager.setMlxRegParam()", "device", device.Name, "param", param.Name)
 	for _, port := range device.Status.Ports {
-		args := []string{"-d", port.PCI, "--reg_name", param.MlxReg.Register, "--set", setValue, "--yes"}
+		target := resolveMlxRegTarget(port)
+		args := []string{"-d", target, "--reg_name", param.MlxReg.Register, "--set", setValue, "--yes"}
 		command := commandLine(mlxregBinary, args)
 		log.Log.V(2).Info("setMlxRegParam(): running mlxreg set",
-			"device", device.Name, "pci", port.PCI, "param", param.Name, "register", param.MlxReg.Register,
+			"device", device.Name, "target", target, "pci", port.PCI, "fwctlDevice", port.FwctlDevice,
+			"param", param.Name, "register", param.MlxReg.Register,
 			"setValue", setValue, "command", command)
 
 		cmd := m.execInterface.Command(mlxregBinary, args...)
 		output, err := cmd.CombinedOutput()
 		if err != nil {
 			log.Log.Error(err, "setMlxRegParam(): failed to run mlxreg set",
-				"device", device.Name, "pci", port.PCI, "param", param.Name, "command", command, "output", string(output))
-			return fmt.Errorf("failed to set mlxreg parameter %q for PF %s: %w", param.Name, port.PCI, err)
+				"device", device.Name, "target", target, "pci", port.PCI, "fwctlDevice", port.FwctlDevice,
+				"param", param.Name, "command", command, "output", string(output))
+			return fmt.Errorf("failed to set mlxreg parameter %q for target %s: %w", param.Name, target, err)
 		}
-		log.Log.V(2).Info("setMlxRegParam(): successfully set mlxreg parameter on PF",
-			"device", device.Name, "pci", port.PCI, "param", param.Name, "command", command, "output", string(output))
+		log.Log.V(2).Info("setMlxRegParam(): successfully set mlxreg parameter",
+			"device", device.Name, "target", target, "pci", port.PCI, "fwctlDevice", port.FwctlDevice,
+			"param", param.Name, "command", command, "output", string(output))
 	}
 	return nil
 }
@@ -465,33 +481,43 @@ func (m *spectrumXConfigManager) checkRuntimeParamsApplied(device *v1alpha1.NicD
 }
 
 func (m *spectrumXConfigManager) applyRuntimeParams(device *v1alpha1.NicDevice, params []types.ConfigurationParameter, dmsClient dms.DMSClient) error {
-	dmsBatch := []types.ConfigurationParameter{}
-	flushDMSBatch := func() error {
-		if len(dmsBatch) == 0 {
+	for _, param := range params {
+		if err := m.setParamWithRetry(device, param, dmsClient); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *spectrumXConfigManager) setParamWithRetry(device *v1alpha1.NicDevice, param types.ConfigurationParameter, dmsClient dms.DMSClient) error {
+	paramType := "DMS"
+	mlxRegParam := isMlxRegParam(param)
+	if mlxRegParam {
+		paramType = "mlxreg"
+	}
+
+	var err error
+	for attempt := 1; attempt <= setParamMaxAttempts; attempt++ {
+		if mlxRegParam {
+			err = m.setMlxRegParam(device, param)
+		} else {
+			err = dmsClient.SetParameters([]types.ConfigurationParameter{param})
+		}
+		if err == nil {
 			return nil
 		}
-		err := dmsClient.SetParameters(dmsBatch)
-		dmsBatch = nil
-		return err
-	}
 
-	for _, param := range params {
-		if isMlxRegParam(param) {
-			if err := validateMlxRegParam(param); err != nil {
-				return err
-			}
-			if err := flushDMSBatch(); err != nil {
-				return err
-			}
-			if err := m.setMlxRegParam(device, param); err != nil {
-				return err
-			}
-			continue
+		if attempt < setParamMaxAttempts {
+			log.Log.V(2).Info("failed to set runtime parameter, retrying",
+				"device", device.Name, "param", param.Name, "paramType", paramType, "path", param.DMSPath,
+				"attempt", attempt, "maxAttempts", setParamMaxAttempts, "error", err)
+			time.Sleep(setParamRetryInterval)
 		}
-		dmsBatch = append(dmsBatch, param)
 	}
 
-	return flushDMSBatch()
+	return fmt.Errorf("failed to set %s runtime parameter %q after %d attempts: %w",
+		paramType, param.Name, setParamMaxAttempts, err)
 }
 
 // RuntimeConfigApplied checks if the desired Spectrum-X runtime spec is applied to the device

--- a/pkg/spectrumx/spectrumx_test.go
+++ b/pkg/spectrumx/spectrumx_test.go
@@ -166,6 +166,11 @@ var _ = Describe("SpectrumXConfigManager", func() {
 		dmsMgr = dmsmocks.DMSManager{}
 		dmsCli = dmsmocks.DMSClient{}
 		execFake = &fakeExec{}
+		originalSetParamRetryInterval := setParamRetryInterval
+		setParamRetryInterval = 0
+		DeferCleanup(func() {
+			setParamRetryInterval = originalSetParamRetryInterval
+		})
 
 		cfgs = map[string]*types.SpectrumXConfig{
 			"v1": {
@@ -393,10 +398,13 @@ var _ = Describe("SpectrumXConfigManager", func() {
 		})
 
 		It("bubbles up DMS errors", func() {
-			dmsCli.On("SetParameters", cfgs["v1"].RuntimeConfig.Roce).Return(errors.New("roce set error"))
+			dmsCli.On("SetParameters", cfgs["v1"].RuntimeConfig.Roce).
+				Return(errors.New("roce set error")).Times(setParamMaxAttempts)
 			_, err := manager.ApplyRuntimeConfig(device)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("roce set error"))
+			Expect(err.Error()).To(ContainSubstring("after 10 attempts"))
+			dmsCli.AssertNumberOfCalls(GinkgoT(), "SetParameters", setParamMaxAttempts)
 		})
 	})
 
@@ -1091,7 +1099,8 @@ var _ = Describe("SpectrumXConfigManager", func() {
 					{Name: "ipg_no_filter", Value: "500", DMSPath: "/ipg/nofilter"},
 				}
 
-				dmsCli.On("SetParameters", expectedIPG).Return(nil)
+				dmsCli.On("SetParameters", expectedIPG[:1]).Return(nil).Once()
+				dmsCli.On("SetParameters", expectedIPG[1:]).Return(nil).Once()
 				dmsCli.On("SetParameters", mock.MatchedBy(func(params []types.ConfigurationParameter) bool {
 					return len(params) == 1 && params[0].Name == shutdownInterfaceParamName
 				})).Return(nil)
@@ -1203,6 +1212,21 @@ cc_probe_mp_mode                               | 0x00000001
 			}))
 		})
 
+		It("prefers the fwctl device for mlxreg sets", func() {
+			device.Status.Ports[0].FwctlDevice = "/dev/fwctl/fwctl3"
+			execFake.cmds = []*fakeCmd{{output: []byte("ok"), err: nil}}
+
+			err := manager.setMlxRegParam(device, ccProbeMPModeParam())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(execFake.calls).To(HaveLen(1))
+			Expect(execFake.calls[0].args).To(Equal([]string{
+				"-d", "/dev/fwctl/fwctl3",
+				"--reg_name", "ROCE_ACCL",
+				"--set", "cc_probe_mp_mode=0x1,cc_probe_mp_mode_field_select=0x1",
+				"--yes",
+			}))
+		})
+
 		It("returns error when mlxreg set fails", func() {
 			execFake.cmds = []*fakeCmd{{output: []byte("failed"), err: errors.New("mlxreg set error")}}
 
@@ -1211,7 +1235,7 @@ cc_probe_mp_mode                               | 0x00000001
 			Expect(err.Error()).To(ContainSubstring("mlxreg"))
 		})
 
-		It("checks ordered runtime params with DMS batches split by mlxreg barriers", func() {
+		It("keeps ordered DMS reads batched around mlxreg barriers", func() {
 			params := []types.ConfigurationParameter{
 				{Name: "dms before 1", Value: "a", DMSPath: "/before/1"},
 				{Name: "dms before 2", Value: "b", DMSPath: "/before/2"},
@@ -1227,33 +1251,103 @@ cc_probe_mp_mode                               | 0x00000001
 			Expect(applied).To(BeTrue())
 		})
 
-		It("applies ordered runtime params with DMS batches split by mlxreg barriers", func() {
+		It("applies each DMS runtime parameter separately in profile order", func() {
 			params := []types.ConfigurationParameter{
 				{Name: "dms before 1", Value: "a", DMSPath: "/before/1"},
 				{Name: "dms before 2", Value: "b", DMSPath: "/before/2"},
 				ccProbeMPModeParam(),
 				{Name: "dms after", Value: "c", DMSPath: "/after"},
 			}
-			dmsCli.On("SetParameters", params[:2]).Return(nil).Once()
+			dmsCli.On("SetParameters", params[:1]).Return(nil).Once()
+			dmsCli.On("SetParameters", params[1:2]).Return(nil).Once()
 			dmsCli.On("SetParameters", params[3:]).Return(nil).Once()
 			execFake.cmds = []*fakeCmd{{output: []byte("ok"), err: nil}}
 
 			err := manager.applyRuntimeParams(device, params, &dmsCli)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(execFake.calls).To(HaveLen(1))
+			Expect(dmsCli.Calls).To(HaveLen(3))
+			Expect(dmsCli.Calls[0].Arguments.Get(0)).To(Equal(params[:1]))
+			Expect(dmsCli.Calls[1].Arguments.Get(0)).To(Equal(params[1:2]))
+			Expect(dmsCli.Calls[2].Arguments.Get(0)).To(Equal(params[3:]))
 		})
 
-		It("validates mlxreg parameters before flushing a pending DMS batch", func() {
+		It("retries only the failed DMS runtime parameter", func() {
+			params := []types.ConfigurationParameter{
+				{Name: "retry", Value: "a", DMSPath: "/retry"},
+				{Name: "next", Value: "b", DMSPath: "/next"},
+			}
+			temporaryErr := errors.New("temporary DMS set error")
+			dmsCli.On("SetParameters", params[:1]).Return(temporaryErr).Times(2)
+			dmsCli.On("SetParameters", params[:1]).Return(nil).Once()
+			dmsCli.On("SetParameters", params[1:]).Return(nil).Once()
+
+			err := manager.applyRuntimeParams(device, params, &dmsCli)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dmsCli.Calls).To(HaveLen(4))
+			Expect(dmsCli.Calls[3].Arguments.Get(0)).To(Equal(params[1:]))
+		})
+
+		It("returns the DMS error after ten failed attempts", func() {
+			params := []types.ConfigurationParameter{
+				{Name: "persistent failure", Value: "a", DMSPath: "/failure"},
+			}
+			setErr := errors.New("persistent DMS set error")
+			dmsCli.On("SetParameters", params).Return(setErr).Times(setParamMaxAttempts)
+
+			err := manager.applyRuntimeParams(device, params, &dmsCli)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, setErr)).To(BeTrue())
+			Expect(err.Error()).To(ContainSubstring("after 10 attempts"))
+			dmsCli.AssertNumberOfCalls(GinkgoT(), "SetParameters", setParamMaxAttempts)
+		})
+
+		It("retries a failed mlxreg runtime parameter before continuing", func() {
+			params := []types.ConfigurationParameter{
+				ccProbeMPModeParam(),
+				{Name: "next", Value: "b", DMSPath: "/next"},
+			}
+			temporaryErr := errors.New("temporary mlxreg set error")
+			execFake.cmds = []*fakeCmd{
+				{output: []byte("failed"), err: temporaryErr},
+				{output: []byte("failed"), err: temporaryErr},
+				{output: []byte("ok"), err: nil},
+			}
+			dmsCli.On("SetParameters", params[1:]).Return(nil).Once()
+
+			err := manager.applyRuntimeParams(device, params, &dmsCli)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(execFake.calls).To(HaveLen(3))
+			dmsCli.AssertNumberOfCalls(GinkgoT(), "SetParameters", 1)
+		})
+
+		It("returns the mlxreg error after ten failed attempts", func() {
+			params := []types.ConfigurationParameter{ccProbeMPModeParam()}
+			setErr := errors.New("persistent mlxreg set error")
+			execFake.cmds = make([]*fakeCmd, setParamMaxAttempts)
+			for i := range execFake.cmds {
+				execFake.cmds[i] = &fakeCmd{output: []byte("failed"), err: setErr}
+			}
+
+			err := manager.applyRuntimeParams(device, params, &dmsCli)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, setErr)).To(BeTrue())
+			Expect(err.Error()).To(ContainSubstring("after 10 attempts"))
+			Expect(execFake.calls).To(HaveLen(setParamMaxAttempts))
+		})
+
+		It("validates mlxreg parameters when they are reached in profile order", func() {
 			mixedParam := ccProbeMPModeParam()
 			mixedParam.DMSPath = "/mixed"
 			params := []types.ConfigurationParameter{
 				{Name: "dms before", Value: "a", DMSPath: "/before"},
 				mixedParam,
 			}
+			dmsCli.On("SetParameters", params[:1]).Return(nil).Once()
 
 			err := manager.applyRuntimeParams(device, params, &dmsCli)
 			Expect(err).To(MatchError(ContainSubstring("cannot define both dmsPath and mlxreg")))
-			dmsCli.AssertNotCalled(GinkgoT(), "SetParameters", mock.Anything)
+			dmsCli.AssertNumberOfCalls(GinkgoT(), "SetParameters", 1)
 			Expect(execFake.calls).To(BeEmpty())
 		})
 


### PR DESCRIPTION
## Summary

- keep Spectrum-X DMS runtime reads batched
- apply each declared runtime parameter separately in profile order
- route DMS and mlxreg parameters through a shared setParamWithRetry path with up to 10 total attempts and a one-second interval
- prefer each port fwctl device for mlxreg sets, falling back to its PCI address
- preserve existing IgnoreError behavior for DMS parameters

## Testing

- go test ./pkg/spectrumx/... -count=1
- go build ./...
- make lint