### PR TITLE
docs: correct Spectrum-X profile reference and multiplane mode names

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,8 @@ Spectrum-X profiles can configure NICs with multiple data planes. Available mode
 | Mode | Description | Supported NICs | Planes |
 |------|-------------|----------------|--------|
 | `none` | Single plane (default) | ConnectX-7, ConnectX-8, ConnectX-9, BF3 SuperNIC | 1 |
-| `swplb` | Software Packet Load Balancing | ConnectX-8, ConnectX-9, BF3 SuperNIC | 2, 4 |
-| `hwplb` | Hardware Packet Load Balancing | ConnectX-8, ConnectX-9 only | 2, 4 |
+| `swplb` | Software Plane Load Balancing | ConnectX-8, ConnectX-9, BF3 SuperNIC | 2, 4 |
+| `hwplb` | Hardware Plane Load Balancing | ConnectX-8, ConnectX-9 only | 2, 4 |
 
 `spectrumx.SpectrumXManager` includes the `spectrumx.PlanManager` interface. Before the controller
 starts its existing concurrent per-device NV apply, it calls `PreparePlan` once for the node's
@@ -244,9 +244,9 @@ spec:
       linkType: Ethernet
       spectrumXOptimized:
           enabled: true
-          version: "RA2.1"
+          version: "example-spectrum-x-profile"
           overlay: "none"
-          multiplaneMode: "hwplb" # Hardware Packet Load Balancing, ConnectX-8 only
+          multiplaneMode: "hwplb" # Hardware Plane Load Balancing, ConnectX-8, ConnectX-9 only
           numberOfPlanes: 4
 ```
 


### PR DESCRIPTION
Four corrections to the Spectrum-X section of `README.md`. Each is inconsistent with something else in the same file.

### 1. `version: "RA2.1"` no longer resolves (line 247)

Since 26.7.0 `spectrumXOptimized.version` names a Spectrum-X profile ConfigMap rather than selecting a built-in Reference Architecture version. `SpectrumXOptimizedSpec.Version` is a free-form string documented as "Should match the name of the config map with Spectrum-X profile", with no enum validation, and the profile controller keys profiles by ConfigMap name with no built-ins.

So `"RA2.1"` now resolves to a ConfigMap named `RA2.1`. None exists, the API accepts the template anyway, and Spectrum-X tuning is silently never applied.

The fix is not invented: this README defines a ConfigMap named `example-spectrum-x-profile` at line 136, tells the reader at line 122 to use its name, and the standalone snippet at line 173 already does. Line 247 was the only outlier.

### 2 and 3. `hwplb` / `swplb` are Plane Load Balancing, not Packet (lines 191-192)

The mechanism is the **Plane Load Balancer (PLB)** — NVIDIA's Spectrum-X material describes it as a dedicated hardware engine in the SuperNIC that distributes packets across network planes.

Terminology counts across the ecosystem:

| Source | "Plane" | "Packet" |
|---|---:|---:|
| NVIDIA/k8s-launch-kit | 24 | 0 |
| Mellanox/network-operator-docs | 12 | 0 |
| Mellanox/network-operator | 0 | 0 |
| Mellanox/spectrum-x-operator | 0 | 0 |
| Mellanox/sriov-network-operator | 0 | 0 |
| **this README** | 0 | **3** |

### 4. `hwplb` is not ConnectX-8 only (line 249)

The example comment says `ConnectX-8 only`, contradicting the mode table at line 192 in this same file (`ConnectX-8, ConnectX-9 only`) and the CRD's own validation message:

> `hwplb MultiplaneMode can only be enabled for ConnectX-8 (NicType 1023) or ConnectX-9 (NicType 1025)`

Wording matches line 192 exactly rather than introducing a third phrasing.

---

### Why this matters beyond the README

`Mellanox/network-operator-docs` generates `docs/nic-conf-operator/configuration-details.rst` from this file via `hack/fetch-config-docs.sh`, which overwrites the whole page. Hand-edits to the generated page do not survive; one was silently reverted by a docs-ci bot commit, and a docs PR was closed for the same reason. Correcting the source is the only durable route.

### Notes for maintainers

- **`network-operator-26.7.x` needs the same change** (lines 189, 190, 213, 215).
- `fetch-config-docs` pins the tag from `release.yaml`, currently `network-operator-v26.7.0`, which is already cut. A README fix alone therefore will not reach the published 26.7.0 documentation. Reaching it needs a patch tag, repointing the fetch at the branch, or removing that page from the generated set — your call, and out of scope here.
- ConnectX-7 is deliberately untouched: `main` already lists it correctly at lines 107, 181, 190 and 239.
- Minor observation, not changed here to keep the diff at four lines: the Network Operator documentation consistently says "ConnectX-8 SuperNIC" / "ConnectX-9 SuperNIC", while this README says "ConnectX-8" / "ConnectX-9". Worth normalising some time.

Scope: documentation only. No code, CRD, or behaviour change.