### PR TITLE
feat: load doSPCX data from ConfigMaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,34 @@ data:
                 value: "0x1"
 ```
 
+The same label also selects the doSPCX data bundle published by the
+`dospcx-data` repository. This ConfigMap uses a versioned format marker and a
+gzip-compressed tar archive instead of `data.profile`:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: doscpx-data-main
+  labels:
+    network.nvidia.com/operator.nic-configuration.spectrum-x-profile: ""
+data:
+  format: dospcx-data.tar.gz/v1
+binaryData:
+  dospcx-data.tar.gz: <base64-encoded-archive>
+```
+
+The Kubernetes API decodes `binaryData` before it reaches the daemon. The
+daemon validates and extracts the archive with the Go standard library, then
+replaces `/opt/mellanox/doca/services/dms/doSpcx/data` with the restored
+`data/` tree. Archive paths must remain under `data/`; links, special files,
+path traversal, oversized archives, and incomplete doSPCX layouts are rejected.
+A failed update leaves the previous valid tree in place. Exactly one labeled
+doSPCX data bundle may exist cluster-wide; multiple bundles are rejected instead
+of selecting one based on reconciliation order, and manager-installed data is
+deactivated while the conflict exists. Removing the active bundle removes the
+data installed from it and invalidates plans cached with its digest.
+
 Reference the profile from a `NicConfigurationTemplate` by using the ConfigMap name as the Spectrum-X version:
 
 ```yaml
@@ -202,9 +230,9 @@ translation remains execution-free. Configure groups `eswitch` and `vf-lifecycle
 current operation plan and reported as skipped; unknown groups fail closed.
 
 The manager creates its command executor internally and points the `dms-cli` child process at the
-Blueprints source tree fixed at `/opt/nvidia/blueprints`. The daemon image build must inject a
-compatible tree at that path, including `planner/`, `installer/`, `data/`, and `plugins/`. When
-`PreparePlan` is called, files are written to:
+Blueprints action tree fixed at `/opt/nvidia/blueprints`. The executable DMS planner remains part of
+the daemon base image, while the labeled doSPCX data ConfigMap restores its authored catalog under
+`/opt/mellanox/doca/services/dms/doSpcx/data`. When `PreparePlan` is called, files are written to:
 
 ```text
 /var/lib/blueprints/target-maps/nco-<node>-spcx.json
@@ -220,8 +248,9 @@ post-breakout inventory after NVConfig is active. The planner does not read `int
 interface naming remains an independent NCO capability.
 
 Each stage stores a flat metadata document containing only the planner inputs, including the
-platform, Spectrum-X settings, planner parameters, and target-map digest. A later `PreparePlan`
-call reuses the saved plan when that metadata still matches, the target-map digest is unchanged,
+platform, Spectrum-X settings, planner parameters, doSPCX data archive digest, and target-map
+digest. A later `PreparePlan` call reuses the saved plan when that metadata still matches, the
+target-map digest is unchanged,
 and the saved plan passes normal validation. Any input change or invalid saved artifact regenerates
 the plan through `dms-cli`. Before applying an individual Spectrum-X device, the configuration
 manager calls `GetPreparedPlan` and fails without changing the device if the stage-specific plan is

--- a/docs/nic-configuration-library.md
+++ b/docs/nic-configuration-library.md
@@ -415,11 +415,11 @@ dms-cli --json /nvidia/blueprints/plan profile=<profile> name=<name> \
 For Blueprints planning, the wrapper sets `BLUEPRINTS_ROOT` and
 `BLUEPRINTS_STATE_DIR` only on the `dms-cli` child process.
 `SpectrumXConfigManager` supplies the fixed `/opt/nvidia/blueprints` path and
-creates its command executor internally. The daemon image must inject a
-compatible DMS Blueprints source tree there. The tree must contain `planner/`,
-`installer/`, `data/`, and `plugins/`, because that is the external-root layout
-expected by the DMS action wrapper. Existing process environment entries are
-preserved, and inherited entries for either variable are replaced.
+creates its command executor internally. The executable DMS Blueprints action
+tree remains part of the daemon image. Authored doSPCX data is supplied
+separately through a labeled ConfigMap and installed at
+`/opt/mellanox/doca/services/dms/doSpcx/data`. Existing process environment
+entries are preserved, and inherited entries for either variable are replaced.
 
 `pkg/dmscli` is the low-level command wrapper. `pkg/spectrumx.PlanManager` is the
 plan lifecycle abstraction included by `SpectrumXManager`; it owns
@@ -436,8 +436,9 @@ before each existing concurrent per-device NV or runtime apply.
 `interfaceNameTemplate` is not an input to doSPCX planning.
 
 Each plan directory also contains `metadata.json`, a flat document with only the
-inputs used for that stage and the target-map digest. A later `PreparePlan` call
-reuses the saved plan when the metadata exactly matches the current inputs, the
+inputs used for that stage, the installed doSPCX data archive digest, and the
+target-map digest. A later `PreparePlan` call reuses the saved plan when the
+metadata exactly matches the current inputs, the
 target-map file still has the recorded digest, and the plan passes the same
 structural validation as a newly generated plan. Missing, malformed, or changed
 cache artifacts cause normal regeneration through `dms-cli`. Individual
@@ -448,7 +449,8 @@ device membership before touching hardware.
 
 ### pkg/spectrumx/ — Spectrum-X Configuration
 
-Sources: `pkg/spectrumx/spectrumx.go`, `pkg/spectrumx/prepareplan.go`, `pkg/spectrumx/semanticplan.go`
+Sources: `pkg/spectrumx/spectrumx.go`, `pkg/spectrumx/blueprintsdata.go`,
+`pkg/spectrumx/prepareplan.go`, `pkg/spectrumx/semanticplan.go`
 
 #### PlanManager Interface
 
@@ -473,6 +475,27 @@ type PlanManager interface {
 }
 ```
 
+Blueprint data installation is a separate capability embedded by
+`SpectrumXManager`:
+
+```go
+type BlueprintsDataManager interface {
+    InstallBlueprintsData(archive []byte) error
+    RemoveBlueprintsData() error
+}
+```
+
+`InstallBlueprintsData` accepts the decoded `dospcx-data.tar.gz/v1` archive,
+validates and stages its `data/` tree, and activates it under the DMS
+installation directory. It rejects paths outside `data/`, non-regular archive
+entries, oversized payloads, and incomplete layouts. Activation retains the
+previous valid tree when an update fails. The installed archive digest is part
+of plan metadata, so changing or removing the bundle invalidates cached plans.
+The controller accepts exactly one labeled doSPCX data bundle cluster-wide.
+Manager-installed data is deactivated while multiple bundles conflict and is
+removed when the active ConfigMap is deleted. Data already present in the daemon
+image is not removed when no ConfigMap bundle was installed.
+
 `PreparePlan` generates or reuses the stage-specific plan for the supplied
 Spectrum-X device group. It is a no-op when none of the supplied devices enable
 Spectrum-X. `GetPreparedPlan` retrieves the persisted plan without invoking
@@ -495,6 +518,7 @@ creates the command executor internally:
 ```go
 type SpectrumXManager interface {
     PlanManager
+    BlueprintsDataManager
     // Existing Spectrum-X configuration methods...
 }
 

--- a/internal/controller/spectrumxprofile_controller.go
+++ b/internal/controller/spectrumxprofile_controller.go
@@ -18,6 +18,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 
@@ -35,10 +36,9 @@ import (
 	"github.com/Mellanox/nic-configuration-operator/pkg/types"
 )
 
-// SpectrumXProfileReconciler reconciles Spectrum-X profile ConfigMaps (selected by
-// consts.SpectrumXProfileLabel, in any namespace) and pushes the parsed profile into the
-// SpectrumXManager. The ConfigMap name is used as the Spectrum-X version key referenced by
-// template.spectrumXOptimized.version.
+// SpectrumXProfileReconciler reconciles Spectrum-X ConfigMaps selected by
+// consts.SpectrumXProfileLabel. Legacy profile ConfigMaps are loaded into SpectrumXManager by
+// version, while doSPCX data bundles are restored into the DMS data directory.
 type SpectrumXProfileReconciler struct {
 	client.Client
 	Scheme           *runtime.Scheme
@@ -50,6 +50,12 @@ type SpectrumXProfileReconciler struct {
 	// visible and ensures that deleting a non-owning duplicate does not wipe the active profile.
 	ownersMu sync.Mutex
 	owners   map[string]client.ObjectKey
+
+	// blueprintsSources tracks manager-wide doSPCX bundle ConfigMaps separately from versioned
+	// legacy profiles. Keeping the previous set lets delete and label-removal requests avoid the
+	// legacy RemoveConfig path even though the object is no longer available from the cache.
+	blueprintsMu      sync.Mutex
+	blueprintsSources map[client.ObjectKey]struct{}
 }
 
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
@@ -58,12 +64,23 @@ type SpectrumXProfileReconciler struct {
 func (r *SpectrumXProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	reqLog := log.FromContext(ctx)
 
+	// Reconcile the doSPCX data bundle from the complete selected ConfigMap set. The bundle is
+	// manager-wide rather than versioned, so accepting more than one source would make the active
+	// tree depend on informer event order. This also handles deletion and label-removal events,
+	// where the reconciled object itself is no longer available from the filtered cache.
+	blueprintsRequest, err := r.reconcileBlueprintsData(ctx, req.NamespacedName)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	cm := &corev1.ConfigMap{}
-	err := r.Get(ctx, req.NamespacedName, cm)
+	err = r.Get(ctx, req.NamespacedName, cm)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			// ConfigMap was deleted - drop the corresponding profile from the manager.
-			r.removeProfile(ctx, req.NamespacedName)
+			if !blueprintsRequest {
+				// A legacy profile ConfigMap was deleted - drop it from the manager.
+				r.removeProfile(ctx, req.NamespacedName)
+			}
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
@@ -73,8 +90,14 @@ func (r *SpectrumXProfileReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// cache informer is filtered by the label, so a label removal surfaces as a delete event,
 	// but a stale object could still reach us here.
 	if _, ok := cm.Labels[consts.SpectrumXProfileLabel]; !ok {
-		reqLog.Info("Spectrum-X profile label removed from ConfigMap, removing profile", "version", req.Name)
-		r.removeProfile(ctx, req.NamespacedName)
+		if !blueprintsRequest {
+			reqLog.Info("Spectrum-X profile label removed from ConfigMap, removing profile", "version", req.Name)
+			r.removeProfile(ctx, req.NamespacedName)
+		}
+		return ctrl.Result{}, nil
+	}
+
+	if isBlueprintsDataConfigMap(cm) {
 		return ctrl.Result{}, nil
 	}
 
@@ -109,6 +132,97 @@ func (r *SpectrumXProfileReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	return ctrl.Result{}, nil
 }
 
+func (r *SpectrumXProfileReconciler) reconcileBlueprintsData(
+	ctx context.Context,
+	requestKey client.ObjectKey,
+) (bool, error) {
+	r.blueprintsMu.Lock()
+	defer r.blueprintsMu.Unlock()
+
+	_, requestWasBlueprintsSource := r.blueprintsSources[requestKey]
+	configMaps := &corev1.ConfigMapList{}
+	if err := r.List(ctx, configMaps); err != nil {
+		return requestWasBlueprintsSource,
+			fmt.Errorf("list Spectrum-X ConfigMaps while reconciling doSPCX data: %w", err)
+	}
+
+	bundles := make([]*corev1.ConfigMap, 0, 1)
+	currentSources := map[client.ObjectKey]struct{}{}
+	for index := range configMaps.Items {
+		configMap := &configMaps.Items[index]
+		if _, selected := configMap.Labels[consts.SpectrumXProfileLabel]; selected && isBlueprintsDataConfigMap(configMap) {
+			bundles = append(bundles, configMap)
+			currentSources[client.ObjectKeyFromObject(configMap)] = struct{}{}
+		}
+	}
+	if _, requestIsBlueprintsSource := currentSources[requestKey]; requestIsBlueprintsSource {
+		requestWasBlueprintsSource = true
+	}
+	r.blueprintsSources = currentSources
+	sort.Slice(bundles, func(i, j int) bool {
+		if bundles[i].Namespace == bundles[j].Namespace {
+			return bundles[i].Name < bundles[j].Name
+		}
+		return bundles[i].Namespace < bundles[j].Namespace
+	})
+
+	if len(bundles) == 0 {
+		if err := r.SpectrumXManager.RemoveBlueprintsData(); err != nil {
+			return requestWasBlueprintsSource,
+				fmt.Errorf("remove doSPCX data after its ConfigMap was removed: %w", err)
+		}
+		return requestWasBlueprintsSource, nil
+	}
+	if len(bundles) > 1 {
+		sources := make([]string, 0, len(bundles))
+		for _, bundle := range bundles {
+			sources = append(sources, client.ObjectKeyFromObject(bundle).String())
+		}
+		if err := r.SpectrumXManager.RemoveBlueprintsData(); err != nil {
+			return requestWasBlueprintsSource, fmt.Errorf(
+				"multiple doSPCX data ConfigMaps are selected (%s) and the active bundle could not be deactivated: %w",
+				strings.Join(sources, ", "), err)
+		}
+		return requestWasBlueprintsSource, fmt.Errorf(
+			"multiple doSPCX data ConfigMaps are selected (%s); exactly one bundle is supported",
+			strings.Join(sources, ", "))
+	}
+
+	bundle := bundles[0]
+	format, hasFormat := bundle.Data[consts.SpectrumXBlueprintsConfigMapFormatKey]
+	if !hasFormat || strings.TrimSpace(format) != consts.SpectrumXBlueprintsConfigMapFormat {
+		return requestWasBlueprintsSource, fmt.Errorf(
+			"spectrum-x doSPCX data ConfigMap %s/%s has unsupported %q value %q",
+			bundle.Namespace, bundle.Name, consts.SpectrumXBlueprintsConfigMapFormatKey, format)
+	}
+	archive, hasArchive := bundle.BinaryData[consts.SpectrumXBlueprintsConfigMapArchiveKey]
+	if !hasArchive || len(archive) == 0 {
+		return requestWasBlueprintsSource, fmt.Errorf(
+			"spectrum-x doSPCX data ConfigMap %s/%s is missing or has an empty binaryData %q key",
+			bundle.Namespace, bundle.Name, consts.SpectrumXBlueprintsConfigMapArchiveKey)
+	}
+	if err := r.SpectrumXManager.InstallBlueprintsData(archive); err != nil {
+		return requestWasBlueprintsSource, fmt.Errorf(
+			"failed to install doSPCX data from ConfigMap %s/%s: %w", bundle.Namespace, bundle.Name, err)
+	}
+	log.FromContext(ctx).V(2).Info("Reconciled doSPCX data bundle",
+		"configMap", client.ObjectKeyFromObject(bundle).String(),
+		"format", format,
+		"sourceCommit", bundle.Annotations[consts.SpectrumXBlueprintsCommitAnnotation],
+		"sourceRef", bundle.Annotations[consts.SpectrumXBlueprintsRefAnnotation],
+		"sourceTree", bundle.Annotations[consts.SpectrumXBlueprintsTreeAnnotation])
+	return requestWasBlueprintsSource, nil
+}
+
+func isBlueprintsDataConfigMap(configMap *corev1.ConfigMap) bool {
+	if configMap == nil {
+		return false
+	}
+	_, hasFormat := configMap.Data[consts.SpectrumXBlueprintsConfigMapFormatKey]
+	_, hasArchive := configMap.BinaryData[consts.SpectrumXBlueprintsConfigMapArchiveKey]
+	return hasFormat || hasArchive
+}
+
 // removeProfile drops the profile for a version, but only when the reconciled ConfigMap is the
 // current owner (or no owner is recorded). This prevents a duplicate same-named ConfigMap in a
 // different namespace from wiping the profile that another ConfigMap is actively providing.
@@ -130,6 +244,9 @@ func (r *SpectrumXProfileReconciler) removeProfile(ctx context.Context, key clie
 func (r *SpectrumXProfileReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r.owners == nil {
 		r.owners = map[string]client.ObjectKey{}
+	}
+	if r.blueprintsSources == nil {
+		r.blueprintsSources = map[client.ObjectKey]struct{}{}
 	}
 
 	// Only reconcile ConfigMaps carrying the Spectrum-X profile label. This predicate complements

--- a/internal/controller/spectrumxprofile_controller_test.go
+++ b/internal/controller/spectrumxprofile_controller_test.go
@@ -17,6 +17,7 @@ package controller
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -56,6 +57,7 @@ func newProfileReconciler(t *testing.T, objs ...*corev1.ConfigMap) (*SpectrumXPr
 	}
 
 	mgr := spectrumxmocks.NewSpectrumXManager(t)
+	mgr.On("RemoveBlueprintsData").Return(nil).Maybe()
 	return &SpectrumXProfileReconciler{
 		Client:           builder.Build(),
 		Scheme:           scheme,
@@ -68,6 +70,8 @@ func newProfileReconciler(t *testing.T, objs ...*corev1.ConfigMap) (*SpectrumXPr
 const (
 	testProfileVersion = "RA2.0"
 	testProfileNS      = "any-ns"
+	testFirstBundle    = "first"
+	testSecondBundle   = "second"
 )
 
 func profileConfigMap(withLabel bool, data map[string]string) *corev1.ConfigMap {
@@ -78,6 +82,19 @@ func profileConfigMap(withLabel bool, data map[string]string) *corev1.ConfigMap 
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: testProfileVersion, Namespace: testProfileNS, Labels: labels},
 		Data:       data,
+	}
+}
+
+func blueprintsConfigMap(format string, archive []byte) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testProfileVersion, Namespace: testProfileNS,
+			Labels: map[string]string{consts.SpectrumXProfileLabel: ""},
+		},
+		Data: map[string]string{consts.SpectrumXBlueprintsConfigMapFormatKey: format},
+		BinaryData: map[string][]byte{
+			consts.SpectrumXBlueprintsConfigMapArchiveKey: archive,
+		},
 	}
 }
 
@@ -96,6 +113,141 @@ func TestSpectrumXProfile_SetConfigOnValidConfigMap(t *testing.T) {
 
 	if _, err := reconcileProfile(r); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSpectrumXProfile_InstallsBlueprintsDataBundle(t *testing.T) {
+	archive := []byte("gzip archive")
+	cm := blueprintsConfigMap(consts.SpectrumXBlueprintsConfigMapFormat, archive)
+	r, mgr := newProfileReconciler(t, cm)
+	mgr.On("InstallBlueprintsData", archive).Return(nil).Once()
+
+	if _, err := reconcileProfile(r); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSpectrumXProfile_RemovesBlueprintsDataWhenBundleIsDeleted(t *testing.T) {
+	archive := []byte("gzip archive")
+	cm := blueprintsConfigMap(consts.SpectrumXBlueprintsConfigMapFormat, archive)
+	r, mgr := newProfileReconciler(t, cm)
+	mgr.On("InstallBlueprintsData", archive).Return(nil).Once()
+
+	if _, err := reconcileProfile(r); err != nil {
+		t.Fatalf("unexpected error installing doSPCX data: %v", err)
+	}
+	if err := r.Delete(context.Background(), cm); err != nil {
+		t.Fatalf("failed to delete doSPCX data ConfigMap: %v", err)
+	}
+	if _, err := reconcileProfile(r); err != nil {
+		t.Fatalf("unexpected error removing doSPCX data: %v", err)
+	}
+	mgr.AssertNumberOfCalls(t, "RemoveBlueprintsData", 1)
+}
+
+func TestSpectrumXProfile_RejectsMultipleBlueprintsDataBundles(t *testing.T) {
+	first := blueprintsConfigMap(consts.SpectrumXBlueprintsConfigMapFormat, []byte("first archive"))
+	first.Name = testFirstBundle
+	second := blueprintsConfigMap(consts.SpectrumXBlueprintsConfigMapFormat, []byte("second archive"))
+	second.Name = testSecondBundle
+	r, mgr := newProfileReconciler(t, first, second)
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{
+		Name: first.Name, Namespace: first.Namespace,
+	}})
+	if err == nil || !strings.Contains(err.Error(), "multiple doSPCX data ConfigMaps") {
+		t.Fatalf("expected multiple bundle error, got %v", err)
+	}
+	mgr.AssertNotCalled(t, "InstallBlueprintsData", mock.Anything)
+}
+
+func TestSpectrumXProfile_DeactivatesInstalledBlueprintsDataWhenConflictAppears(t *testing.T) {
+	firstArchive := []byte("first archive")
+	first := blueprintsConfigMap(consts.SpectrumXBlueprintsConfigMapFormat, firstArchive)
+	first.Name = testFirstBundle
+	r, mgr := newProfileReconciler(t, first)
+	mgr.On("InstallBlueprintsData", firstArchive).Return(nil).Once()
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{
+		Name: first.Name, Namespace: first.Namespace,
+	}}); err != nil {
+		t.Fatalf("unexpected error installing initial doSPCX data bundle: %v", err)
+	}
+	second := blueprintsConfigMap(consts.SpectrumXBlueprintsConfigMapFormat, []byte("second archive"))
+	second.Name = testSecondBundle
+	if err := r.Create(context.Background(), second); err != nil {
+		t.Fatalf("failed to create conflicting doSPCX data ConfigMap: %v", err)
+	}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{
+		Name: second.Name, Namespace: second.Namespace,
+	}})
+	if err == nil || !strings.Contains(err.Error(), "multiple doSPCX data ConfigMaps") {
+		t.Fatalf("expected multiple bundle error, got %v", err)
+	}
+	mgr.AssertNumberOfCalls(t, "RemoveBlueprintsData", 1)
+}
+
+func TestSpectrumXProfile_InstallsRemainingBlueprintsDataBundleAfterConflictIsDeleted(t *testing.T) {
+	first := blueprintsConfigMap(consts.SpectrumXBlueprintsConfigMapFormat, []byte("first archive"))
+	first.Name = testFirstBundle
+	secondArchive := []byte("second archive")
+	second := blueprintsConfigMap(consts.SpectrumXBlueprintsConfigMapFormat, secondArchive)
+	second.Name = testSecondBundle
+	r, mgr := newProfileReconciler(t, first, second)
+	mgr.On("InstallBlueprintsData", secondArchive).Return(nil).Once()
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{
+		Name: first.Name, Namespace: first.Namespace,
+	}}); err == nil {
+		t.Fatal("expected initial multiple bundle error, got nil")
+	}
+	if err := r.Delete(context.Background(), first); err != nil {
+		t.Fatalf("failed to delete conflicting doSPCX data ConfigMap: %v", err)
+	}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{
+		Name: first.Name, Namespace: first.Namespace,
+	}}); err != nil {
+		t.Fatalf("unexpected error installing remaining doSPCX data bundle: %v", err)
+	}
+}
+
+func TestSpectrumXProfile_ReturnsBlueprintsInstallationError(t *testing.T) {
+	archive := []byte("gzip archive")
+	cm := blueprintsConfigMap(consts.SpectrumXBlueprintsConfigMapFormat, archive)
+	r, mgr := newProfileReconciler(t, cm)
+	mgr.On("InstallBlueprintsData", archive).Return(context.DeadlineExceeded).Once()
+
+	if _, err := reconcileProfile(r); err == nil {
+		t.Fatal("expected doSPCX data installation error, got nil")
+	}
+}
+
+func TestSpectrumXProfile_ErrorWhenBlueprintsFormatUnsupported(t *testing.T) {
+	cm := blueprintsConfigMap("unsupported/v1", []byte("gzip archive"))
+	r, _ := newProfileReconciler(t, cm)
+
+	if _, err := reconcileProfile(r); err == nil {
+		t.Fatal("expected error for unsupported doSPCX data format, got nil")
+	}
+}
+
+func TestSpectrumXProfile_ErrorWhenBlueprintsArchiveMissing(t *testing.T) {
+	cm := blueprintsConfigMap(consts.SpectrumXBlueprintsConfigMapFormat, nil)
+	r, _ := newProfileReconciler(t, cm)
+
+	if _, err := reconcileProfile(r); err == nil {
+		t.Fatal("expected error for missing doSPCX data archive, got nil")
+	}
+}
+
+func TestSpectrumXProfile_ErrorWhenBlueprintsFormatMissing(t *testing.T) {
+	cm := blueprintsConfigMap("", []byte("gzip archive"))
+	delete(cm.Data, consts.SpectrumXBlueprintsConfigMapFormatKey)
+	r, _ := newProfileReconciler(t, cm)
+
+	if _, err := reconcileProfile(r); err == nil {
+		t.Fatal("expected error for missing doSPCX data format, got nil")
 	}
 }
 

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -123,16 +123,28 @@ const (
 
 	SupportedNicFirmwareConfigmap = "nic-configuration-operator-supported-nic-firmware"
 
-	// SpectrumXProfileLabel selects ConfigMaps that carry a Spectrum-X profile.
+	// SpectrumXProfileLabel selects ConfigMaps that carry a Spectrum-X profile or doSPCX data bundle.
 	// Presence of the key selects the ConfigMap; its value is ignored.
 	SpectrumXProfileLabel = "network.nvidia.com/operator.nic-configuration.spectrum-x-profile"
 	// SpectrumXProfileConfigMapDataKey is the ConfigMap Data key holding the SpectrumXConfig YAML.
 	// The ConfigMap name is used as the Spectrum-X version key (template.spectrumXOptimized.version).
 	SpectrumXProfileConfigMapDataKey = "profile"
-	Mlx5ModuleVersionPath            = "/sys/bus/pci/drivers/mlx5_core/module/version"
-	Mlx5CoreDriverName               = "mlx5_core"
-	PCIDevicesSysfsPath              = "/sys/bus/pci/devices"
-	Mlx5CoreDriverBindPath           = "/sys/bus/pci/drivers/mlx5_core/bind"
+	// SpectrumXBlueprintsConfigMapFormatKey identifies the doSPCX data bundle format.
+	SpectrumXBlueprintsConfigMapFormatKey = "format"
+	// SpectrumXBlueprintsConfigMapFormat is the supported doSPCX data bundle format.
+	SpectrumXBlueprintsConfigMapFormat = "dospcx-data.tar.gz/v1"
+	// SpectrumXBlueprintsConfigMapArchiveKey holds the gzip-compressed doSPCX data tar archive.
+	SpectrumXBlueprintsConfigMapArchiveKey = "dospcx-data.tar.gz"
+	// SpectrumXBlueprintsCommitAnnotation records the dospcx-data source commit.
+	SpectrumXBlueprintsCommitAnnotation = "configuration.net.nvidia.com/dospcx-data-commit"
+	// SpectrumXBlueprintsRefAnnotation records the dospcx-data source ref.
+	SpectrumXBlueprintsRefAnnotation = "configuration.net.nvidia.com/dospcx-data-ref"
+	// SpectrumXBlueprintsTreeAnnotation records the Git tree containing the packaged data directory.
+	SpectrumXBlueprintsTreeAnnotation = "configuration.net.nvidia.com/dospcx-data-tree"
+	Mlx5ModuleVersionPath             = "/sys/bus/pci/drivers/mlx5_core/module/version"
+	Mlx5CoreDriverName                = "mlx5_core"
+	PCIDevicesSysfsPath               = "/sys/bus/pci/devices"
+	Mlx5CoreDriverBindPath            = "/sys/bus/pci/drivers/mlx5_core/bind"
 
 	FwConfigNotAppliedAfterRebootErrorMsg = "firmware configuration failed to apply after reboot"
 

--- a/pkg/spectrumx/blueprintsdata.go
+++ b/pkg/spectrumx/blueprintsdata.go
@@ -1,0 +1,319 @@
+/*
+Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spectrumx
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	maxBlueprintsArchiveBytes      = 1 << 20
+	maxBlueprintsExpandedBytes     = 32 << 20
+	maxBlueprintsDecompressedBytes = 40 << 20
+	maxBlueprintsArchiveFiles      = 4096
+)
+
+var (
+	removeBlueprintsDataDirectory = os.RemoveAll
+	removeBlueprintsDataBackup    = os.RemoveAll
+)
+
+var requiredBlueprintsDataDirectories = []string{
+	"features",
+	"profiles",
+	"templates",
+}
+
+var requiredBlueprintsDataFiles = []string{
+	"execution-groups.yaml",
+	"formulas.yaml",
+	"hca-types.yaml",
+	"phase-config.yaml",
+	"platform-types.yaml",
+}
+
+// InstallBlueprintsData restores a doSPCX data archive under the DMS installation directory.
+// The previous valid tree remains active if validation, extraction, or activation fails.
+func (m *spectrumXConfigManager) InstallBlueprintsData(archive []byte) error {
+	if m == nil {
+		return fmt.Errorf("spectrum-x manager must not be nil")
+	}
+	if strings.TrimSpace(m.dospcxDataRoot) == "" || !filepath.IsAbs(m.dospcxDataRoot) {
+		return fmt.Errorf("doSPCX data root must be a non-empty absolute path")
+	}
+	if len(archive) == 0 {
+		return fmt.Errorf("doSPCX data archive must not be empty")
+	}
+	if len(archive) > maxBlueprintsArchiveBytes {
+		return fmt.Errorf("doSPCX data archive exceeds the %d-byte compressed size limit", maxBlueprintsArchiveBytes)
+	}
+
+	digest := sha256Digest(archive)
+	m.planMutex.Lock()
+	defer m.planMutex.Unlock()
+	if digest == m.dospcxDataDigest {
+		if err := validateBlueprintsDataLayout(m.dospcxDataRoot); err == nil {
+			return nil
+		}
+	}
+	if err := installBlueprintsDataArchive(archive, m.dospcxDataRoot); err != nil {
+		return err
+	}
+	m.dospcxDataDigest = digest
+	return nil
+}
+
+// RemoveBlueprintsData removes data previously installed from a ConfigMap. Data supplied by the
+// daemon image is left intact when this manager has not installed a bundle during its lifetime.
+func (m *spectrumXConfigManager) RemoveBlueprintsData() error {
+	if m == nil {
+		return fmt.Errorf("spectrum-x manager must not be nil")
+	}
+	if strings.TrimSpace(m.dospcxDataRoot) == "" || !filepath.IsAbs(m.dospcxDataRoot) {
+		return fmt.Errorf("doSPCX data root must be a non-empty absolute path")
+	}
+
+	m.planMutex.Lock()
+	defer m.planMutex.Unlock()
+	if m.dospcxDataDigest == "" {
+		return nil
+	}
+	if err := removeBlueprintsDataDirectory(m.dospcxDataRoot); err != nil {
+		return fmt.Errorf("remove doSPCX data directory %q: %w", m.dospcxDataRoot, err)
+	}
+	m.dospcxDataDigest = ""
+	return nil
+}
+
+func installBlueprintsDataArchive(archive []byte, destination string) error {
+	parent := filepath.Dir(destination)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return fmt.Errorf("create doSPCX data parent directory %q: %w", parent, err)
+	}
+
+	stagingDirectory, err := os.MkdirTemp(parent, ".nco-dospcx-data-")
+	if err != nil {
+		return fmt.Errorf("create doSPCX data staging directory in %q: %w", parent, err)
+	}
+	defer func() { _ = os.RemoveAll(stagingDirectory) }()
+
+	if err := extractBlueprintsDataArchive(archive, stagingDirectory); err != nil {
+		return fmt.Errorf("extract doSPCX data archive: %w", err)
+	}
+	stagedDataRoot := filepath.Join(stagingDirectory, "data")
+	if err := validateBlueprintsDataLayout(stagedDataRoot); err != nil {
+		return err
+	}
+	if err := replaceBlueprintsDataDirectory(stagedDataRoot, destination); err != nil {
+		return fmt.Errorf("activate doSPCX data directory %q: %w", destination, err)
+	}
+	return nil
+}
+
+func extractBlueprintsDataArchive(archive []byte, destination string) error {
+	gzipReader, err := gzip.NewReader(bytes.NewReader(archive))
+	if err != nil {
+		return fmt.Errorf("open gzip stream: %w", err)
+	}
+	defer func() { _ = gzipReader.Close() }()
+
+	decompressed := &io.LimitedReader{R: gzipReader, N: maxBlueprintsDecompressedBytes + 1}
+	tarReader := tar.NewReader(decompressed)
+	destinationRoot, err := os.OpenRoot(destination)
+	if err != nil {
+		return fmt.Errorf("open extraction root %q: %w", destination, err)
+	}
+	defer func() { _ = destinationRoot.Close() }()
+
+	seen := map[string]struct{}{}
+	directoryModes := map[string]os.FileMode{}
+	var expandedBytes int64
+	entries := 0
+	for {
+		header, nextErr := tarReader.Next()
+		if nextErr == io.EOF {
+			break
+		}
+		if nextErr != nil {
+			return fmt.Errorf("read tar entry: %w", nextErr)
+		}
+
+		entries++
+		if entries > maxBlueprintsArchiveFiles {
+			return fmt.Errorf("archive exceeds the %d-entry limit", maxBlueprintsArchiveFiles)
+		}
+		archivePath, pathErr := cleanBlueprintsArchivePath(header.Name)
+		if pathErr != nil {
+			return pathErr
+		}
+		// Keep this guard adjacent to the rooted file operations. cleanBlueprintsArchivePath
+		// already rejects traversal, and os.Root independently prevents escaping destination.
+		if strings.Contains(archivePath, "..") {
+			return fmt.Errorf("archive contains unsafe path %q", header.Name)
+		}
+		if _, exists := seen[archivePath]; exists {
+			return fmt.Errorf("archive contains duplicate path %q", header.Name)
+		}
+		seen[archivePath] = struct{}{}
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := destinationRoot.MkdirAll(archivePath, 0o755); err != nil {
+				return fmt.Errorf("create directory %q: %w", archivePath, err)
+			}
+			directoryModes[archivePath] = os.FileMode(header.Mode).Perm()
+		case tar.TypeReg:
+			if header.Size < 0 || header.Size > maxBlueprintsExpandedBytes-expandedBytes {
+				return fmt.Errorf("archive exceeds the %d-byte expanded size limit", maxBlueprintsExpandedBytes)
+			}
+			expandedBytes += header.Size
+			if err := destinationRoot.MkdirAll(path.Dir(archivePath), 0o755); err != nil {
+				return fmt.Errorf("create parent directory for %q: %w", archivePath, err)
+			}
+			file, openErr := destinationRoot.OpenFile(
+				archivePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, os.FileMode(header.Mode).Perm())
+			if openErr != nil {
+				return fmt.Errorf("create file %q: %w", archivePath, openErr)
+			}
+			_, copyErr := io.CopyN(file, tarReader, header.Size)
+			closeErr := file.Close()
+			if copyErr != nil {
+				return fmt.Errorf("write file %q: %w", archivePath, copyErr)
+			}
+			if closeErr != nil {
+				return fmt.Errorf("close file %q: %w", archivePath, closeErr)
+			}
+		default:
+			return fmt.Errorf("archive path %q uses unsupported tar entry type %d", header.Name, header.Typeflag)
+		}
+	}
+	if _, err := io.Copy(io.Discard, decompressed); err != nil {
+		return fmt.Errorf("validate gzip stream: %w", err)
+	}
+	if decompressed.N <= 0 {
+		return fmt.Errorf("archive exceeds the %d-byte decompressed size limit", maxBlueprintsDecompressedBytes)
+	}
+
+	directories := make([]string, 0, len(directoryModes))
+	for directory := range directoryModes {
+		directories = append(directories, directory)
+	}
+	sort.Slice(directories, func(i, j int) bool {
+		return strings.Count(directories[i], "/") > strings.Count(directories[j], "/")
+	})
+	for _, directory := range directories {
+		if err := destinationRoot.Chmod(directory, directoryModes[directory]); err != nil {
+			return fmt.Errorf("set directory permissions for %q: %w", directory, err)
+		}
+	}
+	return nil
+}
+
+func cleanBlueprintsArchivePath(name string) (string, error) {
+	if name == "" || strings.ContainsRune(name, '\x00') || strings.Contains(name, `\`) {
+		return "", fmt.Errorf("archive contains invalid path %q", name)
+	}
+	trimmed := strings.TrimSuffix(name, "/")
+	cleaned := path.Clean(trimmed)
+	if path.IsAbs(cleaned) || cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return "", fmt.Errorf("archive contains unsafe path %q", name)
+	}
+	if cleaned != trimmed {
+		return "", fmt.Errorf("archive contains non-canonical path %q", name)
+	}
+	if cleaned != "data" && !strings.HasPrefix(cleaned, "data/") {
+		return "", fmt.Errorf("archive path %q is outside the required data directory", name)
+	}
+	return cleaned, nil
+}
+
+func validateBlueprintsDataLayout(dataRoot string) error {
+	info, err := os.Stat(dataRoot)
+	if err != nil {
+		return fmt.Errorf("doSPCX archive is missing its data root: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("doSPCX archive data root is not a directory")
+	}
+	for _, requiredPath := range requiredBlueprintsDataDirectories {
+		info, err := os.Stat(filepath.Join(dataRoot, requiredPath))
+		if err != nil {
+			return fmt.Errorf("doSPCX archive is missing required path %q: %w", requiredPath, err)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("doSPCX archive required path %q is not a directory", requiredPath)
+		}
+	}
+	for _, requiredPath := range requiredBlueprintsDataFiles {
+		info, err := os.Stat(filepath.Join(dataRoot, requiredPath))
+		if err != nil {
+			return fmt.Errorf("doSPCX archive is missing required path %q: %w", requiredPath, err)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("doSPCX archive required path %q is not a regular file", requiredPath)
+		}
+	}
+	return nil
+}
+
+func replaceBlueprintsDataDirectory(stagedDataRoot, destination string) error {
+	parent := filepath.Dir(destination)
+	backupPath := ""
+	if _, err := os.Lstat(destination); err == nil {
+		backupDirectory, tempErr := os.MkdirTemp(parent, ".nco-dospcx-data-backup-")
+		if tempErr != nil {
+			return fmt.Errorf("reserve backup path: %w", tempErr)
+		}
+		if removeErr := os.Remove(backupDirectory); removeErr != nil {
+			return fmt.Errorf("prepare backup path %q: %w", backupDirectory, removeErr)
+		}
+		backupPath = backupDirectory
+		if renameErr := os.Rename(destination, backupPath); renameErr != nil {
+			return fmt.Errorf("move current data directory to %q: %w", backupPath, renameErr)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("inspect current data directory: %w", err)
+	}
+
+	if err := os.Rename(stagedDataRoot, destination); err != nil {
+		if backupPath != "" {
+			if rollbackErr := os.Rename(backupPath, destination); rollbackErr != nil {
+				return fmt.Errorf("activate staged data: %w; restore previous data: %v", err, rollbackErr)
+			}
+		}
+		return fmt.Errorf("activate staged data: %w", err)
+	}
+	if backupPath != "" {
+		if err := removeBlueprintsDataBackup(backupPath); err != nil {
+			// Activation already succeeded. Treat backup removal as best-effort so callers update
+			// their digest to match the active tree instead of reporting a failed installation
+			// while leaving the new data active.
+			log.Log.Error(err, "failed to remove previous doSPCX data directory", "path", backupPath)
+		}
+	}
+	return nil
+}

--- a/pkg/spectrumx/blueprintsdata_test.go
+++ b/pkg/spectrumx/blueprintsdata_test.go
@@ -1,0 +1,272 @@
+/*
+Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spectrumx
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type blueprintsArchiveEntry struct {
+	name     string
+	typeFlag byte
+	mode     int64
+	content  string
+}
+
+type zeroReader struct{}
+
+func (zeroReader) Read(data []byte) (int, error) {
+	clear(data)
+	return len(data), nil
+}
+
+func blueprintsArchive(entries ...blueprintsArchiveEntry) []byte {
+	var output bytes.Buffer
+	gzipWriter := gzip.NewWriter(&output)
+	tarWriter := tar.NewWriter(gzipWriter)
+	for _, entry := range entries {
+		header := &tar.Header{
+			Name:     entry.name,
+			Typeflag: entry.typeFlag,
+			Mode:     entry.mode,
+			Size:     int64(len(entry.content)),
+		}
+		Expect(tarWriter.WriteHeader(header)).To(Succeed())
+		if entry.content != "" {
+			_, err := tarWriter.Write([]byte(entry.content))
+			Expect(err).NotTo(HaveOccurred())
+		}
+	}
+	Expect(tarWriter.Close()).To(Succeed())
+	Expect(gzipWriter.Close()).To(Succeed())
+	return output.Bytes()
+}
+
+func validBlueprintsArchive(extra ...blueprintsArchiveEntry) []byte {
+	entries := make([]blueprintsArchiveEntry, 0, 10+len(extra))
+	entries = append(entries, []blueprintsArchiveEntry{
+		{name: "data/", typeFlag: tar.TypeDir, mode: 0o755},
+		{name: "data/features/", typeFlag: tar.TypeDir, mode: 0o755},
+		{name: "data/profiles/", typeFlag: tar.TypeDir, mode: 0o755},
+		{name: "data/templates/", typeFlag: tar.TypeDir, mode: 0o755},
+		{name: "data/execution-groups.yaml", typeFlag: tar.TypeReg, mode: 0o644, content: "groups: {}\n"},
+		{name: "data/formulas.yaml", typeFlag: tar.TypeReg, mode: 0o644, content: "formulas: {}\n"},
+		{name: "data/hca-types.yaml", typeFlag: tar.TypeReg, mode: 0o644, content: "hca_types: {}\n"},
+		{name: "data/phase-config.yaml", typeFlag: tar.TypeReg, mode: 0o644, content: "phases: {}\n"},
+		{name: "data/platform-types.yaml", typeFlag: tar.TypeReg, mode: 0o644, content: "platform_types: {}\n"},
+		{name: "data/temp.sh", typeFlag: tar.TypeReg, mode: 0o755, content: "#!/bin/sh\n"},
+	}...)
+	return blueprintsArchive(append(entries, extra...)...)
+}
+
+func newBlueprintsDataManager(dataRoot string) *spectrumXConfigManager {
+	return &spectrumXConfigManager{
+		spectrumXConfigs:   nil,
+		dmsManager:         nil,
+		execInterface:      nil,
+		blueprintsRoot:     "",
+		blueprintsStateDir: "",
+		dospcxDataRoot:     dataRoot,
+		dospcxDataDigest:   "",
+		ccProcesses:        nil,
+		ccTerminationChan:  nil,
+	}
+}
+
+var _ = Describe("doSPCX data archive installation", func() {
+	It("restores the data tree and replaces obsolete files", func() {
+		dataRoot := filepath.Join(GinkgoT().TempDir(), "doSpcx", "data")
+		Expect(os.MkdirAll(dataRoot, 0o755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(dataRoot, "obsolete"), []byte("old"), 0o644)).To(Succeed())
+		archive := validBlueprintsArchive()
+		manager := newBlueprintsDataManager(dataRoot)
+
+		Expect(manager.InstallBlueprintsData(archive)).To(Succeed())
+
+		content, err := os.ReadFile(filepath.Join(dataRoot, "execution-groups.yaml"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(content)).To(Equal("groups: {}\n"))
+		_, err = os.Stat(filepath.Join(dataRoot, "obsolete"))
+		Expect(os.IsNotExist(err)).To(BeTrue())
+		info, err := os.Stat(filepath.Join(dataRoot, "temp.sh"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.Mode().Perm()).To(Equal(os.FileMode(0o755)))
+		Expect(manager.dospcxDataDigest).To(Equal(sha256Digest(archive)))
+	})
+
+	It("keeps the active tree when the archive is malformed", func() {
+		dataRoot := filepath.Join(GinkgoT().TempDir(), "doSpcx", "data")
+		Expect(os.MkdirAll(dataRoot, 0o755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(dataRoot, "active"), []byte("keep"), 0o644)).To(Succeed())
+		manager := newBlueprintsDataManager(dataRoot)
+
+		Expect(manager.InstallBlueprintsData([]byte("not gzip"))).NotTo(Succeed())
+
+		content, err := os.ReadFile(filepath.Join(dataRoot, "active"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(content)).To(Equal("keep"))
+		Expect(manager.dospcxDataDigest).To(BeEmpty())
+	})
+
+	It("rejects an archive with an invalid gzip checksum", func() {
+		dataRoot := filepath.Join(GinkgoT().TempDir(), "doSpcx", "data")
+		archive := validBlueprintsArchive()
+		archive[len(archive)-1] ^= 0xff
+		manager := newBlueprintsDataManager(dataRoot)
+
+		Expect(manager.InstallBlueprintsData(archive)).NotTo(Succeed())
+		Expect(dataRoot).NotTo(BeADirectory())
+		Expect(manager.dospcxDataDigest).To(BeEmpty())
+	})
+
+	It("bounds decompression after the tar end marker", func() {
+		archive := validBlueprintsArchive()
+		var trailing bytes.Buffer
+		gzipWriter := gzip.NewWriter(&trailing)
+		_, err := io.CopyN(gzipWriter, zeroReader{}, maxBlueprintsDecompressedBytes+1)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(gzipWriter.Close()).To(Succeed())
+		archive = append(archive, trailing.Bytes()...)
+		Expect(len(archive)).To(BeNumerically("<", maxBlueprintsArchiveBytes))
+		manager := newBlueprintsDataManager(filepath.Join(GinkgoT().TempDir(), "data"))
+
+		Expect(manager.InstallBlueprintsData(archive)).To(
+			MatchError(ContainSubstring("decompressed size limit")))
+		Expect(manager.dospcxDataDigest).To(BeEmpty())
+	})
+
+	It("rejects paths outside the data directory without changing the active tree", func() {
+		dataRoot := filepath.Join(GinkgoT().TempDir(), "doSpcx", "data")
+		Expect(os.MkdirAll(dataRoot, 0o755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(dataRoot, "active"), []byte("keep"), 0o644)).To(Succeed())
+		archive := validBlueprintsArchive(blueprintsArchiveEntry{
+			name: "../outside", typeFlag: tar.TypeReg, mode: 0o644, content: "unsafe",
+		})
+		manager := newBlueprintsDataManager(dataRoot)
+
+		err := manager.InstallBlueprintsData(archive)
+		Expect(err).To(MatchError(ContainSubstring("unsafe path")))
+		Expect(filepath.Join(filepath.Dir(dataRoot), "outside")).NotTo(BeAnExistingFile())
+		Expect(filepath.Join(dataRoot, "active")).To(BeAnExistingFile())
+	})
+
+	It("rejects links and other non-file archive entries", func() {
+		dataRoot := filepath.Join(GinkgoT().TempDir(), "doSpcx", "data")
+		archive := validBlueprintsArchive(blueprintsArchiveEntry{
+			name: "data/link", typeFlag: tar.TypeSymlink, mode: 0o777,
+		})
+		manager := newBlueprintsDataManager(dataRoot)
+
+		Expect(manager.InstallBlueprintsData(archive)).To(MatchError(ContainSubstring("unsupported tar entry type")))
+		Expect(dataRoot).NotTo(BeADirectory())
+	})
+
+	It("rejects archives with an incomplete data layout", func() {
+		dataRoot := filepath.Join(GinkgoT().TempDir(), "doSpcx", "data")
+		archive := blueprintsArchive(
+			blueprintsArchiveEntry{name: "data/", typeFlag: tar.TypeDir, mode: 0o755},
+			blueprintsArchiveEntry{name: "data/profiles/", typeFlag: tar.TypeDir, mode: 0o755},
+		)
+		manager := newBlueprintsDataManager(dataRoot)
+
+		Expect(manager.InstallBlueprintsData(archive)).To(MatchError(ContainSubstring("missing required path")))
+		Expect(dataRoot).NotTo(BeADirectory())
+	})
+
+	It("rejects archives larger than the compressed size limit", func() {
+		manager := newBlueprintsDataManager(filepath.Join(GinkgoT().TempDir(), "data"))
+
+		Expect(manager.InstallBlueprintsData(make([]byte, maxBlueprintsArchiveBytes+1))).To(
+			MatchError(ContainSubstring("compressed size limit")))
+	})
+
+	It("requires an absolute installation path", func() {
+		manager := newBlueprintsDataManager("relative/data")
+
+		Expect(manager.InstallBlueprintsData(validBlueprintsArchive())).To(
+			MatchError(ContainSubstring("non-empty absolute path")))
+	})
+
+	It("keeps the active data and digest consistent when backup cleanup fails", func() {
+		dataRoot := filepath.Join(GinkgoT().TempDir(), "doSpcx", "data")
+		manager := newBlueprintsDataManager(dataRoot)
+		Expect(manager.InstallBlueprintsData(validBlueprintsArchive())).To(Succeed())
+		updatedArchive := validBlueprintsArchive(blueprintsArchiveEntry{
+			name: "data/new-profile-marker", typeFlag: tar.TypeReg, mode: 0o644, content: "new",
+		})
+
+		originalRemove := removeBlueprintsDataBackup
+		DeferCleanup(func() { removeBlueprintsDataBackup = originalRemove })
+		cleanupAttempted := false
+		removeBlueprintsDataBackup = func(string) error {
+			cleanupAttempted = true
+			return errors.New("injected cleanup failure")
+		}
+
+		Expect(manager.InstallBlueprintsData(updatedArchive)).To(Succeed())
+		Expect(cleanupAttempted).To(BeTrue())
+		Expect(filepath.Join(dataRoot, "new-profile-marker")).To(BeAnExistingFile())
+		Expect(manager.dospcxDataDigest).To(Equal(sha256Digest(updatedArchive)))
+	})
+
+	It("removes data installed from a ConfigMap and clears its digest", func() {
+		dataRoot := filepath.Join(GinkgoT().TempDir(), "doSpcx", "data")
+		manager := newBlueprintsDataManager(dataRoot)
+		Expect(manager.InstallBlueprintsData(validBlueprintsArchive())).To(Succeed())
+
+		Expect(manager.RemoveBlueprintsData()).To(Succeed())
+		Expect(dataRoot).NotTo(BeADirectory())
+		Expect(manager.dospcxDataDigest).To(BeEmpty())
+	})
+
+	It("keeps the active digest when removing installed data fails", func() {
+		dataRoot := filepath.Join(GinkgoT().TempDir(), "doSpcx", "data")
+		manager := newBlueprintsDataManager(dataRoot)
+		archive := validBlueprintsArchive()
+		Expect(manager.InstallBlueprintsData(archive)).To(Succeed())
+
+		originalRemove := removeBlueprintsDataDirectory
+		DeferCleanup(func() { removeBlueprintsDataDirectory = originalRemove })
+		removeBlueprintsDataDirectory = func(string) error {
+			return errors.New("injected removal failure")
+		}
+
+		Expect(manager.RemoveBlueprintsData()).To(MatchError(ContainSubstring("injected removal failure")))
+		Expect(dataRoot).To(BeADirectory())
+		Expect(manager.dospcxDataDigest).To(Equal(sha256Digest(archive)))
+	})
+
+	It("does not remove image-provided data when no ConfigMap bundle was installed", func() {
+		dataRoot := filepath.Join(GinkgoT().TempDir(), "doSpcx", "data")
+		Expect(os.MkdirAll(dataRoot, 0o755)).To(Succeed())
+		imageData := filepath.Join(dataRoot, "image-data")
+		Expect(os.WriteFile(imageData, []byte("keep"), 0o644)).To(Succeed())
+		manager := newBlueprintsDataManager(dataRoot)
+
+		Expect(manager.RemoveBlueprintsData()).To(Succeed())
+		Expect(imageData).To(BeAnExistingFile())
+		Expect(manager.dospcxDataDigest).To(BeEmpty())
+	})
+})

--- a/pkg/spectrumx/mocks/SpectrumXManager.go
+++ b/pkg/spectrumx/mocks/SpectrumXManager.go
@@ -18,6 +18,34 @@ type SpectrumXManager struct {
 	mock.Mock
 }
 
+// InstallBlueprintsData provides a mock function with given fields: archive.
+func (_m *SpectrumXManager) InstallBlueprintsData(archive []byte) error {
+	ret := _m.Called(archive)
+
+	if len(ret) == 0 {
+		panic("no return value specified for InstallBlueprintsData")
+	}
+
+	if rf, ok := ret.Get(0).(func([]byte) error); ok {
+		return rf(archive)
+	}
+	return ret.Error(0)
+}
+
+// RemoveBlueprintsData provides a mock function with no fields.
+func (_m *SpectrumXManager) RemoveBlueprintsData() error {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveBlueprintsData")
+	}
+
+	if rf, ok := ret.Get(0).(func() error); ok {
+		return rf()
+	}
+	return ret.Error(0)
+}
+
 // PreparePlan provides a mock function with given fields: ctx, devices, stage.
 func (_m *SpectrumXManager) PreparePlan(ctx context.Context, devices []*v1alpha1.NicDevice, stage spectrumx.PlanStage) error {
 	ret := _m.Called(ctx, devices, stage)

--- a/pkg/spectrumx/prepareplan.go
+++ b/pkg/spectrumx/prepareplan.go
@@ -40,6 +40,7 @@ import (
 const (
 	defaultBlueprintsRoot     = "/opt/nvidia/blueprints"
 	defaultBlueprintsStateDir = "/var/lib/blueprints"
+	defaultDospcxDataRoot     = "/opt/mellanox/doca/services/dms/doSpcx/data"
 	deploymentModeHostK8s     = "host-k8s"
 )
 
@@ -111,20 +112,21 @@ type planConfig struct {
 // planMetadata contains only the inputs used to generate a doSPCX plan.
 // Exact equality with the current inputs allows the saved plan to be reused.
 type planMetadata struct {
-	BlueprintsRoot     string   `json:"blueprints_root"`
-	BlueprintsStateDir string   `json:"blueprints_state_dir"`
-	PlanName           string   `json:"plan_name"`
-	Stage              string   `json:"stage"`
-	Profile            string   `json:"profile"`
-	PlatformType       string   `json:"platform_type"`
-	SpectrumXVersion   string   `json:"spectrum_x_version"`
-	MultiplaneMode     string   `json:"multiplane_mode"`
-	Overlay            string   `json:"overlay"`
-	Planes             int      `json:"planes"`
-	DeploymentMode     string   `json:"deployment_mode"`
-	Parameters         []string `json:"parameters"`
-	TargetMapFile      string   `json:"target_map_file"`
-	TargetMapDigest    string   `json:"target_map_digest"`
+	BlueprintsRoot       string   `json:"blueprints_root"`
+	BlueprintsStateDir   string   `json:"blueprints_state_dir"`
+	BlueprintsDataDigest string   `json:"blueprints_data_digest,omitempty"`
+	PlanName             string   `json:"plan_name"`
+	Stage                string   `json:"stage"`
+	Profile              string   `json:"profile"`
+	PlatformType         string   `json:"platform_type"`
+	SpectrumXVersion     string   `json:"spectrum_x_version"`
+	MultiplaneMode       string   `json:"multiplane_mode"`
+	Overlay              string   `json:"overlay"`
+	Planes               int      `json:"planes"`
+	DeploymentMode       string   `json:"deployment_mode"`
+	Parameters           []string `json:"parameters"`
+	TargetMapFile        string   `json:"target_map_file"`
+	TargetMapDigest      string   `json:"target_map_digest"`
 }
 
 // PreparePlan ensures that a matching node-scoped plan is cached for the
@@ -172,20 +174,21 @@ func (m *spectrumXConfigManager) PreparePlan(
 	planPath := filepath.Join(stateDir, "plans", generatedPlanName, "plan.json")
 	metadataPath := filepath.Join(filepath.Dir(planPath), "metadata.json")
 	metadata := planMetadata{
-		BlueprintsRoot:     m.blueprintsRoot,
-		BlueprintsStateDir: stateDir,
-		PlanName:           generatedPlanName,
-		Stage:              string(stage),
-		Profile:            config.profile,
-		PlatformType:       config.platformType,
-		SpectrumXVersion:   config.version,
-		MultiplaneMode:     config.multiplane,
-		Overlay:            config.overlay,
-		Planes:             config.planes,
-		DeploymentMode:     deploymentModeHostK8s,
-		Parameters:         append([]string(nil), params...),
-		TargetMapFile:      targetMapPath,
-		TargetMapDigest:    sha256Digest(targetMapContent),
+		BlueprintsRoot:       m.blueprintsRoot,
+		BlueprintsStateDir:   stateDir,
+		BlueprintsDataDigest: m.dospcxDataDigest,
+		PlanName:             generatedPlanName,
+		Stage:                string(stage),
+		Profile:              config.profile,
+		PlatformType:         config.platformType,
+		SpectrumXVersion:     config.version,
+		MultiplaneMode:       config.multiplane,
+		Overlay:              config.overlay,
+		Planes:               config.planes,
+		DeploymentMode:       deploymentModeHostK8s,
+		Parameters:           append([]string(nil), params...),
+		TargetMapFile:        targetMapPath,
+		TargetMapDigest:      sha256Digest(targetMapContent),
 	}
 	if reusable, reason := reusablePlan(planPath, metadataPath, targetMapPath, metadata, config); reusable {
 		log.FromContext(ctx).V(2).Info("reusing saved doSPCX plan",
@@ -285,20 +288,21 @@ func (m *spectrumXConfigManager) GetPreparedPlan(device *v1alpha1.NicDevice, sta
 		return nil, fmt.Errorf("decode doSPCX %s plan metadata %q: %w", stage, metadataPath, err)
 	}
 	expectedMetadata := planMetadata{
-		BlueprintsRoot:     m.blueprintsRoot,
-		BlueprintsStateDir: stateDir,
-		PlanName:           generatedPlanName,
-		Stage:              string(stage),
-		Profile:            config.profile,
-		PlatformType:       config.platformType,
-		SpectrumXVersion:   config.version,
-		MultiplaneMode:     config.multiplane,
-		Overlay:            config.overlay,
-		Planes:             config.planes,
-		DeploymentMode:     deploymentModeHostK8s,
-		Parameters:         params,
-		TargetMapFile:      targetMapPath,
-		TargetMapDigest:    metadata.TargetMapDigest,
+		BlueprintsRoot:       m.blueprintsRoot,
+		BlueprintsStateDir:   stateDir,
+		BlueprintsDataDigest: m.dospcxDataDigest,
+		PlanName:             generatedPlanName,
+		Stage:                string(stage),
+		Profile:              config.profile,
+		PlatformType:         config.platformType,
+		SpectrumXVersion:     config.version,
+		MultiplaneMode:       config.multiplane,
+		Overlay:              config.overlay,
+		Planes:               config.planes,
+		DeploymentMode:       deploymentModeHostK8s,
+		Parameters:           params,
+		TargetMapFile:        targetMapPath,
+		TargetMapDigest:      metadata.TargetMapDigest,
 	}
 	if metadata.TargetMapDigest == "" || !reflect.DeepEqual(metadata, expectedMetadata) {
 		return nil, fmt.Errorf("cached doSPCX %s plan does not match device %q inputs", stage, device.Name)

--- a/pkg/spectrumx/prepareplan_test.go
+++ b/pkg/spectrumx/prepareplan_test.go
@@ -53,6 +53,8 @@ func newTestPlanManager(
 		execInterface:      execInterface,
 		blueprintsRoot:     blueprintsRoot,
 		blueprintsStateDir: stateDir,
+		dospcxDataRoot:     filepath.Join(stateDir, "dospcx-data"),
+		dospcxDataDigest:   "",
 		ccProcesses:        nil,
 		ccTerminationChan:  nil,
 	}
@@ -426,6 +428,36 @@ var _ = Describe("doSPCX planning", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(secondPath).To(Equal(firstPath))
 		Expect(secondCommands).To(BeEmpty())
+	})
+
+	It("regenerates a saved plan when the doSPCX data bundle changes", func() {
+		stateDir := GinkgoT().TempDir()
+		device := newDevice("rail-0", "0000:64:00.0", "hwplb")
+		generatedPlanName := planName(nodeName, prepareStage)
+		firstCommands := []preparePlanCommand{}
+		manager := newTestPlanManager(
+			preparePlanFakeExecutor(
+				planResponse(generatedPlanName, "hwmp", prepareStage, 2, 1), &firstCommands,
+			), blueprintsRoot, stateDir,
+		).(*spectrumXConfigManager)
+		manager.dospcxDataDigest = "first-bundle"
+
+		Expect(manager.PreparePlan(context.Background(), []*v1alpha1.NicDevice{device}, PlanStagePrepare)).To(Succeed())
+		Expect(firstCommands).To(HaveLen(1))
+
+		secondCommands := []preparePlanCommand{}
+		manager.execInterface = preparePlanFakeExecutor(
+			planResponse(generatedPlanName, "hwmp", prepareStage, 2, 1), &secondCommands,
+		)
+		manager.dospcxDataDigest = "second-bundle"
+
+		Expect(manager.PreparePlan(context.Background(), []*v1alpha1.NicDevice{device}, PlanStagePrepare)).To(Succeed())
+		Expect(secondCommands).To(HaveLen(1))
+		metadataContent, err := os.ReadFile(filepath.Join(stateDir, "plans", generatedPlanName, "metadata.json"))
+		Expect(err).NotTo(HaveOccurred())
+		var metadata planMetadata
+		Expect(json.Unmarshal(metadataContent, &metadata)).To(Succeed())
+		Expect(metadata.BlueprintsDataDigest).To(Equal("second-bundle"))
 	})
 
 	DescribeTable("rejects a cached plan that does not match the requesting device",

--- a/pkg/spectrumx/spectrumx.go
+++ b/pkg/spectrumx/spectrumx.go
@@ -44,8 +44,15 @@ const cnpDscpExpectedValue = "48"
 // mlxregBinary is the path to the mlxreg binary. This is a var to allow substitution in tests.
 var mlxregBinary = "/usr/bin/mlxreg"
 
+// BlueprintsDataManager installs the authored data consumed by the doSPCX planner.
+type BlueprintsDataManager interface {
+	InstallBlueprintsData(archive []byte) error
+	RemoveBlueprintsData() error
+}
+
 type SpectrumXManager interface {
 	PlanManager
+	BlueprintsDataManager
 	// GetBreakoutMlxConfig returns the breakout mlxconfig map for the device based on its SpectrumX spec
 	GetBreakoutMlxConfig(device *v1alpha1.NicDevice) (map[string]string, error)
 	// GetPostBreakoutMlxConfig returns the post-breakout mlxconfig map for the device
@@ -81,6 +88,8 @@ type spectrumXConfigManager struct {
 	execInterface      execUtils.Interface
 	blueprintsRoot     string
 	blueprintsStateDir string
+	dospcxDataRoot     string
+	dospcxDataDigest   string
 
 	ccProcesses       map[string]*ccProcess
 	ccTerminationChan chan string // buffered; carries RDMA iface name on unexpected exit
@@ -854,6 +863,8 @@ func NewSpectrumXConfigManager(
 		execInterface:      execUtils.New(),
 		blueprintsRoot:     defaultBlueprintsRoot,
 		blueprintsStateDir: "",
+		dospcxDataRoot:     defaultDospcxDataRoot,
+		dospcxDataDigest:   "",
 		ccProcesses:        make(map[string]*ccProcess),
 		ccTerminationChan:  make(chan string, 10),
 	}

--- a/pkg/spectrumx/spectrumx_test.go
+++ b/pkg/spectrumx/spectrumx_test.go
@@ -171,6 +171,8 @@ var _ = Describe("SpectrumXConfigManager", func() {
 		Expect(internalManager.execInterface).NotTo(BeNil())
 		Expect(internalManager.blueprintsRoot).To(Equal(defaultBlueprintsRoot))
 		Expect(internalManager.blueprintsStateDir).To(BeEmpty())
+		Expect(internalManager.dospcxDataRoot).To(Equal(defaultDospcxDataRoot))
+		Expect(internalManager.dospcxDataDigest).To(BeEmpty())
 	})
 
 	BeforeEach(func() {
@@ -227,6 +229,8 @@ var _ = Describe("SpectrumXConfigManager", func() {
 			execInterface:      execFake,
 			blueprintsRoot:     defaultBlueprintsRoot,
 			blueprintsStateDir: "",
+			dospcxDataRoot:     defaultDospcxDataRoot,
+			dospcxDataDigest:   "",
 			ccProcesses:        map[string]*ccProcess{},
 			ccTerminationChan:  make(chan string, 10),
 		}


### PR DESCRIPTION
## Summary

- recognize the `dospcx-data.tar.gz/v1` ConfigMap format published by `dospcx-data`
- safely stage and restore the archive at `/opt/mellanox/doca/services/dms/doSpcx/data` using Go standard libraries
- reject traversal, links, special files, oversized payloads, and incomplete layouts while preserving the previous valid tree
- include the installed archive digest in flat plan metadata so data updates invalidate cached plans
- log the source commit, ref, and tree annotations supplied by the ConfigMap

## Validation

- `go test $(go list ./... | rg -v /e2e$) -count=1` with Kubernetes 1.31 envtest assets
- `go build ./...`
- `make lint`
- `git diff --check`