### PR TITLE
fix: align doSPCX planning with DMS contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,11 +223,18 @@ Spectrum-X profiles can configure NICs with multiple data planes. Available mode
 starts its existing concurrent per-device NV apply, it calls `PreparePlan` once for the node's
 Spectrum-X device group with the `prepare` stage. It does the same with the `configure` stage before
 the existing concurrent runtime apply. Plan preparation never executes generated plan operations.
-`GetPreparedPlan` parses the host-k8s `plan.semantic.groups` contract and makes the semantic plan
-available to library consumers. `BuildDMSOperationPlan` turns it into an ordered, target-resolved
-DMS operation plan, including current plus pending queries for prepare-stage NVConfig. This
-translation remains execution-free. Configure groups `eswitch` and `vf-lifecycle` are intentionally excluded from the
-current operation plan and reported as skipped; unknown groups fail closed.
+`GetPreparedPlan` parses the host-k8s `plan.semantic.groups` contract and returns its validated
+semantic source to library consumers. Plans are accepted only when `BuildDMSOperationPlan` can
+compile them into an ordered, target-resolved operation plan. That compiled form includes current
+plus pending queries for prepare-stage NVConfig and retains the planner's fanout order. This
+translation remains execution-free. Semantic group references are authoritative; public doSPCX
+operations do not need to repeat group or network-role fields, and an omitted operation kind means
+`set`, matching DMS. Configure groups `eswitch` and `vf-lifecycle` are intentionally excluded from
+the current operation plan and reported as skipped; unknown groups fail closed.
+
+NCO translates its CRD multiplane modes to the public profiles supplied by the doSPCX data bundle:
+`none` selects `single-plane`, `swplb` selects `SPX_NetPlugin`, and `hwplb` selects
+`SPX_Multiplane`.
 
 The manager creates its command executor internally and points the `dms-cli` child process at the
 Blueprints action tree fixed at `/opt/nvidia/blueprints`. The executable DMS planner remains part of
@@ -242,16 +249,19 @@ the daemon base image, while the labeled doSPCX data ConfigMap restores its auth
 /var/lib/blueprints/plans/nco-<node>-spcx-configure/metadata.json
 ```
 
-NICs are sorted by function-zero BDF and assigned deterministic target-map rail IDs. The same
-pre-breakout target map is passed to both stages; during `configure`, doSPCX resolves the
-post-breakout inventory after NVConfig is active. The planner does not read `interfaceNameTemplate`;
-interface naming remains an independent NCO capability.
+NICs are sorted by function-zero BDF and assigned deterministic target-map rail IDs. NCO writes the
+doSPCX schema-v1 target-map contract: every pre-breakout target has an ID, function-zero BDF,
+hexadecimal device ID, `ew` role, and rail. The same pre-breakout target map is passed to both
+stages; during `configure`, doSPCX resolves the post-breakout inventory after NVConfig is active.
+The planner does not read `interfaceNameTemplate`; interface naming remains an independent NCO
+capability.
 
 Each stage stores a flat metadata document containing only the planner inputs, including the
 platform, Spectrum-X settings, planner parameters, doSPCX data archive digest, and target-map
 digest. A later `PreparePlan` call reuses the saved plan when that metadata still matches, the
-target-map digest is unchanged,
-and the saved plan passes normal validation. Any input change or invalid saved artifact regenerates
+target-map digest is unchanged, the generated devices exactly match the target-map-derived BDF,
+DMS-target, device-ID, rail, plane, and role set, and the semantic operations compile under NCO's
+execution policy. Any input change or invalid saved artifact regenerates
 the plan through `dms-cli`. Before applying an individual Spectrum-X device, the configuration
 manager calls `GetPreparedPlan` and fails without changing the device if the stage-specific plan is
 missing, stale, or does not contain that device.

--- a/docs/nic-configuration-library.md
+++ b/docs/nic-configuration-library.md
@@ -412,8 +412,12 @@ dms-cli --json /nvidia/blueprints/plan profile=<profile> name=<name> \
   params=deployment_mode=host-k8s,planes=<count>
 ```
 
-For Blueprints planning, the wrapper sets `BLUEPRINTS_ROOT` and
-`BLUEPRINTS_STATE_DIR` only on the `dms-cli` child process.
+For Blueprints planning, the wrapper sets `BLUEPRINTS_ROOT` and the DMS
+`BP_STATE_DIR` variable only on the `dms-cli` child process.
+Planner stdout and stderr are captured separately because stdout is the JSON
+protocol while DMS diagnostics are written to stderr. Successful calls log the
+exact command, result status, and plan size without repeating the embedded plan;
+failure output is bounded before logging.
 `SpectrumXConfigManager` supplies the fixed `/opt/nvidia/blueprints` path and
 creates its command executor internally. The executable DMS Blueprints action
 tree remains part of the daemon image. Authored doSPCX data is supplied
@@ -426,21 +430,25 @@ plan lifecycle abstraction included by `SpectrumXManager`; it owns
 target-map construction, generation, cache validation, persistence, and
 retrieval.
 
-`PreparePlan` writes a schema-v3 target map and the returned prepare or
+`PreparePlan` writes a schema-v1 target map and the returned prepare or
 configure plan below `${BLUEPRINTS_STATE_DIR:-/var/lib/blueprints}`. Neither
-stage executes any generated operation. Target-map rails are assigned by sorting
-the participating function-zero PCI BDFs. Both stages receive the same
-pre-breakout map; the configure stage resolves post-breakout devices from the
-active hardware inventory. The NicDevice reconciler prepares one group plan
-before each existing concurrent per-device NV or runtime apply.
+stage executes any generated operation. Each pre-breakout target contains a
+deterministic ID, function-zero BDF, hexadecimal device ID, `ew` role, and rail.
+Target-map rails are assigned by sorting the participating function-zero PCI
+BDFs. Both stages receive the same pre-breakout map; the configure stage resolves
+post-breakout devices from the active hardware inventory. NCO maps `none` to the
+`single-plane` profile, `swplb` to `SPX_NetPlugin`, and `hwplb` to
+`SPX_Multiplane`. The NicDevice reconciler prepares one group plan before each
+existing concurrent per-device NV or runtime apply.
 `interfaceNameTemplate` is not an input to doSPCX planning.
 
 Each plan directory also contains `metadata.json`, a flat document with only the
 inputs used for that stage, the installed doSPCX data archive digest, and the
 target-map digest. A later `PreparePlan` call reuses the saved plan when the
 metadata exactly matches the current inputs, the
-target-map file still has the recorded digest, and the plan passes the same
-structural validation as a newly generated plan. Missing, malformed, or changed
+target-map file still has the recorded digest, the generated devices exactly
+match the target-map-derived topology, and the plan passes the same structural
+and execution-policy compilation as a newly generated plan. Missing, malformed, or changed
 cache artifacts cause normal regeneration through `dms-cli`. Individual
 Spectrum-X apply calls use `GetPreparedPlan` to require matching inputs and
 device membership before touching hardware.
@@ -499,18 +507,27 @@ image is not removed when no ConfigMap bundle was installed.
 `PreparePlan` generates or reuses the stage-specific plan for the supplied
 Spectrum-X device group. It is a no-op when none of the supplied devices enable
 Spectrum-X. `GetPreparedPlan` retrieves the persisted plan without invoking
-`dms-cli`, and rejects it unless its cached inputs and target map still match the
-supplied device. It also parses the host-k8s `plan.semantic.groups` surface and
-resolves every `operation_ref` through `plan.operations`. The parser preserves
-group and operation ordering, including repeated writes, and does not inspect
-bare-metal steps, services, or artifacts.
+`dms-cli`, and rejects it unless its cached inputs, exact generated device
+topology, and target map still match the supplied device. It also parses the
+host-k8s `plan.semantic.groups` surface and resolves every `operation_ref`
+through `plan.operations`. A generated or cached plan is accepted only when
+`BuildDMSOperationPlan` can compile its execution policy and targets. The parser
+preserves group and operation ordering, including repeated writes, and does not
+inspect bare-metal steps, services, or artifacts.
 
 `SemanticPlan.BuildDMSOperationPlan(ctx)` resolves `pf_netdev_all` and
 `pf_rdma_scope` to target-specific query and SET batches without executing
 them. Queries represent the final desired state; prepare-stage queries include
 both the current and `-pending` leaves used by the doSPCX NVConfig gate. SET
-operations preserve the complete transition sequence. `post-breakout` remains
-an ordered phase marker. Configure groups `eswitch` and `vf-lifecycle` are parsed and validated
+operations preserve the complete transition sequence. Public operations may
+omit `kind` (`set` is the DMS default), `execution_group`, and `target_role`;
+group membership comes from `semantic.groups[].operation_refs`, and operations
+without a role apply to all plan devices. For `pf_rdma_scope`, `per_pf` selects
+devices with an RDMA endpoint and `per_rail_bond` selects each rail's plane-zero
+PF, matching DMS lifecycle targeting. Compiled groups retain `fanout_order`, and
+eSwitch or per-VF operations are rejected if they appear under an executable
+group instead of an explicitly skipped group. `post-breakout` remains an ordered phase
+marker. Configure groups `eswitch` and `vf-lifecycle` are parsed and validated
 but explicitly reported as skipped; unknown groups fail closed. The existing
 Spectrum-X manager implementation provides both plan lifecycle methods and
 creates the command executor internally:
@@ -949,7 +966,10 @@ Methods support two modes via option structs:
 
 ### Command Execution Logging
 
-All external commands use `cmd.CombinedOutput()` (not `cmd.Output()`) and log unconditionally at `log.Log.V(2)`. Output is not duplicated in error-level logs.
+External commands normally use `cmd.CombinedOutput()` and log at `log.Log.V(2)`.
+JSON protocol commands that can emit DMS diagnostics on stderr, such as
+Blueprint plan generation, capture the streams separately and parse stdout
+only. Output is not duplicated in error-level logs.
 
 ### Batch Operations
 

--- a/pkg/dmscli/blueprints.go
+++ b/pkg/dmscli/blueprints.go
@@ -28,7 +28,10 @@ import (
 	execUtils "k8s.io/utils/exec"
 )
 
-const blueprintsPlanPath = "/nvidia/blueprints/plan"
+const (
+	blueprintsPlanPath       = "/nvidia/blueprints/plan"
+	maxBlueprintLogOutputLen = 4096
+)
 
 // BlueprintPlanRequest describes one DMS Blueprints planning action.
 type BlueprintPlanRequest struct {
@@ -44,16 +47,9 @@ type BlueprintPlanRequest struct {
 // BlueprintPlanResult is the normalized result of /nvidia/blueprints/plan.
 // PlanJSON contains the complete JSON document returned in the plan-json field.
 type BlueprintPlanResult struct {
-	Status             string
-	PlanName           string
-	Family             string
-	Profile            string
-	Stage              string
-	Devices            int
-	Operations         int
-	SemanticGroupCount int
-	PlanJSON           json.RawMessage
-	ErrorMessage       string
+	Status       string
+	PlanJSON     json.RawMessage
+	ErrorMessage string
 }
 
 // GenerateBlueprintPlan invokes the agentless DMS Blueprints planner.
@@ -87,22 +83,23 @@ func GenerateBlueprintPlan(
 
 	command := execInterface.CommandContext(ctx, dmsCLIExecutable, args...)
 	environment := environmentWithOverride(os.Environ(), "BLUEPRINTS_ROOT", request.BlueprintsRoot)
-	environment = environmentWithOverride(environment, "BLUEPRINTS_STATE_DIR", request.BlueprintsStateDir)
+	environment = environmentWithOverride(environment, "BP_STATE_DIR", request.BlueprintsStateDir)
 	command.SetEnv(environment)
-	output, commandErr := command.CombinedOutput()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	command.SetStdout(&stdout)
+	command.SetStderr(&stderr)
+	commandErr := command.Run()
 	commandAndArgs := append([]string{dmsCLIExecutable}, args...)
-	logr.FromContextOrDiscard(ctx).V(2).Info("command output",
-		"command", commandAndArgs,
-		"plan", request.Name,
-		"blueprintsRoot", request.BlueprintsRoot,
-		"blueprintsStateDir", request.BlueprintsStateDir,
-		"output", string(output))
 
-	result, decodeErr := decodeBlueprintPlanResult(output)
+	result, decodeErr := decodeBlueprintPlanResult(stdout.Bytes())
+	logBlueprintPlanResult(ctx, request, commandAndArgs, result, stdout.String(), stderr.String(), commandErr, decodeErr)
 	if commandErr != nil {
-		detail := strings.TrimSpace(string(output))
+		detail := strings.TrimSpace(stderr.String())
 		if result != nil && result.ErrorMessage != "" {
 			detail = result.ErrorMessage
+		} else if detail == "" {
+			detail = strings.TrimSpace(stdout.String())
 		}
 		if detail != "" {
 			return result, fmt.Errorf("generate Blueprint plan %q: %w: %s", request.Name, commandErr, detail)
@@ -119,11 +116,44 @@ func GenerateBlueprintPlan(
 		}
 		return result, fmt.Errorf("generate Blueprint plan %q: %s", request.Name, detail)
 	}
-	if result.PlanName != "" && result.PlanName != request.Name {
-		return result, fmt.Errorf("generate Blueprint plan %q: response contains plan %q", request.Name, result.PlanName)
-	}
-
 	return result, nil
+}
+
+func logBlueprintPlanResult(
+	ctx context.Context,
+	request BlueprintPlanRequest,
+	command []string,
+	result *BlueprintPlanResult,
+	stdout string,
+	stderr string,
+	commandErr error,
+	decodeErr error,
+) {
+	fields := []any{
+		"command", command,
+		"plan", request.Name,
+		"blueprintsRoot", request.BlueprintsRoot,
+		"blueprintsStateDir", request.BlueprintsStateDir,
+	}
+	if result != nil {
+		fields = append(fields,
+			"status", result.Status,
+			"planJSONBytes", len(result.PlanJSON))
+	}
+	if commandErr != nil || decodeErr != nil {
+		fields = append(fields, "stdout", boundedBlueprintLogOutput(stdout))
+	}
+	if stderr != "" {
+		fields = append(fields, "stderr", boundedBlueprintLogOutput(stderr))
+	}
+	logr.FromContextOrDiscard(ctx).V(2).Info("command output", fields...)
+}
+
+func boundedBlueprintLogOutput(output string) string {
+	if len(output) <= maxBlueprintLogOutputLen {
+		return output
+	}
+	return output[:maxBlueprintLogOutputLen] + "... [truncated]"
 }
 
 func validateBlueprintPlanRequest(request BlueprintPlanRequest) error {
@@ -180,32 +210,18 @@ func decodeBlueprintPlanResult(output []byte) (*BlueprintPlanResult, error) {
 	}
 
 	var response struct {
-		Status             string          `json:"status"`
-		PlanName           string          `json:"plan"`
-		Family             string          `json:"family"`
-		Profile            string          `json:"profile"`
-		Stage              string          `json:"stage"`
-		Devices            int             `json:"devices"`
-		Operations         int             `json:"operations"`
-		SemanticGroupCount int             `json:"semantic_group_count"`
-		PlanJSON           json.RawMessage `json:"plan-json"`
-		Error              string          `json:"error"`
-		ErrorMessage       string          `json:"error_msg"`
+		Status       string          `json:"status"`
+		PlanJSON     json.RawMessage `json:"plan-json"`
+		Error        string          `json:"error"`
+		ErrorMessage string          `json:"error_msg"`
 	}
 	if err := json.Unmarshal(output, &response); err != nil {
 		return nil, fmt.Errorf("invalid dms-cli JSON response: %w", err)
 	}
 
 	result := &BlueprintPlanResult{
-		Status:             response.Status,
-		PlanName:           response.PlanName,
-		Family:             response.Family,
-		Profile:            response.Profile,
-		Stage:              response.Stage,
-		Devices:            response.Devices,
-		Operations:         response.Operations,
-		SemanticGroupCount: response.SemanticGroupCount,
-		ErrorMessage:       response.ErrorMessage,
+		Status:       response.Status,
+		ErrorMessage: response.ErrorMessage,
 	}
 	if result.ErrorMessage == "" {
 		result.ErrorMessage = response.Error

--- a/pkg/dmscli/blueprints_test.go
+++ b/pkg/dmscli/blueprints_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -38,7 +39,7 @@ var _ = Describe("Blueprint plan", func() {
 		return BlueprintPlanRequest{
 			BlueprintsRoot:     blueprintsRoot,
 			BlueprintsStateDir: blueprintsStateDir,
-			Profile:            "hwmp",
+			Profile:            "SPX_Multiplane",
 			Name:               planName,
 			Stage:              "prepare",
 			TargetMapFile:      "/var/lib/blueprints/target-maps/nco-node-1.json",
@@ -48,26 +49,14 @@ var _ = Describe("Blueprint plan", func() {
 
 	It("generates a prepare plan through the agentless action", func() {
 		executor := fakeExecutor([]byte(`{
-			"plan":"nco-node-1-spcx-prepare",
-			"family":"spcx",
-			"profile":"hwmp",
-			"stage":"prepare",
-			"devices":2,
-			"operations":5,
-			"semantic_group_count":2,
+			"status":"ok",
 			"plan-json":{"plan":{"name":"nco-node-1-spcx-prepare","stage":"prepare"},"artifacts":{"manifest":[]}}
 		}`), nil, &commands)
 
 		result, err := GenerateBlueprintPlan(context.Background(), executor, newRequest())
 
 		Expect(err).NotTo(HaveOccurred())
-		Expect(result.PlanName).To(Equal(planName))
-		Expect(result.Family).To(Equal("spcx"))
-		Expect(result.Profile).To(Equal("hwmp"))
-		Expect(result.Stage).To(Equal("prepare"))
-		Expect(result.Devices).To(Equal(2))
-		Expect(result.Operations).To(Equal(5))
-		Expect(result.SemanticGroupCount).To(Equal(2))
+		Expect(result.Status).To(Equal("ok"))
 		Expect(json.Valid(result.PlanJSON)).To(BeTrue())
 
 		Expect(commands).To(HaveLen(1))
@@ -75,14 +64,16 @@ var _ = Describe("Blueprint plan", func() {
 		Expect(commands[0].args).To(Equal([]string{
 			"--json",
 			blueprintsPlanPath,
-			"profile=hwmp",
+			"profile=SPX_Multiplane",
 			"name=" + planName,
 			"stage=prepare",
 			"target-map-file=file:/var/lib/blueprints/target-maps/nco-node-1.json",
 			"params=deployment_mode=host-k8s,planes=2",
 		}))
+		Expect(commands[0].command.RunCalls).To(Equal(1))
+		Expect(commands[0].command.CombinedOutputCalls).To(BeZero())
 		Expect(commands[0].command.Env).To(ContainElement("BLUEPRINTS_ROOT=" + blueprintsRoot))
-		Expect(commands[0].command.Env).To(ContainElement("BLUEPRINTS_STATE_DIR=" + blueprintsStateDir))
+		Expect(commands[0].command.Env).To(ContainElement("BP_STATE_DIR=" + blueprintsStateDir))
 	})
 
 	It("accepts the YANG string encoding of plan-json", func() {
@@ -98,12 +89,26 @@ var _ = Describe("Blueprint plan", func() {
 		Expect(string(result.PlanJSON)).To(Equal(`{"plan":{"name":"nco-node-1-spcx-prepare","stage":"prepare"}}`))
 	})
 
-	It("logs the exact command and combined output", func() {
-		executor := fakeExecutor([]byte(`{"plan":"nco-node-1-spcx-prepare","plan-json":{"plan":{"name":"nco-node-1-spcx-prepare"}}}`), nil, &commands)
+	It("decodes JSON stdout independently from DMS diagnostics on stderr", func() {
+		stdout := []byte(`{"status":"ok","plan":"nco-node-1-spcx-prepare","plan-json":{"plan":{"name":"nco-node-1-spcx-prepare"}}}`)
+		stderr := []byte("[2026-09-07 11:10:40][DOCA][WRN] Ignoring unknown batch_op 'GET-CAPS'\n")
+		executor := fakeExecutorWithStderr(stdout, stderr, nil, &commands)
+
+		result, err := GenerateBlueprintPlan(context.Background(), executor, newRequest())
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Status).To(Equal("ok"))
+		Expect(json.Valid(result.PlanJSON)).To(BeTrue())
+	})
+
+	It("logs the exact command, structured result, and stderr without the full plan JSON", func() {
+		stdout := []byte(`{"status":"ok","plan-json":{"plan":{"name":"nco-node-1-spcx-prepare"}},"error":""}`)
+		stderr := []byte("DMS diagnostic\n")
+		executor := fakeExecutorWithStderr(stdout, stderr, nil, &commands)
 		entries := []capturedLogEntry{}
 		ctx := logr.NewContext(context.Background(), logr.New(&capturingLogSink{entries: &entries}))
 
-		_, err := GenerateBlueprintPlan(ctx, executor, newRequest())
+		result, err := GenerateBlueprintPlan(ctx, executor, newRequest())
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(entries).To(HaveLen(1))
@@ -112,7 +117,24 @@ var _ = Describe("Blueprint plan", func() {
 		Expect(entries[0].fields).To(HaveKeyWithValue("plan", planName))
 		Expect(entries[0].fields).To(HaveKeyWithValue("blueprintsRoot", blueprintsRoot))
 		Expect(entries[0].fields).To(HaveKeyWithValue("blueprintsStateDir", blueprintsStateDir))
-		Expect(entries[0].fields["output"]).To(ContainSubstring(`"plan-json"`))
+		Expect(entries[0].fields).NotTo(HaveKey("stdout"))
+		Expect(entries[0].fields).To(HaveKeyWithValue("status", "ok"))
+		Expect(entries[0].fields).To(HaveKeyWithValue("planJSONBytes", len(result.PlanJSON)))
+		Expect(entries[0].fields).To(HaveKeyWithValue("stderr", string(stderr)))
+	})
+
+	It("bounds malformed stdout in diagnostics", func() {
+		stdout := []byte("not-json-" + strings.Repeat("x", maxBlueprintLogOutputLen))
+		executor := fakeExecutor(stdout, nil, &commands)
+		entries := []capturedLogEntry{}
+		ctx := logr.NewContext(context.Background(), logr.New(&capturingLogSink{entries: &entries}))
+
+		_, err := GenerateBlueprintPlan(ctx, executor, newRequest())
+
+		Expect(err).To(HaveOccurred())
+		Expect(entries).To(HaveLen(1))
+		Expect(entries[0].fields["stdout"]).To(HaveLen(maxBlueprintLogOutputLen + len("... [truncated]")))
+		Expect(entries[0].fields["stdout"]).To(HaveSuffix("... [truncated]"))
 	})
 
 	It("returns the structured planner error", func() {
@@ -172,15 +194,6 @@ var _ = Describe("Blueprint plan", func() {
 		Expect(err).To(MatchError(ContainSubstring("does not contain plan-json")))
 	})
 
-	It("rejects a response for a different plan", func() {
-		executor := fakeExecutor([]byte(`{"plan":"other-plan","plan-json":{"plan":{"name":"other-plan"}}}`), nil, &commands)
-
-		result, err := GenerateBlueprintPlan(context.Background(), executor, newRequest())
-
-		Expect(result).NotTo(BeNil())
-		Expect(err).To(MatchError(ContainSubstring(`response contains plan "other-plan"`)))
-	})
-
 	It("replaces an inherited Blueprints root without duplicating it", func() {
 		environment := environmentWithOverride([]string{
 			"PATH=/usr/bin",
@@ -192,6 +205,20 @@ var _ = Describe("Blueprint plan", func() {
 			"PATH=/usr/bin",
 			"HOME=/tmp/test-home",
 			"BLUEPRINTS_ROOT=" + blueprintsRoot,
+		}))
+	})
+
+	It("replaces an inherited DMS state directory without duplicating it", func() {
+		environment := environmentWithOverride([]string{
+			"PATH=/usr/bin",
+			"BP_STATE_DIR=/old/blueprints-state",
+			"HOME=/tmp/test-home",
+		}, "BP_STATE_DIR", blueprintsStateDir)
+
+		Expect(environment).To(Equal([]string{
+			"PATH=/usr/bin",
+			"HOME=/tmp/test-home",
+			"BP_STATE_DIR=" + blueprintsStateDir,
 		}))
 	})
 })

--- a/pkg/dmscli/nvconfig_test.go
+++ b/pkg/dmscli/nvconfig_test.go
@@ -79,9 +79,16 @@ func (s *capturingLogSink) WithName(name string) logr.LogSink {
 }
 
 func fakeExecutor(output []byte, commandErr error, commands *[]recordedCommand) *execTesting.FakeExec {
+	return fakeExecutorWithStderr(output, nil, commandErr, commands)
+}
+
+func fakeExecutorWithStderr(stdout, stderr []byte, commandErr error, commands *[]recordedCommand) *execTesting.FakeExec {
 	command := &execTesting.FakeCmd{}
 	command.CombinedOutputScript = append(command.CombinedOutputScript, func() ([]byte, []byte, error) {
-		return output, nil, commandErr
+		return stdout, stderr, commandErr
+	})
+	command.RunScript = append(command.RunScript, func() ([]byte, []byte, error) {
+		return stdout, stderr, commandErr
 	})
 
 	executor := &execTesting.FakeExec{}

--- a/pkg/spectrumx/blueprintsdata.go
+++ b/pkg/spectrumx/blueprintsdata.go
@@ -166,14 +166,14 @@ func extractBlueprintsDataArchive(archive []byte, destination string) error {
 		if entries > maxBlueprintsArchiveFiles {
 			return fmt.Errorf("archive exceeds the %d-entry limit", maxBlueprintsArchiveFiles)
 		}
+		// git archive adds a global PAX header containing the source commit before the
+		// archived files. It is metadata only and must not be treated as a filesystem path.
+		if header.Typeflag == tar.TypeXGlobalHeader {
+			continue
+		}
 		archivePath, pathErr := cleanBlueprintsArchivePath(header.Name)
 		if pathErr != nil {
 			return pathErr
-		}
-		// Keep this guard adjacent to the rooted file operations. cleanBlueprintsArchivePath
-		// already rejects traversal, and os.Root independently prevents escaping destination.
-		if strings.Contains(archivePath, "..") {
-			return fmt.Errorf("archive contains unsafe path %q", header.Name)
 		}
 		if _, exists := seen[archivePath]; exists {
 			return fmt.Errorf("archive contains duplicate path %q", header.Name)

--- a/pkg/spectrumx/blueprintsdata_test.go
+++ b/pkg/spectrumx/blueprintsdata_test.go
@@ -29,10 +29,11 @@ import (
 )
 
 type blueprintsArchiveEntry struct {
-	name     string
-	typeFlag byte
-	mode     int64
-	content  string
+	name       string
+	typeFlag   byte
+	mode       int64
+	content    string
+	paxRecords map[string]string
 }
 
 type zeroReader struct{}
@@ -48,10 +49,11 @@ func blueprintsArchive(entries ...blueprintsArchiveEntry) []byte {
 	tarWriter := tar.NewWriter(gzipWriter)
 	for _, entry := range entries {
 		header := &tar.Header{
-			Name:     entry.name,
-			Typeflag: entry.typeFlag,
-			Mode:     entry.mode,
-			Size:     int64(len(entry.content)),
+			Name:       entry.name,
+			Typeflag:   entry.typeFlag,
+			Mode:       entry.mode,
+			Size:       int64(len(entry.content)),
+			PAXRecords: entry.paxRecords,
 		}
 		Expect(tarWriter.WriteHeader(header)).To(Succeed())
 		if entry.content != "" {
@@ -114,6 +116,19 @@ var _ = Describe("doSPCX data archive installation", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(info.Mode().Perm()).To(Equal(os.FileMode(0o755)))
 		Expect(manager.dospcxDataDigest).To(Equal(sha256Digest(archive)))
+	})
+
+	It("accepts the global PAX metadata emitted by git archive", func() {
+		dataRoot := filepath.Join(GinkgoT().TempDir(), "doSpcx", "data")
+		archive := validBlueprintsArchive(blueprintsArchiveEntry{
+			name:       "pax_global_header",
+			typeFlag:   tar.TypeXGlobalHeader,
+			paxRecords: map[string]string{"comment": "3656b4dff0ec9f9b6a00e049a7804eb7a64da671"},
+		})
+		manager := newBlueprintsDataManager(dataRoot)
+
+		Expect(manager.InstallBlueprintsData(archive)).To(Succeed())
+		Expect(filepath.Join(dataRoot, "platform-types.yaml")).To(BeAnExistingFile())
 	})
 
 	It("keeps the active tree when the archive is malformed", func() {

--- a/pkg/spectrumx/prepareplan.go
+++ b/pkg/spectrumx/prepareplan.go
@@ -42,6 +42,12 @@ const (
 	defaultBlueprintsStateDir = "/var/lib/blueprints"
 	defaultDospcxDataRoot     = "/opt/mellanox/doca/services/dms/doSpcx/data"
 	deploymentModeHostK8s     = "host-k8s"
+	targetMapSchemaVersion    = 1
+	targetRoleEW              = "ew"
+	dospcxProfileSinglePlane  = "single-plane"
+	dospcxProfileNetPlugin    = "SPX_NetPlugin"
+	dospcxProfileMultiplane   = "SPX_Multiplane"
+	defaultDospcxPlatformType = "gb300"
 )
 
 // PlanStage identifies the doSPCX configuration phase represented by a plan.
@@ -72,20 +78,9 @@ type PlanManager interface {
 var canonicalFunctionZeroBDF = regexp.MustCompile(`^[0-9a-f]{4}:[0-9a-f]{2}:([0-9a-f]{2})\.0$`)
 
 type targetMap struct {
-	SchemaVersion     int                         `json:"schema_version"`
-	PlatformType      string                      `json:"platform_type"`
-	DefaultRole       string                      `json:"default_role"`
-	TargetConstraints map[string]targetConstraint `json:"target_constraints"`
-	PreBreakout       targetMapTarget             `json:"pre_breakout"`
-}
-
-type targetTopology struct {
-	PortsPerTarget int `json:"ports_per_target"`
-}
-
-type targetConstraint struct {
-	HCATypes []string       `json:"hca_types"`
-	Topology targetTopology `json:"topology"`
+	SchemaVersion int             `json:"schema_version"`
+	PlatformType  string          `json:"platform_type"`
+	PreBreakout   targetMapTarget `json:"pre_breakout"`
 }
 
 type targetMapTarget struct {
@@ -93,8 +88,11 @@ type targetMapTarget struct {
 }
 
 type preBreakoutTarget struct {
-	BDF  string `json:"bdf"`
-	Rail int    `json:"rail"`
+	ID       string `json:"id"`
+	BDF      string `json:"bdf"`
+	DeviceID string `json:"device_id"`
+	Role     string `json:"role"`
+	Rail     int    `json:"rail"`
 }
 
 type planConfig struct {
@@ -360,9 +358,9 @@ func planParameters(config *planConfig) ([]string, error) {
 	if config.overlay == "" {
 		return params, nil
 	}
-	if config.profile == "hwmp" {
+	if config.profile == dospcxProfileMultiplane {
 		if config.overlay != consts.OverlayNone {
-			return nil, fmt.Errorf("doSPCX profile hwmp does not support overlay %q", config.overlay)
+			return nil, fmt.Errorf("doSPCX profile %s does not support overlay %q", config.profile, config.overlay)
 		}
 		return params, nil
 	}
@@ -370,31 +368,25 @@ func planParameters(config *planConfig) ([]string, error) {
 }
 
 func validateDeviceInTargetMap(config *planConfig, saved targetMap) error {
-	if saved.SchemaVersion != 3 || saved.PlatformType != config.platformType || saved.DefaultRole != "ew" {
+	if saved.SchemaVersion != targetMapSchemaVersion || saved.PlatformType != config.platformType {
 		return fmt.Errorf("target map identity changed")
 	}
-	constraint, found := saved.TargetConstraints[saved.DefaultRole]
-	if !found || constraint.Topology.PortsPerTarget != 1 {
-		return fmt.Errorf("target map constraint changed")
-	}
-	expectedHCA := config.targetMap.TargetConstraints[config.targetMap.DefaultRole].HCATypes[0]
-	hcaFound := false
-	for _, hcaType := range constraint.HCATypes {
-		if hcaType == expectedHCA {
-			hcaFound = true
-			break
-		}
-	}
-	if !hcaFound {
-		return fmt.Errorf("HCA type %q is absent from the target map", expectedHCA)
-	}
-	expectedBDF := config.targetMap.PreBreakout.Targets[0].BDF
+	expectedTarget := config.targetMap.PreBreakout.Targets[0]
 	for _, target := range saved.PreBreakout.Targets {
-		if target.BDF == expectedBDF {
+		if target.BDF == expectedTarget.BDF {
+			if strings.TrimSpace(target.ID) == "" {
+				return fmt.Errorf("BDF %q has no target ID", expectedTarget.BDF)
+			}
+			if target.DeviceID != expectedTarget.DeviceID {
+				return fmt.Errorf("BDF %q device ID is %q, expected %q", expectedTarget.BDF, target.DeviceID, expectedTarget.DeviceID)
+			}
+			if target.Role != targetRoleEW {
+				return fmt.Errorf("BDF %q role is %q, expected %q", expectedTarget.BDF, target.Role, targetRoleEW)
+			}
 			return nil
 		}
 	}
-	return fmt.Errorf("BDF %q is absent from the target map", expectedBDF)
+	return fmt.Errorf("BDF %q is absent from the target map", expectedTarget.BDF)
 }
 
 func (m *spectrumXConfigManager) resolvedStateDir() string {
@@ -486,9 +478,13 @@ func buildPlanConfig(devices []*v1alpha1.NicDevice) (*planConfig, error) {
 	if planes == 0 {
 		planes = 1
 	}
+	platformType := strings.TrimSpace(firstSpec.PlatformType)
+	if platformType == "" {
+		platformType = defaultDospcxPlatformType
+	}
 	config := &planConfig{
 		nodeName:      nodeName,
-		platformType:  firstSpec.PlatformType,
+		platformType:  platformType,
 		profile:       profile,
 		version:       firstSpec.Version,
 		multiplane:    normalizedMultiplaneMode(firstSpec.MultiplaneMode),
@@ -496,25 +492,17 @@ func buildPlanConfig(devices []*v1alpha1.NicDevice) (*planConfig, error) {
 		planes:        planes,
 		selectedCount: len(selected),
 		targetMap: targetMap{
-			SchemaVersion: 3,
-			PlatformType:  firstSpec.PlatformType,
-			DefaultRole:   "ew",
-			TargetConstraints: map[string]targetConstraint{
-				"ew": {Topology: targetTopology{PortsPerTarget: 1}},
-			},
-			PreBreakout: targetMapTarget{Targets: make([]preBreakoutTarget, 0, len(selected))},
+			SchemaVersion: targetMapSchemaVersion,
+			PlatformType:  platformType,
+			PreBreakout:   targetMapTarget{Targets: make([]preBreakoutTarget, 0, len(selected))},
 		},
 	}
-	if strings.TrimSpace(config.platformType) == "" {
-		return nil, fmt.Errorf("Spectrum-X platformType must not be empty")
-	}
-
 	type orderedDevice struct {
-		bdf string
+		bdf      string
+		deviceID string
 	}
 	ordered := make([]orderedDevice, 0, len(selected))
 	seenBDFs := map[string]string{}
-	hcaTypes := map[string]struct{}{}
 	for _, device := range selected {
 		if strings.TrimSpace(device.Status.Node) != config.nodeName {
 			return nil, fmt.Errorf("Spectrum-X devices in one plan must belong to the same node; device %q belongs to %q", device.Name, device.Status.Node)
@@ -528,7 +516,11 @@ func buildPlanConfig(devices []*v1alpha1.NicDevice) (*planConfig, error) {
 		if devicePlanes == 0 {
 			devicePlanes = 1
 		}
-		if spec.PlatformType != config.platformType ||
+		devicePlatformType := strings.TrimSpace(spec.PlatformType)
+		if devicePlatformType == "" {
+			devicePlatformType = defaultDospcxPlatformType
+		}
+		if devicePlatformType != config.platformType ||
 			deviceProfile != config.profile ||
 			spec.Version != config.version ||
 			normalizedMultiplaneMode(spec.MultiplaneMode) != config.multiplane ||
@@ -539,11 +531,10 @@ func buildPlanConfig(devices []*v1alpha1.NicDevice) (*planConfig, error) {
 		if len(device.Status.Ports) == 0 {
 			return nil, fmt.Errorf("device %q has no discovered PCI ports", device.Name)
 		}
-		hcaType, hcaTypeErr := blueprintHCAType(device.Status.Type)
-		if hcaTypeErr != nil {
-			return nil, fmt.Errorf("device %q: %w", device.Name, hcaTypeErr)
+		deviceID, deviceIDErr := blueprintDeviceID(device.Status.Type)
+		if deviceIDErr != nil {
+			return nil, fmt.Errorf("device %q: %w", device.Name, deviceIDErr)
 		}
-		hcaTypes[hcaType] = struct{}{}
 		bdf := strings.ToLower(strings.TrimSpace(device.Status.Ports[0].PCI))
 		if !isCanonicalFunctionZeroBDF(bdf) {
 			return nil, fmt.Errorf("device %q first PCI port %q is not a canonical function-zero BDF", device.Name, device.Status.Ports[0].PCI)
@@ -552,24 +543,19 @@ func buildPlanConfig(devices []*v1alpha1.NicDevice) (*planConfig, error) {
 			return nil, fmt.Errorf("devices %q and %q resolve to the same pre-breakout BDF %q", otherDevice, device.Name, bdf)
 		}
 		seenBDFs[bdf] = device.Name
-		ordered = append(ordered, orderedDevice{bdf: bdf})
+		ordered = append(ordered, orderedDevice{bdf: bdf, deviceID: deviceID})
 	}
-	orderedHCATypes := make([]string, 0, len(hcaTypes))
-	for hcaType := range hcaTypes {
-		orderedHCATypes = append(orderedHCATypes, hcaType)
-	}
-	sort.Strings(orderedHCATypes)
-	ewConstraint := config.targetMap.TargetConstraints[config.targetMap.DefaultRole]
-	ewConstraint.HCATypes = orderedHCATypes
-	config.targetMap.TargetConstraints[config.targetMap.DefaultRole] = ewConstraint
 
 	sort.Slice(ordered, func(i, j int) bool {
 		return ordered[i].bdf < ordered[j].bdf
 	})
 	for rail, item := range ordered {
 		config.targetMap.PreBreakout.Targets = append(config.targetMap.PreBreakout.Targets, preBreakoutTarget{
-			BDF:  item.bdf,
-			Rail: rail,
+			ID:       fmt.Sprintf("ew-rail%d-prebreakout", rail),
+			BDF:      item.bdf,
+			DeviceID: item.deviceID,
+			Role:     targetRoleEW,
+			Rail:     rail,
 		})
 	}
 
@@ -603,26 +589,21 @@ func normalizedMultiplaneMode(mode string) string {
 func blueprintProfile(mode string) (string, error) {
 	switch normalizedMultiplaneMode(mode) {
 	case consts.MultiplaneModeNone:
-		return "single-plane", nil
+		return dospcxProfileSinglePlane, nil
 	case consts.MultiplaneModeSwplb:
-		return "swmp", nil
+		return dospcxProfileNetPlugin, nil
 	case consts.MultiplaneModeHwplb:
-		return "hwmp", nil
+		return dospcxProfileMultiplane, nil
 	default:
 		return "", fmt.Errorf("unsupported Spectrum-X multiplaneMode %q", mode)
 	}
 }
 
-func blueprintHCAType(deviceType string) (string, error) {
-	switch strings.ToLower(strings.TrimSpace(deviceType)) {
-	case "1021":
-		return "ConnectX-7", nil
-	case "1023":
-		return "ConnectX-8", nil
-	case "1025":
-		return "ConnectX-9", nil
-	case consts.BlueField3DeviceID:
-		return "BlueField-3", nil
+func blueprintDeviceID(deviceType string) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(deviceType))
+	switch normalized {
+	case "1021", "1023", "1025", consts.BlueField3DeviceID:
+		return "0x" + normalized, nil
 	default:
 		return "", fmt.Errorf("unsupported device type %q for doSPCX target mapping", deviceType)
 	}
@@ -669,7 +650,7 @@ func validateGeneratedPlan(
 			DetectedHW struct {
 				PlatformType string `json:"platform_type"`
 			} `json:"detected_hw"`
-			Devices  []json.RawMessage `json:"devices"`
+			Devices  []PlanDevice `json:"devices"`
 			Semantic *struct {
 				Groups []json.RawMessage `json:"groups"`
 			} `json:"semantic"`
@@ -714,18 +695,65 @@ func validateGeneratedPlan(
 	if len(document.Artifacts.Manifest) > 0 {
 		return nil, fmt.Errorf("generated doSPCX %s plan unexpectedly contains rendered artifacts", expectedStage)
 	}
-	expectedDeviceCount := config.selectedCount
-	if expectedStage == string(PlanStageConfigure) {
-		expectedDeviceCount *= config.planes
-	}
-	if len(document.Plan.Devices) != expectedDeviceCount {
-		return nil, fmt.Errorf("generated doSPCX %s plan has %d devices, expected %d", expectedStage, len(document.Plan.Devices), expectedDeviceCount)
+	if err := validateGeneratedPlanDevices(document.Plan.Devices, config, PlanStage(expectedStage)); err != nil {
+		return nil, err
 	}
 	semanticPlan, err := ParseSemanticPlan(planJSON, PlanStage(expectedStage))
 	if err != nil {
 		return nil, fmt.Errorf("validate generated doSPCX %s semantic plan: %w", expectedStage, err)
 	}
+	if _, err := semanticPlan.BuildDMSOperationPlan(context.Background()); err != nil {
+		return nil, fmt.Errorf("compile generated doSPCX %s semantic plan: %w", expectedStage, err)
+	}
 	return semanticPlan, nil
+}
+
+func validateGeneratedPlanDevices(actual []PlanDevice, config *planConfig, stage PlanStage) error {
+	expected := make(map[string]PlanDevice, config.selectedCount*config.planes)
+	for _, target := range config.targetMap.PreBreakout.Targets {
+		planes := 1
+		if stage == PlanStageConfigure {
+			planes = config.planes
+		}
+		for plane := 0; plane < planes; plane++ {
+			bdf, err := bdfForPlane(target.BDF, plane)
+			if err != nil {
+				return err
+			}
+			expected[bdf] = PlanDevice{
+				BDF:       bdf,
+				DeviceID:  target.DeviceID,
+				DMSTarget: "pci/" + bdf,
+				Rail:      target.Rail,
+				Plane:     plane,
+				Network:   target.Role,
+			}
+		}
+	}
+	if len(actual) != len(expected) {
+		return fmt.Errorf("generated doSPCX %s plan has %d devices, expected %d", stage, len(actual), len(expected))
+	}
+	for _, device := range actual {
+		want, found := expected[device.BDF]
+		if !found {
+			return fmt.Errorf("generated doSPCX %s plan contains unexpected device BDF %q", stage, device.BDF)
+		}
+		if device.DMSTarget != want.DMSTarget || device.DeviceID != want.DeviceID ||
+			device.Rail != want.Rail || device.Plane != want.Plane || device.Network != want.Network {
+			return fmt.Errorf("generated doSPCX %s plan device %q topology does not match the target map", stage, device.BDF)
+		}
+	}
+	return nil
+}
+
+func bdfForPlane(baseBDF string, plane int) (string, error) {
+	if !isCanonicalFunctionZeroBDF(baseBDF) {
+		return "", fmt.Errorf("cannot derive plane %d from non-canonical function-zero BDF %q", plane, baseBDF)
+	}
+	if plane < 0 || plane > 7 {
+		return "", fmt.Errorf("cannot derive PCI function for plane %d", plane)
+	}
+	return strings.TrimSuffix(baseBDF, ".0") + "." + strconv.Itoa(plane), nil
 }
 
 func writeJSONFileAtomic(path string, value any) error {

--- a/pkg/spectrumx/prepareplan_test.go
+++ b/pkg/spectrumx/prepareplan_test.go
@@ -18,7 +18,6 @@ package spectrumx
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -106,7 +105,7 @@ func generateConfigurePlan(
 
 func preparePlanFakeExecutor(output []byte, commands *[]preparePlanCommand) *execTesting.FakeExec {
 	command := &execTesting.FakeCmd{}
-	command.CombinedOutputScript = append(command.CombinedOutputScript, func() ([]byte, []byte, error) {
+	command.RunScript = append(command.RunScript, func() ([]byte, []byte, error) {
 		return output, nil, nil
 	})
 	executor := &execTesting.FakeExec{}
@@ -127,6 +126,7 @@ var _ = Describe("doSPCX planning", func() {
 	const (
 		nodeName       = "worker-01"
 		blueprintsRoot = "/opt/nvidia/blueprints"
+		secondBDF      = "0000:65:00.0"
 	)
 
 	newDevice := func(name, bdf, mode string) *v1alpha1.NicDevice {
@@ -156,15 +156,29 @@ var _ = Describe("doSPCX planning", func() {
 	}
 
 	planResponseForPlatform := func(name, profile, stage, platform string, planes, deviceCount int) []byte {
+		prepareBDFs := []string{"0000:64:00.0", secondBDF, "0001:15:00.0"}
+		configureBDFs := []string{"0000:64:00.0", "0001:15:00.0"}
 		devices := make([]map[string]any, deviceCount)
 		for index := range devices {
-			bdf := fmt.Sprintf("0000:%02x:00.0", index+1)
+			rail := index
+			plane := 0
+			bdf := ""
+			if stage == configureStage {
+				rail = index / planes
+				plane = index % planes
+				var err error
+				bdf, err = bdfForPlane(configureBDFs[rail], plane)
+				Expect(err).NotTo(HaveOccurred())
+			} else {
+				bdf = prepareBDFs[index]
+			}
 			devices[index] = map[string]any{
 				"bdf":        bdf,
+				"device_id":  "0x1023",
 				"dms_target": "pci/" + bdf,
 				"network":    "ew",
-				"rail":       index,
-				"plane":      0,
+				"rail":       rail,
+				"plane":      plane,
 			}
 		}
 		groupName := "breakout"
@@ -209,13 +223,10 @@ var _ = Describe("doSPCX planning", func() {
 					"runtime_ctx":  map[string]any{"deployment_mode": "host-k8s", "rdma_topology": "per_pf"},
 					"operations": map[string]any{
 						operationID: map[string]any{
-							"path":            "/nvidia/test",
-							"values":          map[string]any{"enabled": true},
-							"source_feature":  "test",
-							"kind":            "set",
-							"target_class":    "pf_netdev_all",
-							"target_role":     "ew",
-							"execution_group": groupName,
+							"path":           "/nvidia/test",
+							"values":         map[string]any{"enabled": true},
+							"source_feature": "test",
+							"target_class":   "pf_netdev_all",
 						},
 					},
 					"semantic": map[string]any{"groups": groups},
@@ -230,14 +241,14 @@ var _ = Describe("doSPCX planning", func() {
 		return planResponseForPlatform(name, profile, stage, "gb300", planes, deviceCount)
 	}
 
-	It("builds a schema-v3 target map and saves the returned prepare plan", func() {
+	It("builds a schema-v1 target map and saves the returned prepare plan", func() {
 		stateDir := GinkgoT().TempDir()
 		commands := []preparePlanCommand{}
 		planName := planName(nodeName, prepareStage)
-		executor := preparePlanFakeExecutor(planResponse(planName, "hwmp", prepareStage, 2, 3), &commands)
+		executor := preparePlanFakeExecutor(planResponse(planName, "SPX_Multiplane", prepareStage, 2, 3), &commands)
 		devices := []*v1alpha1.NicDevice{
 			newDevice("last-by-bdf", "0001:15:00.0", "hwplb"),
-			newDevice("second-by-bdf", "0000:65:00.0", "hwplb"),
+			newDevice("second-by-bdf", secondBDF, "hwplb"),
 			newDevice("first-by-bdf", "0000:64:00.0", "hwplb"),
 		}
 
@@ -255,7 +266,7 @@ var _ = Describe("doSPCX planning", func() {
 		planPath := filepath.Join(stateDir, "plans", planName, "plan.json")
 		planContent, err := os.ReadFile(planPath)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(string(planContent)).To(ContainSubstring(`"profile": "hwmp"`))
+		Expect(string(planContent)).To(ContainSubstring(`"profile": "SPX_Multiplane"`))
 		storedPlan, err := manager.GetPreparedPlan(devices[0], PlanStagePrepare)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(storedPlan).To(Equal(plan))
@@ -268,23 +279,21 @@ var _ = Describe("doSPCX planning", func() {
 		Expect(err).NotTo(HaveOccurred())
 		var generated targetMap
 		Expect(json.Unmarshal(targetMapContent, &generated)).To(Succeed())
-		Expect(generated.SchemaVersion).To(Equal(3))
+		Expect(generated.SchemaVersion).To(Equal(1))
 		Expect(generated.PlatformType).To(Equal("gb300"))
-		Expect(generated.DefaultRole).To(Equal("ew"))
-		Expect(generated.TargetConstraints).To(Equal(map[string]targetConstraint{
-			"ew": {HCATypes: []string{"ConnectX-8"}, Topology: targetTopology{PortsPerTarget: 1}},
-		}))
 		Expect(generated.PreBreakout.Targets).To(Equal([]preBreakoutTarget{
-			{BDF: "0000:64:00.0", Rail: 0},
-			{BDF: "0000:65:00.0", Rail: 1},
-			{BDF: "0001:15:00.0", Rail: 2},
+			{ID: "ew-rail0-prebreakout", BDF: "0000:64:00.0", DeviceID: "0x1023", Role: "ew", Rail: 0},
+			{ID: "ew-rail1-prebreakout", BDF: secondBDF, DeviceID: "0x1023", Role: "ew", Rail: 1},
+			{ID: "ew-rail2-prebreakout", BDF: "0001:15:00.0", DeviceID: "0x1023", Role: "ew", Rail: 2},
 		}))
+		Expect(string(targetMapContent)).NotTo(ContainSubstring("default_role"))
+		Expect(string(targetMapContent)).NotTo(ContainSubstring("target_constraints"))
 		Expect(string(targetMapContent)).NotTo(ContainSubstring("nic_index_in_rail"))
 
 		Expect(commands).To(HaveLen(1))
 		Expect(commands[0].executable).To(Equal("/opt/mellanox/doca/services/dms/dms-cli"))
 		Expect(commands[0].args).To(ContainElements(
-			"profile=hwmp",
+			"profile=SPX_Multiplane",
 			"name="+planName,
 			"stage=prepare",
 			"target-map-file=file:"+targetMapPath,
@@ -292,7 +301,7 @@ var _ = Describe("doSPCX planning", func() {
 		))
 		Expect(commands[0].args).NotTo(ContainElement("params=deployment_mode=host-k8s,planes=2,overlay=none"))
 		Expect(commands[0].command.Env).To(ContainElement("BLUEPRINTS_ROOT=" + blueprintsRoot))
-		Expect(commands[0].command.Env).To(ContainElement("BLUEPRINTS_STATE_DIR=" + stateDir))
+		Expect(commands[0].command.Env).To(ContainElement("BP_STATE_DIR=" + stateDir))
 
 		metadataPath := filepath.Join(stateDir, "plans", planName, "metadata.json")
 		metadataContent, err := os.ReadFile(metadataPath)
@@ -304,7 +313,7 @@ var _ = Describe("doSPCX planning", func() {
 			BlueprintsStateDir: stateDir,
 			PlanName:           planName,
 			Stage:              prepareStage,
-			Profile:            "hwmp",
+			Profile:            "SPX_Multiplane",
 			PlatformType:       "gb300",
 			SpectrumXVersion:   "RA2.2",
 			MultiplaneMode:     "hwplb",
@@ -343,7 +352,7 @@ var _ = Describe("doSPCX planning", func() {
 			commands := []preparePlanCommand{}
 			generatedPlanName := planName(otherNode, stage)
 			executor := preparePlanFakeExecutor(
-				planResponse(generatedPlanName, "hwmp", string(stage), 2, deviceCount), &commands,
+				planResponse(generatedPlanName, "SPX_Multiplane", string(stage), 2, deviceCount), &commands,
 			)
 			device := newDevice("rail-0", "0000:64:00.0", "hwplb")
 
@@ -373,7 +382,7 @@ var _ = Describe("doSPCX planning", func() {
 		commands := []preparePlanCommand{}
 		configurePlanName := planName(nodeName, configureStage)
 		executor := preparePlanFakeExecutor(
-			planResponse(configurePlanName, "hwmp", configureStage, 2, 4), &commands,
+			planResponse(configurePlanName, "SPX_Multiplane", configureStage, 2, 4), &commands,
 		)
 		devices := []*v1alpha1.NicDevice{
 			newDevice("rail-1", "0001:15:00.0", "hwplb"),
@@ -409,7 +418,7 @@ var _ = Describe("doSPCX planning", func() {
 		generatedPlanName := planName(nodeName, prepareStage)
 		firstCommands := []preparePlanCommand{}
 		firstExecutor := preparePlanFakeExecutor(
-			planResponse(generatedPlanName, "hwmp", prepareStage, 2, 1), &firstCommands,
+			planResponse(generatedPlanName, "SPX_Multiplane", prepareStage, 2, 1), &firstCommands,
 		)
 
 		firstPath, err := generatePreparePlan(
@@ -437,7 +446,7 @@ var _ = Describe("doSPCX planning", func() {
 		firstCommands := []preparePlanCommand{}
 		manager := newTestPlanManager(
 			preparePlanFakeExecutor(
-				planResponse(generatedPlanName, "hwmp", prepareStage, 2, 1), &firstCommands,
+				planResponse(generatedPlanName, "SPX_Multiplane", prepareStage, 2, 1), &firstCommands,
 			), blueprintsRoot, stateDir,
 		).(*spectrumXConfigManager)
 		manager.dospcxDataDigest = "first-bundle"
@@ -447,7 +456,7 @@ var _ = Describe("doSPCX planning", func() {
 
 		secondCommands := []preparePlanCommand{}
 		manager.execInterface = preparePlanFakeExecutor(
-			planResponse(generatedPlanName, "hwmp", prepareStage, 2, 1), &secondCommands,
+			planResponse(generatedPlanName, "SPX_Multiplane", prepareStage, 2, 1), &secondCommands,
 		)
 		manager.dospcxDataDigest = "second-bundle"
 
@@ -468,7 +477,7 @@ var _ = Describe("doSPCX planning", func() {
 			commands := []preparePlanCommand{}
 			manager := newTestPlanManager(
 				preparePlanFakeExecutor(
-					planResponse(generatedPlanName, "hwmp", prepareStage, 2, 1), &commands,
+					planResponse(generatedPlanName, "SPX_Multiplane", prepareStage, 2, 1), &commands,
 				), blueprintsRoot, stateDir,
 			)
 			Expect(manager.PreparePlan(context.Background(), []*v1alpha1.NicDevice{device}, PlanStagePrepare)).To(Succeed())
@@ -482,8 +491,11 @@ var _ = Describe("doSPCX planning", func() {
 			device.Spec.Configuration.Template.SpectrumXOptimized.PlatformType = "b300"
 		}, "does not match"),
 		Entry("device is absent from the target map", func(device *v1alpha1.NicDevice) {
-			device.Status.Ports[0].PCI = "0000:65:00.0"
+			device.Status.Ports[0].PCI = secondBDF
 		}, "is absent from the target map"),
+		Entry("device type differs from the target map", func(device *v1alpha1.NicDevice) {
+			device.Status.Type = "1025"
+		}, "device ID"),
 	)
 
 	DescribeTable("regenerates a saved plan when an input changes",
@@ -494,18 +506,26 @@ var _ = Describe("doSPCX planning", func() {
 			firstCommands := []preparePlanCommand{}
 			_, err := generatePreparePlan(
 				context.Background(), preparePlanFakeExecutor(
-					planResponse(generatedPlanName, "hwmp", prepareStage, 2, 1), &firstCommands,
+					planResponse(generatedPlanName, "SPX_Multiplane", prepareStage, 2, 1), &firstCommands,
 				), nodeName, []*v1alpha1.NicDevice{device}, blueprintsRoot, stateDir,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
 			mutate(device)
 			secondCommands := []preparePlanCommand{}
+			secondResponse := planResponseForPlatform(
+				generatedPlanName, "SPX_Multiplane", prepareStage, expectedPlatform, expectedPlanes, 1,
+			)
+			var responseDocument map[string]any
+			Expect(json.Unmarshal(secondResponse, &responseDocument)).To(Succeed())
+			planDevices := responseDocument["plan-json"].(map[string]any)["plan"].(map[string]any)["devices"].([]any)
+			planDevices[0].(map[string]any)["bdf"] = device.Status.Ports[0].PCI
+			planDevices[0].(map[string]any)["dms_target"] = "pci/" + device.Status.Ports[0].PCI
+			secondResponse, err = json.Marshal(responseDocument)
+			Expect(err).NotTo(HaveOccurred())
 			_, err = generatePreparePlan(
 				context.Background(), preparePlanFakeExecutor(
-					planResponseForPlatform(
-						generatedPlanName, "hwmp", prepareStage, expectedPlatform, expectedPlanes, 1,
-					), &secondCommands,
+					secondResponse, &secondCommands,
 				), nodeName, []*v1alpha1.NicDevice{device}, blueprintsRoot, stateDir,
 			)
 
@@ -527,7 +547,7 @@ var _ = Describe("doSPCX planning", func() {
 			device.Spec.Configuration.Template.SpectrumXOptimized.NumberOfPlanes = 4
 		}, "gb300", 4),
 		Entry("target-map topology", func(device *v1alpha1.NicDevice) {
-			device.Status.Ports[0].PCI = "0000:65:00.0"
+			device.Status.Ports[0].PCI = secondBDF
 		}, "gb300", 2),
 	)
 
@@ -539,7 +559,7 @@ var _ = Describe("doSPCX planning", func() {
 			firstCommands := []preparePlanCommand{}
 			_, err := generatePreparePlan(
 				context.Background(), preparePlanFakeExecutor(
-					planResponse(generatedPlanName, "hwmp", prepareStage, 2, 1), &firstCommands,
+					planResponse(generatedPlanName, "SPX_Multiplane", prepareStage, 2, 1), &firstCommands,
 				), nodeName, []*v1alpha1.NicDevice{device}, blueprintsRoot, stateDir,
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -548,7 +568,7 @@ var _ = Describe("doSPCX planning", func() {
 			secondCommands := []preparePlanCommand{}
 			_, err = generatePreparePlan(
 				context.Background(), preparePlanFakeExecutor(
-					planResponse(generatedPlanName, "hwmp", prepareStage, 2, 1), &secondCommands,
+					planResponse(generatedPlanName, "SPX_Multiplane", prepareStage, 2, 1), &secondCommands,
 				), nodeName, []*v1alpha1.NicDevice{device}, blueprintsRoot, stateDir,
 			)
 
@@ -572,12 +592,12 @@ var _ = Describe("doSPCX planning", func() {
 		}),
 	)
 
-	It("maps swplb to swmp and passes its overlay", func() {
+	It("maps swplb to SPX_NetPlugin and passes its overlay", func() {
 		stateDir := GinkgoT().TempDir()
 		commands := []preparePlanCommand{}
 		planName := planName(nodeName, prepareStage)
-		executor := preparePlanFakeExecutor(planResponse(planName, "swmp", prepareStage, 2, 1), &commands)
-		device := newDevice("swmp", "0000:64:00.0", "swplb")
+		executor := preparePlanFakeExecutor(planResponse(planName, "SPX_NetPlugin", prepareStage, 2, 1), &commands)
+		device := newDevice("SPX_NetPlugin", "0000:64:00.0", "swplb")
 
 		_, err := generatePreparePlan(
 			context.Background(), executor, nodeName, []*v1alpha1.NicDevice{device}, blueprintsRoot, stateDir,
@@ -585,7 +605,7 @@ var _ = Describe("doSPCX planning", func() {
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(commands).To(HaveLen(1))
-		Expect(commands[0].args).To(ContainElements("profile=swmp", "params=deployment_mode=host-k8s,planes=2,overlay=none"))
+		Expect(commands[0].args).To(ContainElements("profile=SPX_NetPlugin", "params=deployment_mode=host-k8s,planes=2,overlay=none"))
 	})
 
 	It("maps an omitted multiplane mode to a one-plane plan", func() {
@@ -605,7 +625,7 @@ var _ = Describe("doSPCX planning", func() {
 		Expect(commands[0].args).To(ContainElements("profile=single-plane", "params=deployment_mode=host-k8s,planes=1,overlay=none"))
 	})
 
-	It("rejects an unsupported HWMP overlay before writing the target map", func() {
+	It("rejects an unsupported SPX_Multiplane overlay before writing the target map", func() {
 		stateDir := GinkgoT().TempDir()
 		commands := []preparePlanCommand{}
 		device := newDevice("hwmp-l3", "0000:64:00.0", "hwplb")
@@ -647,8 +667,8 @@ var _ = Describe("doSPCX planning", func() {
 		},
 		Entry("default", "", "single-plane"),
 		Entry("none", "none", "single-plane"),
-		Entry("software multiplane", "swplb", "swmp"),
-		Entry("hardware multiplane", "hwplb", "hwmp"),
+		Entry("software multiplane", "swplb", "SPX_NetPlugin"),
+		Entry("hardware multiplane", "hwplb", "SPX_Multiplane"),
 	)
 
 	It("rejects unsupported multiplane modes", func() {
@@ -656,16 +676,16 @@ var _ = Describe("doSPCX planning", func() {
 		Expect(err).To(MatchError(ContainSubstring("unsupported")))
 	})
 
-	DescribeTable("maps NCO device types to doSPCX HCA names",
+	DescribeTable("maps NCO device types to doSPCX device IDs",
 		func(deviceType, expected string) {
-			hcaType, err := blueprintHCAType(deviceType)
+			deviceID, err := blueprintDeviceID(deviceType)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(hcaType).To(Equal(expected))
+			Expect(deviceID).To(Equal(expected))
 		},
-		Entry("ConnectX-7", "1021", "ConnectX-7"),
-		Entry("ConnectX-8", "1023", "ConnectX-8"),
-		Entry("ConnectX-9", "1025", "ConnectX-9"),
-		Entry("BlueField-3", "a2dc", "BlueField-3"),
+		Entry("ConnectX-7", "1021", "0x1021"),
+		Entry("ConnectX-8", "1023", "0x1023"),
+		Entry("ConnectX-9", "1025", "0x1025"),
+		Entry("BlueField-3", "A2DC", "0xa2dc"),
 	)
 
 	DescribeTable("rejects incomplete or inconsistent target-map inputs",
@@ -680,10 +700,6 @@ var _ = Describe("doSPCX planning", func() {
 
 			Expect(err).To(MatchError(ContainSubstring(expected)))
 		},
-		Entry("missing platform type", func(devices []*v1alpha1.NicDevice) {
-			devices[0].Spec.Configuration.Template.SpectrumXOptimized.PlatformType = ""
-			devices[1].Spec.Configuration.Template.SpectrumXOptimized.PlatformType = ""
-		}, "platformType"),
 		Entry("inconsistent platform type", func(devices []*v1alpha1.NicDevice) {
 			devices[1].Spec.Configuration.Template.SpectrumXOptimized.PlatformType = "b300"
 		}, "must use the same"),
@@ -713,6 +729,21 @@ var _ = Describe("doSPCX planning", func() {
 		}, "same pre-breakout BDF"),
 	)
 
+	It("uses gb300 when platformType is absent", func() {
+		devices := []*v1alpha1.NicDevice{
+			newDevice("first", "0000:64:00.0", "hwplb"),
+			newDevice("second", "0001:15:00.0", "hwplb"),
+		}
+		devices[0].Spec.Configuration.Template.SpectrumXOptimized.PlatformType = ""
+		devices[1].Spec.Configuration.Template.SpectrumXOptimized.PlatformType = " "
+
+		config, err := buildPlanConfig(devices)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(config.platformType).To(Equal("gb300"))
+		Expect(config.targetMap.PlatformType).To(Equal("gb300"))
+	})
+
 	It("ignores interface-name configuration when assigning target-map rails", func() {
 		first := newDevice("first", "0000:64:00.0", "hwplb")
 		first.Spec.InterfaceNameTemplate = &v1alpha1.NicDeviceInterfaceNameSpec{
@@ -725,8 +756,8 @@ var _ = Describe("doSPCX planning", func() {
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(config.targetMap.PreBreakout.Targets).To(Equal([]preBreakoutTarget{
-			{BDF: "0000:64:00.0", Rail: 0},
-			{BDF: "0001:15:00.0", Rail: 1},
+			{ID: "ew-rail0-prebreakout", BDF: "0000:64:00.0", DeviceID: "0x1023", Role: "ew", Rail: 0},
+			{ID: "ew-rail1-prebreakout", BDF: "0001:15:00.0", DeviceID: "0x1023", Role: "ew", Rail: 1},
 		}))
 	})
 
@@ -734,7 +765,7 @@ var _ = Describe("doSPCX planning", func() {
 		stateDir := GinkgoT().TempDir()
 		commands := []preparePlanCommand{}
 		planName := planName(nodeName, prepareStage)
-		response := planResponse(planName, "hwmp", prepareStage, 2, 1)
+		response := planResponse(planName, "SPX_Multiplane", prepareStage, 2, 1)
 		var document map[string]any
 		Expect(json.Unmarshal(response, &document)).To(Succeed())
 		document["plan-json"].(map[string]any)["plan"].(map[string]any)["stage"] = "configure"
@@ -758,7 +789,7 @@ var _ = Describe("doSPCX planning", func() {
 			stateDir := GinkgoT().TempDir()
 			commands := []preparePlanCommand{}
 			generatedPlanName := planName(nodeName, prepareStage)
-			response := planResponse(generatedPlanName, "hwmp", prepareStage, 2, 1)
+			response := planResponse(generatedPlanName, "SPX_Multiplane", prepareStage, 2, 1)
 			var document map[string]any
 			Expect(json.Unmarshal(response, &document)).To(Succeed())
 			mutate(document["plan-json"].(map[string]any))
@@ -789,5 +820,24 @@ var _ = Describe("doSPCX planning", func() {
 		Entry("rendered artifacts", func(bundle map[string]any) {
 			bundle["artifacts"] = map[string]any{"manifest": []any{map[string]any{"type": "systemd-unit"}}}
 		}, "rendered artifacts"),
+		Entry("unexpected device BDF", func(bundle map[string]any) {
+			device := bundle["plan"].(map[string]any)["devices"].([]any)[0].(map[string]any)
+			device["bdf"] = secondBDF
+			device["dms_target"] = "pci/" + secondBDF
+		}, "unexpected device BDF"),
+		Entry("wrong device rail", func(bundle map[string]any) {
+			device := bundle["plan"].(map[string]any)["devices"].([]any)[0].(map[string]any)
+			device["rail"] = 1
+		}, "topology does not match"),
+		Entry("unknown semantic group", func(bundle map[string]any) {
+			group := bundle["plan"].(map[string]any)["semantic"].(map[string]any)["groups"].([]any)[0].(map[string]any)
+			group["name"] = "unknown-prepare-group"
+		}, "unsupported doSPCX semantic group"),
+		Entry("eSwitch operation in an executable group", func(bundle map[string]any) {
+			plan := bundle["plan"].(map[string]any)
+			group := plan["semantic"].(map[string]any)["groups"].([]any)[0].(map[string]any)
+			operationID := group["operation_refs"].([]any)[0].(string)
+			plan["operations"].(map[string]any)[operationID].(map[string]any)["path"] = "/nvidia/eswitch"
+		}, "outside the current NCO execution scope"),
 	)
 })

--- a/pkg/spectrumx/semanticplan.go
+++ b/pkg/spectrumx/semanticplan.go
@@ -61,7 +61,9 @@ type PlanDevice struct {
 	TargetID       string   `json:"target_id"`
 }
 
-// ExpectedRDMA identifies the control target selected for one rail.
+// ExpectedRDMA describes one expected RDMA endpoint emitted by the planner.
+// ControlBDF and ControlTarget are retained for compatibility with older,
+// enriched plans; public doSPCX plans do not require them.
 type ExpectedRDMA struct {
 	Rail          int    `json:"rail"`
 	RDMADevice    string `json:"rdma_dev"`
@@ -144,6 +146,7 @@ type DMSOperationGroup struct {
 	Order          int
 	Scope          string
 	DeviceView     string
+	FanoutOrder    string
 	RequiresReboot bool
 	PhaseMarker    bool
 	Targets        []DMSTargetOperations
@@ -302,12 +305,16 @@ func (p *SemanticPlan) BuildDMSOperationPlan(ctx context.Context) (*DMSOperation
 				Order:          group.Order,
 				Scope:          group.Scope,
 				DeviceView:     group.DeviceView,
+				FanoutOrder:    group.FanoutOrder,
 				RequiresReboot: group.RequiresReboot,
 				PhaseMarker:    true,
 				Targets:        nil,
 			})
 			continue
 		case groupDispositionExecute:
+			if err := validateExecutableGroupPolicy(group); err != nil {
+				return nil, err
+			}
 			targets, err := p.resolveGroupTargets(group)
 			if err != nil {
 				return nil, fmt.Errorf("resolve doSPCX semantic group %q: %w", group.Name, err)
@@ -317,6 +324,7 @@ func (p *SemanticPlan) BuildDMSOperationPlan(ctx context.Context) (*DMSOperation
 				Order:          group.Order,
 				Scope:          group.Scope,
 				DeviceView:     group.DeviceView,
+				FanoutOrder:    group.FanoutOrder,
 				RequiresReboot: group.RequiresReboot,
 				PhaseMarker:    false,
 				Targets:        targets,
@@ -326,6 +334,20 @@ func (p *SemanticPlan) BuildDMSOperationPlan(ctx context.Context) (*DMSOperation
 		}
 	}
 	return result, nil
+}
+
+func validateExecutableGroupPolicy(group SemanticGroup) error {
+	for _, operation := range group.Operations {
+		if operation.TargetClass == targetClassPerESwitch ||
+			operation.TargetClass == targetClassVFRepresentor ||
+			operation.Scope == "per_vf" ||
+			strings.HasPrefix(operation.Path, "/nvidia/eswitch") {
+			return fmt.Errorf(
+				"doSPCX semantic group %q contains operation %q outside the current NCO execution scope",
+				group.Name, operation.ID)
+		}
+	}
+	return nil
 }
 
 func validateSemanticPlanHeader(document *semanticPlanDocument, expectedStage PlanStage) error {
@@ -423,10 +445,19 @@ func resolveSemanticGroups(
 			if !found {
 				return nil, fmt.Errorf("doSPCX semantic group %q references missing operation %q", record.Name, ref)
 			}
+			if operation.Kind == "" {
+				// DMS treats an omitted kind as a SET operation. The planner only
+				// emits kind when YANG-based classification is available.
+				operation.Kind = "set"
+			}
 			if operation.TargetClass == "" {
 				operation.TargetClass = targetClassPFNetdevAll
 			}
-			if err := validateSemanticOperation(ref, record.Name, operation); err != nil {
+			// Group membership is defined by semantic.groups.operation_refs in
+			// the public plan. Keep the derived value on the exported operation
+			// for compatibility with callers of this package.
+			operation.ExecutionGroup = record.Name
+			if err := validateSemanticOperation(ref, operation); err != nil {
 				return nil, err
 			}
 			group.Operations = append(group.Operations, SemanticOperation{
@@ -454,12 +485,9 @@ func resolveSemanticGroups(
 	return groups, nil
 }
 
-func validateSemanticOperation(id, group string, operation semanticOperationRecord) error {
+func validateSemanticOperation(id string, operation semanticOperationRecord) error {
 	if operation.Kind != "set" {
 		return fmt.Errorf("doSPCX semantic operation %q has unsupported kind %q", id, operation.Kind)
-	}
-	if operation.ExecutionGroup != group {
-		return fmt.Errorf("doSPCX semantic operation %q belongs to group %q, not %q", id, operation.ExecutionGroup, group)
 	}
 	if !strings.HasPrefix(operation.Path, "/nvidia/") || strings.ContainsAny(operation.Path, " \t\r\n;") {
 		return fmt.Errorf("doSPCX semantic operation %q has invalid path %q", id, operation.Path)
@@ -479,9 +507,6 @@ func validateSemanticOperation(id, group string, operation semanticOperationReco
 	case targetClassPFNetdevAll, targetClassPFRDMAScope, targetClassPerESwitch, targetClassVFRepresentor:
 	default:
 		return fmt.Errorf("doSPCX semantic operation %q has unsupported target class %q", id, operation.TargetClass)
-	}
-	if operation.TargetClass != targetClassVFRepresentor && strings.TrimSpace(operation.TargetRole) == "" {
-		return fmt.Errorf("doSPCX semantic operation %q has no target role", id)
 	}
 	return nil
 }
@@ -589,13 +614,19 @@ func (p *SemanticPlan) resolveGroupTargets(group SemanticGroup) ([]DMSTargetOper
 func (p *SemanticPlan) resolveOperationTargets(operation SemanticOperation) ([]string, error) {
 	eligible := make([]PlanDevice, 0, len(p.Devices))
 	for _, device := range p.Devices {
-		if device.Network != operation.TargetRole {
+		// target_role is not part of the public doSPCX operation schema. If
+		// an enriched plan supplies it, retain the historical filtering;
+		// otherwise the operation targets all plan devices.
+		if operation.TargetRole != "" && device.Network != operation.TargetRole {
 			continue
 		}
 		eligible = append(eligible, device)
 	}
 	if len(eligible) == 0 {
-		return nil, fmt.Errorf("no plan devices match target role %q", operation.TargetRole)
+		if operation.TargetRole != "" {
+			return nil, fmt.Errorf("no plan devices match target role %q", operation.TargetRole)
+		}
+		return nil, fmt.Errorf("doSPCX plan does not contain eligible devices")
 	}
 
 	switch operation.TargetClass {
@@ -610,47 +641,22 @@ func (p *SemanticPlan) resolveOperationTargets(operation SemanticOperation) ([]s
 		case rdmaTopologyPerPF:
 			result := make([]string, 0, len(eligible))
 			for _, device := range eligible {
+				if strings.TrimSpace(device.RDMADevice) == "" {
+					continue
+				}
 				result = append(result, device.DMSTarget)
 			}
 			return result, nil
 		case rdmaTopologyPerRailBond:
-			expected := append([]ExpectedRDMA(nil), p.RuntimeContext.ExpectedRDMA...)
-			sort.SliceStable(expected, func(left, right int) bool {
-				return expected[left].Rail < expected[right].Rail
-			})
-			if len(expected) == 0 {
-				return nil, fmt.Errorf("per-rail-bond topology does not define expected RDMA controls")
-			}
-			seenTargets := make(map[string]struct{}, len(expected))
-			seenRails := make(map[int]struct{}, len(expected))
-			eligibleDevices := make(map[string]PlanDevice, len(eligible))
+			// This mirrors DMS FilterOpsForDevice: a per-rail bond is
+			// controlled through the plane-zero PF. expected_rdma describes
+			// the bond but does not carry a DMS control target in the public
+			// plan schema.
+			result := make([]string, 0, len(eligible))
 			for _, device := range eligible {
-				eligibleDevices[device.DMSTarget] = device
-			}
-			result := make([]string, 0, len(expected))
-			for _, control := range expected {
-				if _, found := seenRails[control.Rail]; found {
-					return nil, fmt.Errorf("RDMA control rail %d is duplicated", control.Rail)
+				if device.Plane == 0 {
+					result = append(result, device.DMSTarget)
 				}
-				seenRails[control.Rail] = struct{}{}
-				if strings.TrimSpace(control.ControlTarget) == "" {
-					return nil, fmt.Errorf("rail %d has no RDMA control target", control.Rail)
-				}
-				device, found := eligibleDevices[control.ControlTarget]
-				if !found {
-					return nil, fmt.Errorf("RDMA control target %q is not a plan device for role %q", control.ControlTarget, operation.TargetRole)
-				}
-				if control.ControlBDF == "" || control.ControlTarget != "pci/"+control.ControlBDF {
-					return nil, fmt.Errorf("RDMA control target %q does not match control BDF %q", control.ControlTarget, control.ControlBDF)
-				}
-				if device.Rail != control.Rail {
-					return nil, fmt.Errorf("RDMA control target %q belongs to rail %d, not rail %d", control.ControlTarget, device.Rail, control.Rail)
-				}
-				if _, found := seenTargets[control.ControlTarget]; found {
-					return nil, fmt.Errorf("RDMA control target %q is duplicated", control.ControlTarget)
-				}
-				seenTargets[control.ControlTarget] = struct{}{}
-				result = append(result, control.ControlTarget)
 			}
 			return result, nil
 		default:

--- a/pkg/spectrumx/semanticplan_test.go
+++ b/pkg/spectrumx/semanticplan_test.go
@@ -46,7 +46,7 @@ var _ = Describe("doSPCX semantic plans", func() {
 			plan := parseFixture("prepare-plan.json", PlanStagePrepare)
 
 			Expect(plan.Name).To(Equal("nco-parser-semantic-prepare"))
-			Expect(plan.Profile).To(Equal("hwmp"))
+			Expect(plan.Profile).To(Equal("SPX_Multiplane"))
 			Expect(plan.PathDialect).To(Equal(semanticPathDialect))
 			Expect(plan.Devices).To(HaveLen(2))
 			Expect(plan.RuntimeContext.RDMATopology).To(Equal(rdmaTopologyPerPF))
@@ -55,6 +55,9 @@ var _ = Describe("doSPCX semantic plans", func() {
 			Expect(plan.Groups[0].Operations).To(HaveLen(15))
 			Expect(plan.Groups[0].Operations[0].ID).To(Equal("spcx-base-nvconfig.roce.adaptive-routing-cc-steering-ext-tx-sched-locality-mode"))
 			Expect(plan.Groups[0].Operations[0].Path).To(Equal("/nvidia/roce"))
+			Expect(plan.Groups[0].Operations[0].Kind).To(Equal("set"))
+			Expect(plan.Groups[0].Operations[0].ExecutionGroup).To(Equal("breakout"))
+			Expect(plan.Groups[0].Operations[0].TargetRole).To(BeEmpty())
 			Expect(plan.Groups[1].Name).To(Equal("post-breakout"))
 			Expect(plan.Groups[1].Operations).To(BeEmpty())
 			Expect(plan.Groups[1].RequiresReboot).To(BeTrue())
@@ -99,13 +102,6 @@ var _ = Describe("doSPCX semantic plans", func() {
 				groups := document["plan"].(map[string]any)["semantic"].(map[string]any)["groups"].([]any)
 				groups[0].(map[string]any)["operation_refs"] = []any{"missing-operation"}
 			}, "references missing operation"),
-			Entry("operation in another group", func(document map[string]any) {
-				operations := document["plan"].(map[string]any)["operations"].(map[string]any)
-				for _, value := range operations {
-					value.(map[string]any)["execution_group"] = "other"
-					break
-				}
-			}, "belongs to group"),
 			Entry("unsupported operation kind", func(document map[string]any) {
 				operations := document["plan"].(map[string]any)["operations"].(map[string]any)
 				for _, value := range operations {
@@ -151,6 +147,21 @@ var _ = Describe("doSPCX semantic plans", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(plan.Groups[0].Operations[0].TargetClass).To(Equal(targetClassPFNetdevAll))
+		})
+
+		It("uses semantic operation references as the authoritative group membership", func() {
+			var document map[string]any
+			Expect(json.Unmarshal(readFixture("prepare-plan.json"), &document)).To(Succeed())
+			planObject := document["plan"].(map[string]any)
+			firstRef := planObject["semantic"].(map[string]any)["groups"].([]any)[0].(map[string]any)["operation_refs"].([]any)[0].(string)
+			planObject["operations"].(map[string]any)[firstRef].(map[string]any)["execution_group"] = "ignored-producer-detail"
+			content, err := json.Marshal(document)
+			Expect(err).NotTo(HaveOccurred())
+
+			plan, err := ParseSemanticPlan(content, PlanStagePrepare)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(plan.Groups[0].Operations[0].ExecutionGroup).To(Equal("breakout"))
 		})
 
 		It("sorts semantic groups by their declared order", func() {
@@ -224,11 +235,13 @@ var _ = Describe("doSPCX semantic plans", func() {
 
 		It("preserves ordered SET transitions but queries only the final desired state", func() {
 			semantic := parseFixture("configure-plan.json", PlanStageConfigure)
+			semantic.Groups[0].FanoutOrder = "per_target"
 			plan, err := semantic.BuildDMSOperationPlan(context.Background())
 			Expect(err).NotTo(HaveOccurred())
 
 			linkRuntime := plan.Groups[0]
 			Expect(linkRuntime.Name).To(Equal("link-runtime"))
+			Expect(linkRuntime.FanoutOrder).To(Equal("per_target"))
 			Expect(linkRuntime.Targets).To(HaveLen(4))
 			batch := linkRuntime.Targets[0]
 			Expect(batch.Operations).To(HaveLen(4))
@@ -240,8 +253,12 @@ var _ = Describe("doSPCX semantic plans", func() {
 			Expect(batch.Queries[1]).To(Equal(dmsQuery("/nvidia/link/physical", "admin-status")))
 		})
 
-		It("resolves bonded RDMA operations only to the per-rail control targets", func() {
+		It("resolves bonded RDMA operations to each plane-zero target", func() {
 			semantic := parseFixture("configure-plan.json", PlanStageConfigure)
+			for _, endpoint := range semantic.RuntimeContext.ExpectedRDMA {
+				Expect(endpoint.ControlBDF).To(BeEmpty())
+				Expect(endpoint.ControlTarget).To(BeEmpty())
+			}
 			plan, err := semantic.BuildDMSOperationPlan(context.Background())
 			Expect(err).NotTo(HaveOccurred())
 
@@ -278,24 +295,44 @@ var _ = Describe("doSPCX semantic plans", func() {
 			Expect(err).To(MatchError(ContainSubstring(`unsupported doSPCX semantic group "new-runtime-phase"`)))
 		})
 
-		It("rejects a missing bonded RDMA control target", func() {
+		DescribeTable("does not allow excluded operation classes in executable groups",
+			func(mutate func(*SemanticOperation)) {
+				semantic := parseFixture("configure-plan.json", PlanStageConfigure)
+				mutate(&semantic.Groups[0].Operations[0])
+
+				plan, err := semantic.BuildDMSOperationPlan(context.Background())
+
+				Expect(plan).To(BeNil())
+				Expect(err).To(MatchError(ContainSubstring("outside the current NCO execution scope")))
+			},
+			Entry("eSwitch path", func(operation *SemanticOperation) {
+				operation.Path = "/nvidia/eswitch"
+			}),
+			Entry("eSwitch target class", func(operation *SemanticOperation) {
+				operation.TargetClass = targetClassPerESwitch
+			}),
+			Entry("VF target class", func(operation *SemanticOperation) {
+				operation.TargetClass = targetClassVFRepresentor
+			}),
+			Entry("per-VF scope", func(operation *SemanticOperation) {
+				operation.Scope = "per_vf"
+			}),
+		)
+
+		It("resolves per-PF RDMA operations only to devices with an RDMA endpoint", func() {
 			semantic := parseFixture("configure-plan.json", PlanStageConfigure)
-			semantic.RuntimeContext.ExpectedRDMA[0].ControlTarget = ""
+			semantic.RuntimeContext.RDMATopology = rdmaTopologyPerPF
+			semantic.Devices[1].RDMADevice = ""
+			semantic.Devices[3].RDMADevice = ""
 
 			plan, err := semantic.BuildDMSOperationPlan(context.Background())
 
-			Expect(plan).To(BeNil())
-			Expect(err).To(MatchError(ContainSubstring("rail 0 has no RDMA control target")))
-		})
-
-		It("rejects duplicated bonded RDMA rails", func() {
-			semantic := parseFixture("configure-plan.json", PlanStageConfigure)
-			semantic.RuntimeContext.ExpectedRDMA[1].Rail = 0
-
-			plan, err := semantic.BuildDMSOperationPlan(context.Background())
-
-			Expect(plan).To(BeNil())
-			Expect(err).To(MatchError(ContainSubstring("RDMA control rail 0 is duplicated")))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(plan.Groups[1].Name).To(Equal("cc"))
+			Expect(plan.Groups[1].Targets).To(HaveLen(2))
+			Expect([]string{plan.Groups[1].Targets[0].Target, plan.Groups[1].Targets[1].Target}).To(Equal([]string{
+				"pci/0000:64:00.0", "pci/0001:15:00.0",
+			}))
 		})
 
 		It("rejects a nil semantic plan", func() {

--- a/pkg/spectrumx/testdata/semantic/configure-plan.json
+++ b/pkg/spectrumx/testdata/semantic/configure-plan.json
@@ -2,7 +2,7 @@
   "plan": {
     "name": "nco-parser-semantic-configure",
     "family": "spcx",
-    "profile": "hwmp",
+    "profile": "SPX_Multiplane",
     "stage": "configure",
     "params": {
       "deployment_mode": "host-k8s",
@@ -101,7 +101,7 @@
     ],
     "runtime_ctx": {
       "deployment_mode": "host-k8s",
-      "multiplane_mode": "hwmp",
+      "multiplane_mode": "SPX_Multiplane",
       "esw_multiport": true,
       "num_vfs": 1,
       "post_breakout": true,
@@ -113,16 +113,12 @@
         {
           "rail": 0,
           "rdma_dev": "roce_r0",
-          "control_bdf": "0000:64:00.0",
-          "control_target": "pci/0000:64:00.0",
-          "source": "endpoint_contract"
+          "source": "post_breakout_topology"
         },
         {
           "rail": 1,
           "rdma_dev": "roce_r1",
-          "control_bdf": "0001:15:00.0",
-          "control_target": "pci/0001:15:00.0",
-          "source": "endpoint_contract"
+          "source": "post_breakout_topology"
         }
       ],
       "expected_names": {
@@ -184,10 +180,7 @@
           "admin": 25
         },
         "source_feature": "spcx-ipg-runtime",
-        "kind": "set",
-        "target_class": "pf_netdev_all",
-        "execution_group": "link-runtime",
-        "target_role": "ew"
+        "target_class": "pf_netdev_all"
       },
       "spcx-ipg-runtime.link-physical.admin-status": {
         "path": "/nvidia/link/physical",
@@ -195,10 +188,7 @@
           "admin-status": "down"
         },
         "source_feature": "spcx-ipg-runtime",
-        "kind": "set",
-        "target_class": "pf_netdev_all",
-        "execution_group": "link-runtime",
-        "target_role": "ew"
+        "target_class": "pf_netdev_all"
       },
       "spcx-ipg-runtime.link-physical.admin-status.2": {
         "path": "/nvidia/link/physical",
@@ -206,10 +196,7 @@
           "admin-status": "up"
         },
         "source_feature": "spcx-ipg-runtime",
-        "kind": "set",
-        "target_class": "pf_netdev_all",
-        "execution_group": "link-runtime",
-        "target_role": "ew"
+        "target_class": "pf_netdev_all"
       },
       "spcx-pf-mtu.link-netdev.mtu": {
         "path": "/nvidia/link/netdev",
@@ -217,10 +204,7 @@
           "mtu": 9216
         },
         "source_feature": "spcx-pf-mtu",
-        "kind": "set",
-        "target_class": "pf_netdev_all",
-        "execution_group": "link-runtime",
-        "target_role": "ew"
+        "target_class": "pf_netdev_all"
       },
       "spcx-eswitch.eswitch.mode": {
         "path": "/nvidia/eswitch",
@@ -228,9 +212,6 @@
           "mode": "legacy"
         },
         "source_feature": "spcx-eswitch",
-        "kind": "set",
-        "execution_group": "eswitch",
-        "target_role": "ew",
         "target_class": "pf_netdev_all"
       },
       "spcx-eswitch.eswitch.flow-steering-mode": {
@@ -239,9 +220,6 @@
           "flow-steering-mode": "hmfs"
         },
         "source_feature": "spcx-eswitch",
-        "kind": "set",
-        "execution_group": "eswitch",
-        "target_role": "ew",
         "target_class": "pf_netdev_all"
       },
       "spcx-eswitch.eswitch.mode.2": {
@@ -250,9 +228,6 @@
           "mode": "switchdev"
         },
         "source_feature": "spcx-eswitch",
-        "kind": "set",
-        "execution_group": "eswitch",
-        "target_role": "ew",
         "target_class": "pf_netdev_all"
       },
       "spcx-eswitch.eswitch.multiport": {
@@ -261,9 +236,7 @@
           "multiport": true
         },
         "source_feature": "spcx-eswitch",
-        "kind": "set",
         "target_class": "per_eswitch",
-        "execution_group": "eswitch",
         "condition": {
           "knob": "@params.multiport == True"
         },
@@ -273,8 +246,7 @@
             "ConnectX-8"
           ],
           "platform_type": "gb300"
-        },
-        "target_role": "ew"
+        }
       },
       "ra22-cc-runtime.cc-algo-slot-15.enabled": {
         "path": "/nvidia/cc/algo/slot/[15]",
@@ -282,10 +254,7 @@
           "enabled": false
         },
         "source_feature": "ra22-cc-runtime",
-        "kind": "set",
-        "target_class": "pf_rdma_scope",
-        "execution_group": "cc",
-        "target_role": "ew"
+        "target_class": "pf_rdma_scope"
       },
       "ra22-cc-runtime.cc-algo-slot-0-param-0.value": {
         "path": "/nvidia/cc/algo/slot/[0]/param/[0]",
@@ -293,9 +262,7 @@
           "value": 400
         },
         "source_feature": "ra22-cc-runtime",
-        "kind": "set",
         "target_class": "pf_rdma_scope",
-        "execution_group": "cc",
         "condition": {
           "knob": "@params.nic_type == '1023' and @params.planes == 2"
         },
@@ -305,8 +272,7 @@
             "ConnectX-8"
           ],
           "platform_type": "gb300"
-        },
-        "target_role": "ew"
+        }
       },
       "ra22-cc-runtime.cc-algo-slot-0-param-1.value": {
         "path": "/nvidia/cc/algo/slot/[0]/param/[1]",
@@ -314,10 +280,7 @@
           "value": 6553
         },
         "source_feature": "ra22-cc-runtime",
-        "kind": "set",
-        "target_class": "pf_rdma_scope",
-        "execution_group": "cc",
-        "target_role": "ew"
+        "target_class": "pf_rdma_scope"
       },
       "ra22-cc-runtime.cc-algo-slot-0-param-2.value": {
         "path": "/nvidia/cc/algo/slot/[0]/param/[2]",
@@ -325,10 +288,7 @@
           "value": 63570
         },
         "source_feature": "ra22-cc-runtime",
-        "kind": "set",
-        "target_class": "pf_rdma_scope",
-        "execution_group": "cc",
-        "target_role": "ew"
+        "target_class": "pf_rdma_scope"
       },
       "ra22-cc-runtime.cc-algo-slot-0-param-3.value": {
         "path": "/nvidia/cc/algo/slot/[0]/param/[3]",
@@ -336,10 +296,7 @@
           "value": 69468
         },
         "source_feature": "ra22-cc-runtime",
-        "kind": "set",
-        "target_class": "pf_rdma_scope",
-        "execution_group": "cc",
-        "target_role": "ew"
+        "target_class": "pf_rdma_scope"
       },
       "ra22-cc-runtime.cc-algo-slot-0-param-4.value": {
         "path": "/nvidia/cc/algo/slot/[0]/param/[4]",
@@ -347,10 +304,7 @@
           "value": 36
         },
         "source_feature": "ra22-cc-runtime",
-        "kind": "set",
-        "target_class": "pf_rdma_scope",
-        "execution_group": "cc",
-        "target_role": "ew"
+        "target_class": "pf_rdma_scope"
       },
       "ra22-cc-runtime.cc-algo-slot-0-param-5.value": {
         "path": "/nvidia/cc/algo/slot/[0]/param/[5]",
@@ -358,10 +312,7 @@
           "value": 1200
         },
         "source_feature": "ra22-cc-runtime",
-        "kind": "set",
-        "target_class": "pf_rdma_scope",
-        "execution_group": "cc",
-        "target_role": "ew"
+        "target_class": "pf_rdma_scope"
       },
       "ra22-cc-runtime.cc-algo-slot-0-param-6.value": {
         "path": "/nvidia/cc/algo/slot/[0]/param/[6]",
@@ -369,10 +320,7 @@
           "value": 7000000
         },
         "source_feature": "ra22-cc-runtime",
-        "kind": "set",
-        "target_class": "pf_rdma_scope",
-        "execution_group": "cc",
-        "target_role": "ew"
+        "target_class": "pf_rdma_scope"
       },
       "ra22-cc-runtime.cc-algo-slot-0-param-7.value": {
         "path": "/nvidia/cc/algo/slot/[0]/param/[7]",
@@ -380,10 +328,7 @@
           "value": 15000
         },
         "source_feature": "ra22-cc-runtime",
-        "kind": "set",
-        "target_class": "pf_rdma_scope",
-        "execution_group": "cc",
-        "target_role": "ew"
+        "target_class": "pf_rdma_scope"
       },
       "ra22-cc-runtime.cc-algo-slot-0-param-8.value": {
         "path": "/nvidia/cc/algo/slot/[0]/param/[8]",
@@ -391,10 +336,7 @@
           "value": 250000
         },
         "source_feature": "ra22-cc-runtime",
-        "kind": "set",
-        "target_class": "pf_rdma_scope",
-        "execution_group": "cc",
-        "target_role": "ew"
+        "target_class": "pf_rdma_scope"
       },
       "ra22-cc-runtime.cc-algo-slot-0-param-9.value": {
         "path": "/nvidia/cc/algo/slot/[0]/param/[9]",
@@ -402,10 +344,7 @@
           "value": 524288
         },
         "source_feature": "ra22-cc-runtime",
-        "kind": "set",
-        "target_class": "pf_rdma_scope",
-        "execution_group": "cc",
-        "target_role": "ew"
+        "target_class": "pf_rdma_scope"
       },
       "ra22-cc-runtime.cc-algo-slot-0-param-10.value": {
         "path": "/nvidia/cc/algo/slot/[0]/param/[10]",
@@ -413,10 +352,7 @@
           "value": 0
         },
         "source_feature": "ra22-cc-runtime",
-        "kind": "set",
-        "target_class": "pf_rdma_scope",
-        "execution_group": "cc",
-        "target_role": "ew"
+        "target_class": "pf_rdma_scope"
       },
       "ra22-cc-runtime.cc-algo-slot-0-param-11.value": {
         "path": "/nvidia/cc/algo/slot/[0]/param/[11]",
@@ -424,10 +360,7 @@
           "value": 1
         },
         "source_feature": "ra22-cc-runtime",
-        "kind": "set",
-        "target_class": "pf_rdma_scope",
-        "execution_group": "cc",
-        "target_role": "ew"
+        "target_class": "pf_rdma_scope"
       },
       "ra22-cc-runtime.cc-algo-slot-0-param-12.value": {
         "path": "/nvidia/cc/algo/slot/[0]/param/[12]",
@@ -435,10 +368,7 @@
           "value": 0
         },
         "source_feature": "ra22-cc-runtime",
-        "kind": "set",
-        "target_class": "pf_rdma_scope",
-        "execution_group": "cc",
-        "target_role": "ew"
+        "target_class": "pf_rdma_scope"
       },
       "ra22-cc-runtime.cc-algo-slot-0-param-13.value": {
         "path": "/nvidia/cc/algo/slot/[0]/param/[13]",
@@ -446,10 +376,7 @@
           "value": 0
         },
         "source_feature": "ra22-cc-runtime",
-        "kind": "set",
-        "target_class": "pf_rdma_scope",
-        "execution_group": "cc",
-        "target_role": "ew"
+        "target_class": "pf_rdma_scope"
       },
       "ra22-cc-runtime.cc-algo-slot-0-param-14.value": {
         "path": "/nvidia/cc/algo/slot/[0]/param/[14]",
@@ -457,10 +384,7 @@
           "value": 2097152
         },
         "source_feature": "ra22-cc-runtime",
-        "kind": "set",
-        "target_class": "pf_rdma_scope",
-        "execution_group": "cc",
-        "target_role": "ew"
+        "target_class": "pf_rdma_scope"
       },
       "ra22-cc-runtime.cc-algo-slot-0-param-15.value": {
         "path": "/nvidia/cc/algo/slot/[0]/param/[15]",
@@ -468,10 +392,7 @@
           "value": 2
         },
         "source_feature": "ra22-cc-runtime",
-        "kind": "set",
-        "target_class": "pf_rdma_scope",
-        "execution_group": "cc",
-        "target_role": "ew"
+        "target_class": "pf_rdma_scope"
       },
       "ra22-cc-runtime.cc-algo-slot-0-param-16.value": {
         "path": "/nvidia/cc/algo/slot/[0]/param/[16]",
@@ -479,10 +400,7 @@
           "value": 1
         },
         "source_feature": "ra22-cc-runtime",
-        "kind": "set",
-        "target_class": "pf_rdma_scope",
-        "execution_group": "cc",
-        "target_role": "ew"
+        "target_class": "pf_rdma_scope"
       },
       "ra22-cc-runtime.cc-algo-slot-0-param-17.value": {
         "path": "/nvidia/cc/algo/slot/[0]/param/[17]",
@@ -490,10 +408,7 @@
           "value": 0
         },
         "source_feature": "ra22-cc-runtime",
-        "kind": "set",
-        "target_class": "pf_rdma_scope",
-        "execution_group": "cc",
-        "target_role": "ew"
+        "target_class": "pf_rdma_scope"
       },
       "ra22-cc-runtime.cc-algo-slot-0-param-18.value": {
         "path": "/nvidia/cc/algo/slot/[0]/param/[18]",
@@ -501,10 +416,7 @@
           "value": 0
         },
         "source_feature": "ra22-cc-runtime",
-        "kind": "set",
-        "target_class": "pf_rdma_scope",
-        "execution_group": "cc",
-        "target_role": "ew"
+        "target_class": "pf_rdma_scope"
       },
       "ra22-cc-runtime.cc-algo-slot-0-param-22.value": {
         "path": "/nvidia/cc/algo/slot/[0]/param/[22]",
@@ -512,10 +424,7 @@
           "value": 1
         },
         "source_feature": "ra22-cc-runtime",
-        "kind": "set",
-        "target_class": "pf_rdma_scope",
-        "execution_group": "cc",
-        "target_role": "ew"
+        "target_class": "pf_rdma_scope"
       },
       "ra22-cc-runtime.cc-algo-slot-0-param-23.value": {
         "path": "/nvidia/cc/algo/slot/[0]/param/[23]",
@@ -523,10 +432,7 @@
           "value": 3
         },
         "source_feature": "ra22-cc-runtime",
-        "kind": "set",
-        "target_class": "pf_rdma_scope",
-        "execution_group": "cc",
-        "target_role": "ew"
+        "target_class": "pf_rdma_scope"
       },
       "ra22-cc-runtime.cc-algo-slot-0-param-24.value": {
         "path": "/nvidia/cc/algo/slot/[0]/param/[24]",
@@ -534,10 +440,7 @@
           "value": 1
         },
         "source_feature": "ra22-cc-runtime",
-        "kind": "set",
-        "target_class": "pf_rdma_scope",
-        "execution_group": "cc",
-        "target_role": "ew"
+        "target_class": "pf_rdma_scope"
       },
       "ra22-cc-runtime.cc-algo-slot-0.counters-enabled-enabled": {
         "path": "/nvidia/cc/algo/slot/[0]",
@@ -546,10 +449,7 @@
           "counters-enabled": true
         },
         "source_feature": "ra22-cc-runtime",
-        "kind": "set",
-        "target_class": "pf_rdma_scope",
-        "execution_group": "cc",
-        "target_role": "ew"
+        "target_class": "pf_rdma_scope"
       },
       "spcx-base-linkup.qos.trust-mode": {
         "path": "/nvidia/qos",
@@ -557,11 +457,8 @@
           "trust-mode": "dscp"
         },
         "source_feature": "spcx-base-linkup",
-        "kind": "set",
         "target_class": "pf_netdev_all",
-        "execution_group": "link-event",
-        "scope": "per_device",
-        "target_role": "ew"
+        "scope": "per_device"
       },
       "spcx-base-linkup.qos-pfc.enabled-priorities": {
         "path": "/nvidia/qos/pfc",
@@ -569,11 +466,8 @@
           "enabled-priorities": "3"
         },
         "source_feature": "spcx-base-linkup",
-        "kind": "set",
         "target_class": "pf_netdev_all",
-        "execution_group": "link-event",
-        "scope": "per_device",
-        "target_role": "ew"
+        "scope": "per_device"
       },
       "spcx-base-linkup.cc-np.cnp-dscp": {
         "path": "/nvidia/cc/np",
@@ -581,11 +475,8 @@
           "cnp-dscp": 48
         },
         "source_feature": "spcx-base-linkup",
-        "kind": "set",
         "target_class": "pf_rdma_scope",
-        "execution_group": "link-event",
-        "scope": "per_device",
-        "target_role": "ew"
+        "scope": "per_device"
       },
       "spcx-base-linkup.roce-tos.traffic-class": {
         "path": "/nvidia/roce/tos",
@@ -593,11 +484,8 @@
           "traffic-class": 96
         },
         "source_feature": "spcx-base-linkup",
-        "kind": "set",
         "target_class": "pf_rdma_scope",
-        "execution_group": "link-event",
-        "scope": "per_device",
-        "target_role": "ew"
+        "scope": "per_device"
       },
       "spcx-base-linkup.roce-accl.adaptive-retransmission-adaptive-routing-force-slow-restart-slow-restart-idle-tx-window": {
         "path": "/nvidia/roce/accl",
@@ -609,11 +497,8 @@
           "adaptive-routing-force": true
         },
         "source_feature": "spcx-base-linkup",
-        "kind": "set",
         "target_class": "pf_rdma_scope",
-        "execution_group": "link-event",
-        "scope": "per_device",
-        "target_role": "ew"
+        "scope": "per_device"
       },
       "ra22-cc-global-status.cc-global-status-rp-0.enabled": {
         "path": "/nvidia/cc/global-status/[rp,0]",
@@ -621,11 +506,8 @@
           "enabled": true
         },
         "source_feature": "ra22-cc-global-status",
-        "kind": "set",
         "target_class": "pf_rdma_scope",
-        "execution_group": "link-event",
-        "scope": "per_device",
-        "target_role": "ew"
+        "scope": "per_device"
       },
       "ra22-cc-global-status.cc-global-status-rp-1.enabled": {
         "path": "/nvidia/cc/global-status/[rp,1]",
@@ -633,11 +515,8 @@
           "enabled": true
         },
         "source_feature": "ra22-cc-global-status",
-        "kind": "set",
         "target_class": "pf_rdma_scope",
-        "execution_group": "link-event",
-        "scope": "per_device",
-        "target_role": "ew"
+        "scope": "per_device"
       },
       "ra22-cc-global-status.cc-global-status-rp-2.enabled": {
         "path": "/nvidia/cc/global-status/[rp,2]",
@@ -645,11 +524,8 @@
           "enabled": true
         },
         "source_feature": "ra22-cc-global-status",
-        "kind": "set",
         "target_class": "pf_rdma_scope",
-        "execution_group": "link-event",
-        "scope": "per_device",
-        "target_role": "ew"
+        "scope": "per_device"
       },
       "ra22-cc-global-status.cc-global-status-rp-3.enabled": {
         "path": "/nvidia/cc/global-status/[rp,3]",
@@ -657,11 +533,8 @@
           "enabled": true
         },
         "source_feature": "ra22-cc-global-status",
-        "kind": "set",
         "target_class": "pf_rdma_scope",
-        "execution_group": "link-event",
-        "scope": "per_device",
-        "target_role": "ew"
+        "scope": "per_device"
       },
       "ra22-cc-global-status.cc-global-status-rp-4.enabled": {
         "path": "/nvidia/cc/global-status/[rp,4]",
@@ -669,11 +542,8 @@
           "enabled": true
         },
         "source_feature": "ra22-cc-global-status",
-        "kind": "set",
         "target_class": "pf_rdma_scope",
-        "execution_group": "link-event",
-        "scope": "per_device",
-        "target_role": "ew"
+        "scope": "per_device"
       },
       "ra22-cc-global-status.cc-global-status-rp-5.enabled": {
         "path": "/nvidia/cc/global-status/[rp,5]",
@@ -681,11 +551,8 @@
           "enabled": true
         },
         "source_feature": "ra22-cc-global-status",
-        "kind": "set",
         "target_class": "pf_rdma_scope",
-        "execution_group": "link-event",
-        "scope": "per_device",
-        "target_role": "ew"
+        "scope": "per_device"
       },
       "ra22-cc-global-status.cc-global-status-rp-6.enabled": {
         "path": "/nvidia/cc/global-status/[rp,6]",
@@ -693,11 +560,8 @@
           "enabled": true
         },
         "source_feature": "ra22-cc-global-status",
-        "kind": "set",
         "target_class": "pf_rdma_scope",
-        "execution_group": "link-event",
-        "scope": "per_device",
-        "target_role": "ew"
+        "scope": "per_device"
       },
       "ra22-cc-global-status.cc-global-status-rp-7.enabled": {
         "path": "/nvidia/cc/global-status/[rp,7]",
@@ -705,11 +569,8 @@
           "enabled": true
         },
         "source_feature": "ra22-cc-global-status",
-        "kind": "set",
         "target_class": "pf_rdma_scope",
-        "execution_group": "link-event",
-        "scope": "per_device",
-        "target_role": "ew"
+        "scope": "per_device"
       },
       "ra22-cc-global-status.cc-global-status-np-0.enabled": {
         "path": "/nvidia/cc/global-status/[np,0]",
@@ -717,11 +578,8 @@
           "enabled": true
         },
         "source_feature": "ra22-cc-global-status",
-        "kind": "set",
         "target_class": "pf_rdma_scope",
-        "execution_group": "link-event",
-        "scope": "per_device",
-        "target_role": "ew"
+        "scope": "per_device"
       },
       "ra22-cc-global-status.cc-global-status-np-1.enabled": {
         "path": "/nvidia/cc/global-status/[np,1]",
@@ -729,11 +587,8 @@
           "enabled": true
         },
         "source_feature": "ra22-cc-global-status",
-        "kind": "set",
         "target_class": "pf_rdma_scope",
-        "execution_group": "link-event",
-        "scope": "per_device",
-        "target_role": "ew"
+        "scope": "per_device"
       },
       "ra22-cc-global-status.cc-global-status-np-2.enabled": {
         "path": "/nvidia/cc/global-status/[np,2]",
@@ -741,11 +596,8 @@
           "enabled": true
         },
         "source_feature": "ra22-cc-global-status",
-        "kind": "set",
         "target_class": "pf_rdma_scope",
-        "execution_group": "link-event",
-        "scope": "per_device",
-        "target_role": "ew"
+        "scope": "per_device"
       },
       "ra22-cc-global-status.cc-global-status-np-3.enabled": {
         "path": "/nvidia/cc/global-status/[np,3]",
@@ -753,11 +605,8 @@
           "enabled": true
         },
         "source_feature": "ra22-cc-global-status",
-        "kind": "set",
         "target_class": "pf_rdma_scope",
-        "execution_group": "link-event",
-        "scope": "per_device",
-        "target_role": "ew"
+        "scope": "per_device"
       },
       "ra22-cc-global-status.cc-global-status-np-4.enabled": {
         "path": "/nvidia/cc/global-status/[np,4]",
@@ -765,11 +614,8 @@
           "enabled": true
         },
         "source_feature": "ra22-cc-global-status",
-        "kind": "set",
         "target_class": "pf_rdma_scope",
-        "execution_group": "link-event",
-        "scope": "per_device",
-        "target_role": "ew"
+        "scope": "per_device"
       },
       "ra22-cc-global-status.cc-global-status-np-5.enabled": {
         "path": "/nvidia/cc/global-status/[np,5]",
@@ -777,11 +623,8 @@
           "enabled": true
         },
         "source_feature": "ra22-cc-global-status",
-        "kind": "set",
         "target_class": "pf_rdma_scope",
-        "execution_group": "link-event",
-        "scope": "per_device",
-        "target_role": "ew"
+        "scope": "per_device"
       },
       "ra22-cc-global-status.cc-global-status-np-6.enabled": {
         "path": "/nvidia/cc/global-status/[np,6]",
@@ -789,11 +632,8 @@
           "enabled": true
         },
         "source_feature": "ra22-cc-global-status",
-        "kind": "set",
         "target_class": "pf_rdma_scope",
-        "execution_group": "link-event",
-        "scope": "per_device",
-        "target_role": "ew"
+        "scope": "per_device"
       },
       "ra22-cc-global-status.cc-global-status-np-7.enabled": {
         "path": "/nvidia/cc/global-status/[np,7]",
@@ -801,11 +641,8 @@
           "enabled": true
         },
         "source_feature": "ra22-cc-global-status",
-        "kind": "set",
         "target_class": "pf_rdma_scope",
-        "execution_group": "link-event",
-        "scope": "per_device",
-        "target_role": "ew"
+        "scope": "per_device"
       },
       "ra22-hwmp-data-direct.data-direct.enabled": {
         "path": "/nvidia/data-direct",
@@ -813,11 +650,9 @@
           "enabled": true
         },
         "source_feature": "ra22-hwmp-data-direct",
-        "kind": "set",
         "target_class": "vf_rep",
         "lifecycle": "pre-vf-bind",
         "scope": "per_vf",
-        "execution_group": "vf-lifecycle",
         "condition": {
           "feature": "@params.multiplane_mode == 'hwmp' and @params.nic_type == '1023' and @params.data_direct == True"
         },

--- a/pkg/spectrumx/testdata/semantic/prepare-plan.json
+++ b/pkg/spectrumx/testdata/semantic/prepare-plan.json
@@ -2,7 +2,7 @@
   "plan": {
     "name": "nco-parser-semantic-prepare",
     "family": "spcx",
-    "profile": "hwmp",
+    "profile": "SPX_Multiplane",
     "stage": "prepare",
     "params": {
       "deployment_mode": "host-k8s",
@@ -137,7 +137,7 @@
     ],
     "runtime_ctx": {
       "deployment_mode": "host-k8s",
-      "multiplane_mode": "hwmp",
+      "multiplane_mode": "SPX_Multiplane",
       "esw_multiport": false,
       "num_vfs": 1,
       "post_breakout": true,
@@ -146,16 +146,12 @@
         {
           "rail": 0,
           "rdma_dev": "roce_r0",
-          "control_bdf": "0000:64:00.0",
-          "control_target": "pci/0000:64:00.0",
-          "source": "endpoint_contract"
+          "source": "device_inventory"
         },
         {
           "rail": 1,
           "rdma_dev": "roce_r1",
-          "control_bdf": "0001:15:00.0",
-          "control_target": "pci/0001:15:00.0",
-          "source": "endpoint_contract"
+          "source": "device_inventory"
         }
       ],
       "expected_names": {
@@ -219,15 +215,7 @@
           "cc-steering-ext": "enabled"
         },
         "source_feature": "spcx-base-nvconfig",
-        "kind": "set",
-        "target_class": "pf_netdev_all",
-        "execution_group": "breakout",
-        "reset": {
-          "action": "host-reboot",
-          "owner": "host-operator",
-          "postcondition": "all pending Spectrum-X NVConfig values become current"
-        },
-        "target_role": "ew"
+        "target_class": "pf_netdev_all"
       },
       "spcx-base-nvconfig.cc-config.user-programmable": {
         "path": "/nvidia/cc/config",
@@ -235,15 +223,7 @@
           "user-programmable": true
         },
         "source_feature": "spcx-base-nvconfig",
-        "kind": "set",
-        "target_class": "pf_netdev_all",
-        "execution_group": "breakout",
-        "reset": {
-          "action": "host-reboot",
-          "owner": "host-operator",
-          "postcondition": "all pending Spectrum-X NVConfig values become current"
-        },
-        "target_role": "ew"
+        "target_class": "pf_netdev_all"
       },
       "ra22-hwmp-breakout-delta.pci.num-pfs": {
         "path": "/nvidia/pci",
@@ -251,15 +231,7 @@
           "num-pfs": 2
         },
         "source_feature": "ra22-hwmp-breakout-delta",
-        "kind": "set",
-        "target_class": "pf_netdev_all",
-        "execution_group": "breakout",
-        "reset": {
-          "action": "host-reboot",
-          "owner": "host-operator",
-          "postcondition": "post-breakout PF topology and XPlane NVConfig become current"
-        },
-        "target_role": "ew"
+        "target_class": "pf_netdev_all"
       },
       "ra22-hwmp-breakout-delta.multiplane.num-planes": {
         "path": "/nvidia/multiplane",
@@ -267,15 +239,7 @@
           "num-planes": 2
         },
         "source_feature": "ra22-hwmp-breakout-delta",
-        "kind": "set",
-        "target_class": "pf_netdev_all",
-        "execution_group": "breakout",
-        "reset": {
-          "action": "host-reboot",
-          "owner": "host-operator",
-          "postcondition": "post-breakout PF topology and XPlane NVConfig become current"
-        },
-        "target_role": "ew"
+        "target_class": "pf_netdev_all"
       },
       "ra22-hwmp-breakout-delta.link-breakout-module-0-port-1.lanes": {
         "path": "/nvidia/link/breakout/module/[0]/port/[1]",
@@ -292,14 +256,7 @@
           ]
         },
         "source_feature": "ra22-hwmp-breakout-delta",
-        "kind": "set",
         "target_class": "pf_netdev_all",
-        "execution_group": "breakout",
-        "reset": {
-          "action": "host-reboot",
-          "owner": "host-operator",
-          "postcondition": "post-breakout PF topology and XPlane NVConfig become current"
-        },
         "condition": {
           "knob": "@params.nic_type == '1023'"
         },
@@ -309,8 +266,7 @@
             "ConnectX-8"
           ],
           "platform_type": "gb300"
-        },
-        "target_role": "ew"
+        }
       },
       "ra22-hwmp-breakout-delta.link-breakout-module-0-port-255.lanes": {
         "path": "/nvidia/link/breakout/module/[0]/port/[255]",
@@ -327,14 +283,7 @@
           ]
         },
         "source_feature": "ra22-hwmp-breakout-delta",
-        "kind": "set",
         "target_class": "pf_netdev_all",
-        "execution_group": "breakout",
-        "reset": {
-          "action": "host-reboot",
-          "owner": "host-operator",
-          "postcondition": "post-breakout PF topology and XPlane NVConfig become current"
-        },
         "condition": {
           "knob": "@params.nic_type == '1023'"
         },
@@ -344,8 +293,7 @@
             "ConnectX-8"
           ],
           "platform_type": "gb300"
-        },
-        "target_role": "ew"
+        }
       },
       "ra22-hwmp-prepare-delta.link-policy.keep-eth-link-up": {
         "path": "/nvidia/link/policy",
@@ -353,15 +301,7 @@
           "keep-eth-link-up": false
         },
         "source_feature": "ra22-hwmp-prepare-delta",
-        "kind": "set",
-        "target_class": "pf_netdev_all",
-        "execution_group": "breakout",
-        "reset": {
-          "action": "device-reset",
-          "owner": "DMS-or-operator",
-          "postcondition": "pending value becomes current"
-        },
-        "target_role": "ew"
+        "target_class": "pf_netdev_all"
       },
       "ra22-hwmp-prepare-delta.multiplane.load-balance-mode": {
         "path": "/nvidia/multiplane",
@@ -369,15 +309,7 @@
           "load-balance-mode": "transport"
         },
         "source_feature": "ra22-hwmp-prepare-delta",
-        "kind": "set",
-        "target_class": "pf_netdev_all",
-        "execution_group": "breakout",
-        "reset": {
-          "action": "device-reset",
-          "owner": "DMS-or-operator",
-          "postcondition": "pending value becomes current"
-        },
-        "target_role": "ew"
+        "target_class": "pf_netdev_all"
       },
       "ra22-hwmp-prepare-delta.lag.resource-allocation": {
         "path": "/nvidia/lag",
@@ -385,15 +317,7 @@
           "resource-allocation": "pre-allocation"
         },
         "source_feature": "ra22-hwmp-prepare-delta",
-        "kind": "set",
-        "target_class": "pf_netdev_all",
-        "execution_group": "breakout",
-        "reset": {
-          "action": "device-reset",
-          "owner": "DMS-or-operator",
-          "postcondition": "pending value becomes current"
-        },
-        "target_role": "ew"
+        "target_class": "pf_netdev_all"
       },
       "spcx-hwmp-sriov-nvconfig.pci-sriov.enabled-max-vfs": {
         "path": "/nvidia/pci/sriov",
@@ -402,15 +326,7 @@
           "max-vfs": 1
         },
         "source_feature": "spcx-hwmp-sriov-nvconfig",
-        "kind": "set",
-        "target_class": "pf_netdev_all",
-        "execution_group": "breakout",
-        "reset": {
-          "action": "device-reset",
-          "owner": "DMS-or-operator",
-          "postcondition": "pending value becomes current"
-        },
-        "target_role": "ew"
+        "target_class": "pf_netdev_all"
       },
       "ra22-hwmp-nvconfig-delta.link-type.value": {
         "path": "/nvidia/link/type",
@@ -418,14 +334,6 @@
           "value": "ETH"
         },
         "source_feature": "ra22-hwmp-nvconfig-delta",
-        "kind": "set",
-        "execution_group": "breakout",
-        "reset": {
-          "action": "device-reset",
-          "owner": "DMS-or-operator",
-          "postcondition": "pending value becomes current"
-        },
-        "target_role": "ew",
         "target_class": "pf_netdev_all"
       },
       "ra22-hwmp-nvconfig-delta.roce-rtt.dscp-dscp-mode": {
@@ -435,14 +343,6 @@
           "dscp-mode": "fixed"
         },
         "source_feature": "ra22-hwmp-nvconfig-delta",
-        "kind": "set",
-        "execution_group": "breakout",
-        "reset": {
-          "action": "device-reset",
-          "owner": "DMS-or-operator",
-          "postcondition": "pending value becomes current"
-        },
-        "target_role": "ew",
         "target_class": "pf_netdev_all"
       },
       "ra22-hwmp-nvconfig-delta.misc-parser.flex-parser-profile": {
@@ -451,14 +351,6 @@
           "flex-parser-profile": 10
         },
         "source_feature": "ra22-hwmp-nvconfig-delta",
-        "kind": "set",
-        "execution_group": "breakout",
-        "reset": {
-          "action": "device-reset",
-          "owner": "DMS-or-operator",
-          "postcondition": "pending value becomes current"
-        },
-        "target_role": "ew",
         "target_class": "pf_netdev_all"
       },
       "ra22-hwmp-nvconfig-delta.pci.rde-disable": {
@@ -467,14 +359,6 @@
           "rde-disable": true
         },
         "source_feature": "ra22-hwmp-nvconfig-delta",
-        "kind": "set",
-        "execution_group": "breakout",
-        "reset": {
-          "action": "device-reset",
-          "owner": "DMS-or-operator",
-          "postcondition": "pending value becomes current"
-        },
-        "target_role": "ew",
         "target_class": "pf_netdev_all"
       },
       "ra22-hwmp-nvconfig-delta.pci-sriov.vf-log-bar-size": {
@@ -483,14 +367,6 @@
           "vf-log-bar-size": 5
         },
         "source_feature": "ra22-hwmp-nvconfig-delta",
-        "kind": "set",
-        "execution_group": "breakout",
-        "reset": {
-          "action": "device-reset",
-          "owner": "DMS-or-operator",
-          "postcondition": "pending value becomes current"
-        },
-        "target_role": "ew",
         "target_class": "pf_netdev_all"
       }
     },


### PR DESCRIPTION
## Summary

- align generated target maps and planner invocation with the DOCA 3.6 contract: schema v1, hexadecimal device IDs, public profile names, and BP_STATE_DIR
- accept git-archive global PAX metadata and parse planner JSON from stdout separately from bounded stderr diagnostics
- align semantic parsing and target resolution with public doSPCX plans, including omitted set kinds, authoritative operation references, and plane-zero RDMA bond targets
- validate the exact generated device topology and compile the semantic execution policy before accepting or caching a plan
- retain fanout ordering and reject eSwitch/per-VF operations if they appear in an executable group

This remains generation and parsing only; it does not execute plan operations. The final shape does not add another stored compiled-plan representation, and the overall patch is net-negative by 73 lines after reducing the test fixtures.

## Validation

- go test ./pkg/dmscli ./pkg/spectrumx -count=1 -timeout 5m
- go build ./...
- go vet ./pkg/dmscli ./pkg/spectrumx
- make lint
- git diff --check
- live configure-plan generation succeeded with the DOCA 3.6 daemon image

The full repository suite still has a pre-existing controller timing failure that reproduces on upstream/main; all affected package tests pass.

## Follow-up architecture before execution

- execute plan groups in semantic order with per-step barriers while preserving per-device status reporting
- replace BDF-sorted rail inference with authoritative topology input, and make platform/RA-version ownership explicit
- narrow the Blueprint ConfigMap trust boundary and preserve the last known good installed bundle
- define the exact XPath query/set JSON contract, share stream-safe dms-cli response handling, and add a parsed in-memory plan cache
