### PR TITLE
fix: fail runtime validation when link has no carrier

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ The name of the device combines the node name, device type and its PCI device ad
 
 `FirmwareUpdateInProgress` status condition can be used for tracking the state of the FW validation/update on a specific device. If an error occurs during FW update, it will be reflected in this field.
 `ConfigUpdateInProgress` status condition can be used for tracking the state of the FW configuration update on a specific device. If an error occurs during FW configuration update, it will be reflected in this field.
+Before validating runtime configuration, the configuration daemon checks every discovered network interface for carrier. An interface reported as `NO-CARRIER` causes runtime validation to fail and is reflected in `ConfigUpdateInProgress` with reason `RuntimeConfigUpdateFailed` until carrier is restored.
 
 for more information refer to [api-reference](docs/api-reference.md).
 

--- a/internal/controller/nicdevice_controller_test.go
+++ b/internal/controller/nicdevice_controller_test.go
@@ -584,6 +584,28 @@ var _ = Describe("NicDeviceReconciler", func() {
 			configurationManager.AssertExpectations(GinkgoT())
 			maintenanceManager.AssertExpectations(GinkgoT())
 		})
+		It("Should reflect a NO-CARRIER runtime config error in status and not release maintenance", func() {
+			errorText := "network interface interface1 for device port 0000:03:00.1 has NO-CARRIER"
+			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(false, false, nil, nil)
+			configurationManager.On("ApplyRuntimeConfiguration", mock.Anything, mock.Anything).Return((*types.RuntimeConfigurationApplyResult)(nil), errors.New(errorText))
+
+			createDevice(false, nil)
+
+			Eventually(getDeviceConditions, timeout).Should(testutils.MatchCondition(metav1.Condition{
+				Type:    consts.ConfigUpdateInProgressCondition,
+				Status:  metav1.ConditionFalse,
+				Reason:  consts.RuntimeConfigUpdateFailedReason,
+				Message: errorText,
+			}))
+
+			maintenanceManager.AssertNotCalled(GinkgoT(), "ScheduleMaintenance", mock.Anything)
+			maintenanceManager.AssertNotCalled(GinkgoT(), "MaintenanceAllowed", mock.Anything)
+			configurationManager.AssertNotCalled(GinkgoT(), "ApplyNVConfiguration", mock.Anything, mock.Anything, mock.Anything)
+			maintenanceManager.AssertNotCalled(GinkgoT(), "Reboot")
+			maintenanceManager.AssertNotCalled(GinkgoT(), "ReleaseMaintenance", mock.Anything)
+			configurationManager.AssertExpectations(GinkgoT())
+			maintenanceManager.AssertExpectations(GinkgoT())
+		})
 		It("Should request maintenance if runtime config needs to be reset", func() {
 			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(false, false, nil, nil)
 			maintenanceManager.On("ScheduleMaintenance", mock.Anything).Return(nil)

--- a/pkg/configuration/configvalidation.go
+++ b/pkg/configuration/configvalidation.go
@@ -360,6 +360,10 @@ func (v *configValidationImpl) RuntimeConfigApplied(device *v1alpha1.NicDevice) 
 	ports := device.Status.Ports
 	desired := v.CalculateDesiredRuntimeConfig(device)
 
+	if err := v.validatePortCarrierState(device); err != nil {
+		return false, err
+	}
+
 	if desired.MaxReadRequestSize != 0 {
 		for _, port := range ports {
 			actualMaxReadReqSize, err := v.utils.GetMaxReadRequestSize(port.PCI)
@@ -425,6 +429,27 @@ func (v *configValidationImpl) RuntimeConfigApplied(device *v1alpha1.NicDevice) 
 	}
 
 	return true, nil
+}
+
+func (v *configValidationImpl) validatePortCarrierState(device *v1alpha1.NicDevice) error {
+	for _, port := range device.Status.Ports {
+		if port.NetworkInterface == "" {
+			continue
+		}
+
+		noCarrier, err := v.utils.HasNoCarrier(port.NetworkInterface)
+		if err != nil {
+			log.Log.Error(err, "can't check link state", "device", device.Name, "port", port.PCI)
+			return err
+		}
+		if noCarrier {
+			return fmt.Errorf(
+				"network interface %s for device port %s has NO-CARRIER",
+				port.NetworkInterface, port.PCI)
+		}
+	}
+
+	return nil
 }
 
 // CalculateDesiredRuntimeConfig returns desired values for runtime config

--- a/pkg/configuration/configvalidation_test.go
+++ b/pkg/configuration/configvalidation_test.go
@@ -1127,13 +1127,26 @@ var _ = Describe("ConfigValidationImpl", func() {
 	})
 
 	Describe("RuntimeConfigApplied", func() {
+		type linkStateResult struct {
+			noCarrier bool
+			err       error
+		}
+
 		var (
-			device  *v1alpha1.NicDevice
-			applied bool
-			err     error
+			device           *v1alpha1.NicDevice
+			applied          bool
+			err              error
+			linkStateResults map[string]linkStateResult
 		)
 
 		BeforeEach(func() {
+			linkStateResults = map[string]linkStateResult{}
+			mockConfigurationUtils.On("HasNoCarrier", mock.Anything).Return(
+				func(interfaceName string) (bool, error) {
+					result := linkStateResults[interfaceName]
+					return result.noCarrier, result.err
+				},
+			)
 			device = &v1alpha1.NicDevice{
 				Spec: v1alpha1.NicDeviceSpec{
 					Configuration: &v1alpha1.NicDeviceConfigurationSpec{
@@ -1149,6 +1162,34 @@ var _ = Describe("ConfigValidationImpl", func() {
 					},
 				},
 			}
+		})
+
+		Context("when a port has NO-CARRIER", func() {
+			BeforeEach(func() {
+				linkStateResults["interface1"] = linkStateResult{noCarrier: true}
+			})
+
+			It("should return an error before checking the runtime settings", func() {
+				applied, err = validator.RuntimeConfigApplied(device)
+				Expect(err).To(MatchError("network interface interface1 for device port 0000:03:00.1 has NO-CARRIER"))
+				Expect(applied).To(BeFalse())
+				mockConfigurationUtils.AssertNotCalled(GinkgoT(), "GetMaxReadRequestSize", mock.Anything)
+				mockConfigurationUtils.AssertNotCalled(GinkgoT(), "GetQoSSettings", mock.Anything, mock.Anything)
+			})
+		})
+
+		Context("when checking a port's link state fails", func() {
+			linkStateErr := errors.New("failed to query link")
+
+			BeforeEach(func() {
+				linkStateResults["interface0"] = linkStateResult{err: linkStateErr}
+			})
+
+			It("should return the link state error", func() {
+				applied, err = validator.RuntimeConfigApplied(device)
+				Expect(err).To(MatchError(linkStateErr))
+				Expect(applied).To(BeFalse())
+			})
 		})
 
 		Context("when desired runtime config is applied correctly on all ports", func() {

--- a/pkg/configuration/mocks/ConfigurationUtils.go
+++ b/pkg/configuration/mocks/ConfigurationUtils.go
@@ -32,6 +32,34 @@ func (_m *ConfigurationUtils) GetLinkType(name string) string {
 	return r0
 }
 
+// HasNoCarrier provides a mock function with given fields: name
+func (_m *ConfigurationUtils) HasNoCarrier(name string) (bool, error) {
+	ret := _m.Called(name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for HasNoCarrier")
+	}
+
+	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (bool, error)); ok {
+		return rf(name)
+	}
+	if rf, ok := ret.Get(0).(func(string) bool); ok {
+		r0 = rf(name)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(name)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetMaxReadRequestSize provides a mock function with given fields: pciAddr
 func (_m *ConfigurationUtils) GetMaxReadRequestSize(pciAddr string) (int, error) {
 	ret := _m.Called(pciAddr)

--- a/pkg/configuration/utils.go
+++ b/pkg/configuration/utils.go
@@ -19,6 +19,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"net"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -44,6 +45,8 @@ var (
 type ConfigurationUtils interface {
 	// GetLinkType return the link type of the net device (Ethernet / Infiniband)
 	GetLinkType(name string) string
+	// HasNoCarrier returns whether the net device is administratively up without a running carrier
+	HasNoCarrier(name string) (bool, error)
 	// GetPCILinkSpeed return PCI bus speed in GT/s
 	GetPCILinkSpeed(pciAddr string) (int, error)
 	// GetMaxReadRequestSize returns MaxReadRequest size for PCI device
@@ -111,6 +114,22 @@ func (d *configurationUtils) GetLinkType(name string) string {
 		return ""
 	}
 	return encapTypeToLinkType(link.Attrs().EncapType)
+}
+
+// HasNoCarrier returns whether the net device is administratively up without a running carrier.
+// This matches the condition rendered as NO-CARRIER by iproute2.
+func (d *configurationUtils) HasNoCarrier(name string) (bool, error) {
+	log.Log.Info("ConfigurationUtils.HasNoCarrier()", "name", name)
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return false, fmt.Errorf("failed to get link state for network interface %s: %w", name, err)
+	}
+
+	return hasNoCarrier(link.Attrs().Flags), nil
+}
+
+func hasNoCarrier(flags net.Flags) bool {
+	return flags&net.FlagUp != 0 && flags&net.FlagRunning == 0
 }
 
 // GetPCILinkSpeed return PCI bus speed in GT/s

--- a/pkg/configuration/utils_test.go
+++ b/pkg/configuration/utils_test.go
@@ -18,6 +18,7 @@ package configuration
 import (
 	"errors"
 	"fmt"
+	"net"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -29,6 +30,17 @@ import (
 )
 
 var _ = Describe("ConfigurationUtils", func() {
+	Describe("hasNoCarrier", func() {
+		DescribeTable("detecting the iproute2 NO-CARRIER flag state",
+			func(flags net.Flags, expected bool) {
+				Expect(hasNoCarrier(flags)).To(Equal(expected))
+			},
+			Entry("administratively up without a running carrier", net.FlagUp, true),
+			Entry("administratively up with a running carrier", net.FlagUp|net.FlagRunning, false),
+			Entry("administratively down", net.Flags(0), false),
+		)
+	})
+
 	Describe("GetPCILinkSpeed", func() {
 		var (
 			h        *configurationUtils


### PR DESCRIPTION
## Summary

- detect Linux `NO-CARRIER` state before validating runtime configuration values
- return an interface- and PCI-specific error so runtime apply stops cleanly
- surface the failure through `ConfigUpdateInProgress` with reason `RuntimeConfigUpdateFailed`
- preserve the original documentation and regression coverage

## Verification

- `go test ./pkg/configuration/... -count=1 -timeout 10m`
- `go build ./...`
- `make lint`
- targeted controller envtest for the new NO-CARRIER status path

A full local `make test` run passed all non-controller packages and the new test, but hit existing timing-sensitive controller specs on the 26.7 release branch.

This is the `network-operator-26.7.x` backport of #430.