### PR TITLE
refactor: simplify doSPCX plan compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,11 +223,12 @@ Spectrum-X profiles can configure NICs with multiple data planes. Available mode
 starts its existing concurrent per-device NV apply, it calls `PreparePlan` once for the node's
 Spectrum-X device group with the `prepare` stage. It does the same with the `configure` stage before
 the existing concurrent runtime apply. Plan preparation never executes generated plan operations.
-`GetPreparedPlan` parses the host-k8s `plan.semantic.groups` contract and returns its validated
-semantic source to library consumers. Plans are accepted only when `BuildDMSOperationPlan` can
-compile them into an ordered, target-resolved operation plan. That compiled form includes current
-plus pending queries for prepare-stage NVConfig and retains the planner's fanout order. This
-translation remains execution-free. Semantic group references are authoritative; public doSPCX
+`PreparePlan` parses the host-k8s `plan.semantic.groups` contract once and caches its ordered,
+target-resolved operation groups in memory. `GetPreparedPlan` only validates the requesting
+device's inputs and membership against that cache; it does not reread or reparse files for every
+per-device apply. The compiled form includes current plus pending queries for prepare-stage
+NVConfig and retains the planner's fanout order. This translation remains execution-free. Semantic
+group references are authoritative; public doSPCX
 operations do not need to repeat group or network-role fields, and an omitted operation kind means
 `set`, matching DMS. Configure groups `eswitch` and `vf-lifecycle` are intentionally excluded from
 the current operation plan and reported as skipped; unknown groups fail closed.
@@ -258,7 +259,8 @@ capability.
 
 Each stage stores a flat metadata document containing only the planner inputs, including the
 platform, Spectrum-X settings, planner parameters, doSPCX data archive digest, and target-map
-digest. A later `PreparePlan` call reuses the saved plan when that metadata still matches, the
+digest. Repeated calls in the same process reuse the in-memory plan. After a process restart,
+`PreparePlan` loads and compiles the saved plan once when that metadata still matches, the
 target-map digest is unchanged, the generated devices exactly match the target-map-derived BDF,
 DMS-target, device-ID, rail, plane, and role set, and the semantic operations compile under NCO's
 execution policy. Any input change or invalid saved artifact regenerates

--- a/docs/nic-configuration-library.md
+++ b/docs/nic-configuration-library.md
@@ -400,9 +400,12 @@ dms-cli --json -t pci/<BDF> /nvidia/link/physical admin-status=down \
 
 SET value keys are sorted for deterministic command lines. Scalar leaf-list
 values use repeated assignments (`lanes=0 lanes=1 ...`), avoiding the current
-DMS compact-list parsing limitation. GET normalizes flat, backend-wrapped, and
-container-keyed JSON responses and surfaces partial and `not-supported` results
-as errors while preserving their structured result.
+DMS compact-list parsing limitation. GET decodes the public `dms-cli --json`
+contract: one container returns a flat values object and a batch returns objects
+keyed by container path. SET success returns `{ "status": "ok" }`. For partial
+GETs, successful leaves are merged into `Values`; SET results retain both the
+`successes` and `failures` maps. Both operations retain `status`, `error_msg`,
+and `error_code` while also returning the command error.
 
 Blueprint planning uses this command shape:
 
@@ -414,10 +417,10 @@ dms-cli --json /nvidia/blueprints/plan profile=<profile> name=<name> \
 
 For Blueprints planning, the wrapper sets `BLUEPRINTS_ROOT` and the DMS
 `BP_STATE_DIR` variable only on the `dms-cli` child process.
-Planner stdout and stderr are captured separately because stdout is the JSON
-protocol while DMS diagnostics are written to stderr. Successful calls log the
+All JSON-based `dms-cli` wrappers capture stdout and stderr separately because
+stdout is the protocol while DMS diagnostics are written to stderr. Successful calls log the
 exact command, result status, and plan size without repeating the embedded plan;
-failure output is bounded before logging.
+failure output is bounded before logging or adding it to a returned error.
 `SpectrumXConfigManager` supplies the fixed `/opt/nvidia/blueprints` path and
 creates its command executor internally. The executable DMS Blueprints action
 tree remains part of the daemon image. Authored doSPCX data is supplied
@@ -471,10 +474,10 @@ const (
 )
 
 type Plan struct {
-    Name     string
-    Stage    PlanStage
-    JSON     json.RawMessage
-    Semantic *SemanticPlan
+    Name          string
+    Stage         PlanStage
+    Groups        []DMSOperationGroup
+    SkippedGroups []SkippedSemanticGroup
 }
 
 type PlanManager interface {
@@ -506,18 +509,17 @@ image is not removed when no ConfigMap bundle was installed.
 
 `PreparePlan` generates or reuses the stage-specific plan for the supplied
 Spectrum-X device group. It is a no-op when none of the supplied devices enable
-Spectrum-X. `GetPreparedPlan` retrieves the persisted plan without invoking
-`dms-cli`, and rejects it unless its cached inputs, exact generated device
-topology, and target map still match the supplied device. It also parses the
-host-k8s `plan.semantic.groups` surface and resolves every `operation_ref`
-through `plan.operations`. A generated or cached plan is accepted only when
-`BuildDMSOperationPlan` can compile its execution policy and targets. The parser
-preserves group and operation ordering, including repeated writes, and does not
-inspect bare-metal steps, services, or artifacts.
+Spectrum-X. It parses the host-k8s `plan.semantic.groups` surface, resolves every
+`operation_ref` through `plan.operations`, and caches the resulting `Plan` in
+memory. A persisted plan is validated and compiled once after process startup;
+later `PreparePlan` calls reuse memory while the inputs match. `GetPreparedPlan`
+does not access the filesystem or invoke `dms-cli`; it rejects the request unless
+the cached inputs and target-map membership match the supplied device.
 
-`SemanticPlan.BuildDMSOperationPlan(ctx)` resolves `pf_netdev_all` and
-`pf_rdma_scope` to target-specific query and SET batches without executing
-them. Queries represent the final desired state; prepare-stage queries include
+Compilation resolves `pf_netdev_all` and `pf_rdma_scope` to target-specific
+query and SET batches without executing them. It preserves group and operation
+ordering, including repeated writes, and does not inspect bare-metal steps,
+services, or artifacts. Queries represent the final desired state; prepare-stage queries include
 both the current and `-pending` leaves used by the doSPCX NVConfig gate. SET
 operations preserve the complete transition sequence. Public operations may
 omit `kind` (`set` is the DMS default), `execution_group`, and `target_role`;
@@ -967,9 +969,9 @@ Methods support two modes via option structs:
 ### Command Execution Logging
 
 External commands normally use `cmd.CombinedOutput()` and log at `log.Log.V(2)`.
-JSON protocol commands that can emit DMS diagnostics on stderr, such as
-Blueprint plan generation, capture the streams separately and parse stdout
-only. Output is not duplicated in error-level logs.
+JSON protocol commands that can emit DMS diagnostics on stderr capture the
+streams separately and parse stdout only. Diagnostic content is bounded in both
+logs and returned errors. Output is not duplicated in error-level logs.
 
 ### Batch Operations
 

--- a/pkg/dmscli/blueprints.go
+++ b/pkg/dmscli/blueprints.go
@@ -26,12 +26,11 @@ import (
 
 	"github.com/go-logr/logr"
 	execUtils "k8s.io/utils/exec"
+
+	"github.com/Mellanox/nic-configuration-operator/pkg/utils"
 )
 
-const (
-	blueprintsPlanPath       = "/nvidia/blueprints/plan"
-	maxBlueprintLogOutputLen = 4096
-)
+const blueprintsPlanPath = "/nvidia/blueprints/plan"
 
 // BlueprintPlanRequest describes one DMS Blueprints planning action.
 type BlueprintPlanRequest struct {
@@ -85,22 +84,17 @@ func GenerateBlueprintPlan(
 	environment := environmentWithOverride(os.Environ(), "BLUEPRINTS_ROOT", request.BlueprintsRoot)
 	environment = environmentWithOverride(environment, "BP_STATE_DIR", request.BlueprintsStateDir)
 	command.SetEnv(environment)
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	command.SetStdout(&stdout)
-	command.SetStderr(&stderr)
-	commandErr := command.Run()
+	output, commandErr := utils.RunCommandWithStreams(command)
 	commandAndArgs := append([]string{dmsCLIExecutable}, args...)
 
-	result, decodeErr := decodeBlueprintPlanResult(stdout.Bytes())
-	logBlueprintPlanResult(ctx, request, commandAndArgs, result, stdout.String(), stderr.String(), commandErr, decodeErr)
+	result, decodeErr := decodeBlueprintPlanResult(output.Stdout)
+	logBlueprintPlanResult(ctx, request, commandAndArgs, result, output, commandErr, decodeErr)
 	if commandErr != nil {
-		detail := strings.TrimSpace(stderr.String())
-		if result != nil && result.ErrorMessage != "" {
-			detail = result.ErrorMessage
-		} else if detail == "" {
-			detail = strings.TrimSpace(stdout.String())
+		structured := ""
+		if result != nil {
+			structured = result.ErrorMessage
 		}
+		detail := commandErrorDetail(output.Stdout, output.Stderr, structured)
 		if detail != "" {
 			return result, fmt.Errorf("generate Blueprint plan %q: %w: %s", request.Name, commandErr, detail)
 		}
@@ -110,7 +104,7 @@ func GenerateBlueprintPlan(
 		return nil, fmt.Errorf("decode Blueprint plan result %q: %w", request.Name, decodeErr)
 	}
 	if result.Status != "" && result.Status != "ok" {
-		detail := result.ErrorMessage
+		detail := boundedCommandOutput([]byte(result.ErrorMessage))
 		if detail == "" {
 			detail = fmt.Sprintf("unexpected status %q", result.Status)
 		}
@@ -124,8 +118,7 @@ func logBlueprintPlanResult(
 	request BlueprintPlanRequest,
 	command []string,
 	result *BlueprintPlanResult,
-	stdout string,
-	stderr string,
+	output utils.CommandOutput,
 	commandErr error,
 	decodeErr error,
 ) {
@@ -141,19 +134,12 @@ func logBlueprintPlanResult(
 			"planJSONBytes", len(result.PlanJSON))
 	}
 	if commandErr != nil || decodeErr != nil {
-		fields = append(fields, "stdout", boundedBlueprintLogOutput(stdout))
+		fields = append(fields, "stdout", boundedCommandOutput(output.Stdout))
 	}
-	if stderr != "" {
-		fields = append(fields, "stderr", boundedBlueprintLogOutput(stderr))
+	if len(output.Stderr) > 0 {
+		fields = append(fields, "stderr", boundedCommandOutput(output.Stderr))
 	}
 	logr.FromContextOrDiscard(ctx).V(2).Info("command output", fields...)
-}
-
-func boundedBlueprintLogOutput(output string) string {
-	if len(output) <= maxBlueprintLogOutputLen {
-		return output
-	}
-	return output[:maxBlueprintLogOutputLen] + "... [truncated]"
 }
 
 func validateBlueprintPlanRequest(request BlueprintPlanRequest) error {

--- a/pkg/dmscli/blueprints_test.go
+++ b/pkg/dmscli/blueprints_test.go
@@ -120,11 +120,11 @@ var _ = Describe("Blueprint plan", func() {
 		Expect(entries[0].fields).NotTo(HaveKey("stdout"))
 		Expect(entries[0].fields).To(HaveKeyWithValue("status", "ok"))
 		Expect(entries[0].fields).To(HaveKeyWithValue("planJSONBytes", len(result.PlanJSON)))
-		Expect(entries[0].fields).To(HaveKeyWithValue("stderr", string(stderr)))
+		Expect(entries[0].fields).To(HaveKeyWithValue("stderr", strings.TrimSpace(string(stderr))))
 	})
 
 	It("bounds malformed stdout in diagnostics", func() {
-		stdout := []byte("not-json-" + strings.Repeat("x", maxBlueprintLogOutputLen))
+		stdout := []byte("not-json-" + strings.Repeat("x", maxCommandOutputLen))
 		executor := fakeExecutor(stdout, nil, &commands)
 		entries := []capturedLogEntry{}
 		ctx := logr.NewContext(context.Background(), logr.New(&capturingLogSink{entries: &entries}))
@@ -133,8 +133,20 @@ var _ = Describe("Blueprint plan", func() {
 
 		Expect(err).To(HaveOccurred())
 		Expect(entries).To(HaveLen(1))
-		Expect(entries[0].fields["stdout"]).To(HaveLen(maxBlueprintLogOutputLen + len("... [truncated]")))
+		Expect(entries[0].fields["stdout"]).To(HaveLen(maxCommandOutputLen + len("... [truncated]")))
 		Expect(entries[0].fields["stdout"]).To(HaveSuffix("... [truncated]"))
+	})
+
+	It("bounds raw command output returned in errors", func() {
+		commandErr := errors.New("exit status 1")
+		stdout := []byte(strings.Repeat("x", maxCommandOutputLen+100))
+		executor := fakeExecutor(stdout, commandErr, &commands)
+
+		_, err := GenerateBlueprintPlan(context.Background(), executor, newRequest())
+
+		Expect(err).To(HaveOccurred())
+		Expect(len(err.Error())).To(BeNumerically("<", maxCommandOutputLen+300))
+		Expect(err.Error()).To(ContainSubstring("... [truncated]"))
 	})
 
 	It("returns the structured planner error", func() {

--- a/pkg/dmscli/command.go
+++ b/pkg/dmscli/command.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dmscli
+
+import "strings"
+
+const maxCommandOutputLen = 4096
+
+func boundedCommandOutput(output []byte) string {
+	trimmed := strings.TrimSpace(string(output))
+	if len(trimmed) <= maxCommandOutputLen {
+		return trimmed
+	}
+	return trimmed[:maxCommandOutputLen] + "... [truncated]"
+}
+
+func commandErrorDetail(stdout, stderr []byte, structured string) string {
+	if structured != "" {
+		return boundedCommandOutput([]byte(structured))
+	}
+	if detail := boundedCommandOutput(stderr); detail != "" {
+		return detail
+	}
+	return boundedCommandOutput(stdout)
+}

--- a/pkg/dmscli/nvconfig.go
+++ b/pkg/dmscli/nvconfig.go
@@ -25,6 +25,8 @@ import (
 
 	"github.com/go-logr/logr"
 	execUtils "k8s.io/utils/exec"
+
+	"github.com/Mellanox/nic-configuration-operator/pkg/utils"
 )
 
 const (
@@ -88,19 +90,21 @@ func ApplyNVConfig(ctx context.Context, execInterface execUtils.Interface, reque
 		nvConfigApplyPath,
 	}
 	command := execInterface.CommandContext(ctx, dmsCLIExecutable, args...)
-	output, commandErr := command.CombinedOutput()
+	output, commandErr := utils.RunCommandWithStreams(command)
 	commandAndArgs := append([]string{dmsCLIExecutable}, args...)
 	logr.FromContextOrDiscard(ctx).V(2).Info("command output",
 		"command", commandAndArgs,
 		"target", request.Target,
-		"output", string(output))
+		"stdout", boundedCommandOutput(output.Stdout),
+		"stderr", boundedCommandOutput(output.Stderr))
 
-	result, decodeErr := decodeApplyNVConfigResult(output)
+	result, decodeErr := decodeApplyNVConfigResult(output.Stdout)
 	if commandErr != nil {
-		detail := strings.TrimSpace(string(output))
-		if result != nil && result.ErrorMessage != "" {
-			detail = result.ErrorMessage
+		structured := ""
+		if result != nil {
+			structured = result.ErrorMessage
 		}
+		detail := commandErrorDetail(output.Stdout, output.Stderr, structured)
 		if detail != "" {
 			return result, fmt.Errorf("apply NVConfig to target %q: %w: %s", request.Target, commandErr, detail)
 		}
@@ -110,7 +114,7 @@ func ApplyNVConfig(ctx context.Context, execInterface execUtils.Interface, reque
 		return nil, fmt.Errorf("decode NVConfig apply result for target %q: %w", request.Target, decodeErr)
 	}
 	if result.Status != "ok" {
-		detail := result.ErrorMessage
+		detail := boundedCommandOutput([]byte(result.ErrorMessage))
 		if detail == "" {
 			detail = fmt.Sprintf("unexpected status %q", result.Status)
 		}

--- a/pkg/dmscli/nvconfig_test.go
+++ b/pkg/dmscli/nvconfig_test.go
@@ -165,7 +165,7 @@ var _ = Describe("NVConfig apply", func() {
 		}))
 	})
 
-	It("logs the exact command argv, target, and combined output", func() {
+	It("logs the exact command argv, target, and separate output streams", func() {
 		entries := []capturedLogEntry{}
 		ctx := logr.NewContext(context.Background(), logr.New(&capturingLogSink{entries: &entries}))
 
@@ -183,7 +183,27 @@ var _ = Describe("NVConfig apply", func() {
 		Expect(entries[0].message).To(Equal("command output"))
 		Expect(entries[0].fields).To(HaveKeyWithValue("command", append([]string{dmsCLIExecutable}, commands[0].args...)))
 		Expect(entries[0].fields).To(HaveKeyWithValue("target", target))
-		Expect(entries[0].fields["output"]).To(ContainSubstring(`"compiled-count":2`))
+		Expect(entries[0].fields["stdout"]).To(ContainSubstring(`"compiled-count":2`))
+		Expect(entries[0].fields).To(HaveKeyWithValue("stderr", ""))
+	})
+
+	It("decodes JSON stdout independently from diagnostics on stderr", func() {
+		executor = fakeExecutorWithStderr(
+			[]byte(`{"status":"ok","primary-target":"pci/0000:3b:00.0","compiled-count":1}`),
+			[]byte("DMS warning\n"), nil, &commands)
+
+		result, err := ApplyNVConfig(context.Background(), executor, ApplyNVConfigRequest{
+			Target:      target,
+			Ports:       nil,
+			Typed:       nil,
+			Raw:         []NVConfigParam{{Param: "A", Value: "1"}},
+			WithDefault: false,
+			Force:       false,
+		})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Status).To(Equal("ok"))
+		Expect(result.CompiledCount).To(Equal(1))
 	})
 
 	It("serializes typed XPath operations, port fanout, arrays, and raw overrides", func() {

--- a/pkg/dmscli/xpath.go
+++ b/pkg/dmscli/xpath.go
@@ -29,11 +29,8 @@ import (
 
 	"github.com/go-logr/logr"
 	execUtils "k8s.io/utils/exec"
-)
 
-const (
-	xpathStatusError   = "error"
-	xpathStatusPartial = "partial"
+	"github.com/Mellanox/nic-configuration-operator/pkg/utils"
 )
 
 // XPathOperation describes typed intent below one DMS XPath.
@@ -48,30 +45,22 @@ type XPathQuery struct {
 	Leaves []string
 }
 
-// XPathStatus is one normalized per-path DMS result.
-type XPathStatus struct {
-	Path         string `json:"path"`
-	Status       string `json:"status"`
-	ErrorCode    int    `json:"error_code,omitempty"`
-	Error        string `json:"error,omitempty"`
-	ErrorMessage string `json:"error_msg,omitempty"`
-}
-
-// QueryXPathsResult is the normalized result of a typed DMS GET. Values and
-// NotSupported are keyed by the requested container or keyed-list XPath.
+// QueryXPathsResult is the normalized result of a typed DMS GET.
 type QueryXPathsResult struct {
 	Status       string
 	Values       map[string]map[string]any
-	NotSupported map[string][]string
-	Results      []XPathStatus
+	Failures     map[string]any
 	ErrorMessage string
+	ErrorCode    any
 }
 
 // SetXPathsResult is the normalized result of a typed DMS SET.
 type SetXPathsResult struct {
 	Status       string
-	Results      []XPathStatus
+	Successes    map[string]any
+	Failures     map[string]any
 	ErrorMessage string
+	ErrorCode    any
 }
 
 // QueryXPaths reads one or more leaf batches from a DMS target.
@@ -88,38 +77,23 @@ func QueryXPaths(
 		return nil, err
 	}
 
-	args := []string{"--json", "-t", target}
-	for index, query := range queries {
-		if index > 0 {
-			args = append(args, ";")
-		}
-		args = append(args, query.Path)
-		args = append(args, query.Leaves...)
-	}
-
+	args := xpathQueryArgs(target, queries)
 	command := execInterface.CommandContext(ctx, dmsCLIExecutable, args...)
-	output, commandErr := command.CombinedOutput()
-	commandAndArgs := append([]string{dmsCLIExecutable}, args...)
-	logr.FromContextOrDiscard(ctx).V(2).Info("command output",
-		"command", commandAndArgs,
-		"target", target,
-		"output", string(output))
+	output, commandErr := utils.RunCommandWithStreams(command)
+	logDMSCLIOutput(ctx, append([]string{dmsCLIExecutable}, args...), target, output)
 
-	result, decodeErr := decodeQueryXPathsResult(output, queries)
 	if commandErr != nil {
-		return result, xpathCommandError("query", target, output, resultErrorMessage(result), commandErr)
-	}
-	if decodeErr != nil {
-		return nil, fmt.Errorf("decode XPath query result for target %q: %w", target, decodeErr)
-	}
-	if queryResultFailed(result) {
-		detail := result.ErrorMessage
-		if detail == "" {
-			detail = fmt.Sprintf("unexpected status %q", result.Status)
+		result, _ := decodeXPathFailure(output.Stdout, queries)
+		detail := ""
+		if result != nil {
+			detail = result.ErrorMessage
 		}
-		return result, fmt.Errorf("query XPaths from target %q: %s", target, detail)
+		return result, xpathCommandError("query", target, commandErrorDetail(output.Stdout, output.Stderr, detail), commandErr)
 	}
-
+	result, err := decodeXPathQuerySuccess(output.Stdout, queries)
+	if err != nil {
+		return nil, fmt.Errorf("decode XPath query result for target %q: %w", target, err)
+	}
 	return result, nil
 }
 
@@ -139,29 +113,42 @@ func SetXPaths(
 	}
 
 	command := execInterface.CommandContext(ctx, dmsCLIExecutable, args...)
-	output, commandErr := command.CombinedOutput()
-	commandAndArgs := append([]string{dmsCLIExecutable}, args...)
-	logr.FromContextOrDiscard(ctx).V(2).Info("command output",
-		"command", commandAndArgs,
-		"target", target,
-		"output", string(output))
+	output, commandErr := utils.RunCommandWithStreams(command)
+	logDMSCLIOutput(ctx, append([]string{dmsCLIExecutable}, args...), target, output)
 
-	result, decodeErr := decodeSetXPathsResult(output)
 	if commandErr != nil {
-		return result, xpathCommandError("set", target, output, setResultErrorMessage(result), commandErr)
-	}
-	if decodeErr != nil {
-		return nil, fmt.Errorf("decode XPath set result for target %q: %w", target, decodeErr)
-	}
-	if setResultFailed(result) {
-		detail := result.ErrorMessage
-		if detail == "" {
-			detail = fmt.Sprintf("unexpected status %q", result.Status)
+		result, _ := decodeXPathSetFailure(output.Stdout)
+		detail := ""
+		if result != nil {
+			detail = result.ErrorMessage
 		}
-		return result, fmt.Errorf("set XPaths on target %q: %s", target, detail)
+		return result, xpathCommandError("set", target, commandErrorDetail(output.Stdout, output.Stderr, detail), commandErr)
 	}
-
+	result, err := decodeXPathSetSuccess(output.Stdout)
+	if err != nil {
+		return nil, fmt.Errorf("decode XPath set result for target %q: %w", target, err)
+	}
 	return result, nil
+}
+
+func logDMSCLIOutput(ctx context.Context, command []string, target string, output utils.CommandOutput) {
+	logr.FromContextOrDiscard(ctx).V(2).Info("command output",
+		"command", command,
+		"target", target,
+		"stdout", boundedCommandOutput(output.Stdout),
+		"stderr", boundedCommandOutput(output.Stderr))
+}
+
+func xpathQueryArgs(target string, queries []XPathQuery) []string {
+	args := []string{"--json", "-t", target}
+	for index, query := range queries {
+		if index > 0 {
+			args = append(args, ";")
+		}
+		args = append(args, query.Path)
+		args = append(args, query.Leaves...)
+	}
+	return args
 }
 
 func validateXPathQueries(target string, queries []XPathQuery) error {
@@ -321,190 +308,148 @@ func formatXPathScalar(value any) (string, error) {
 	}
 }
 
-type xpathResponse struct {
+type xpathFailureEnvelope struct {
 	Status       string         `json:"status"`
-	Values       map[string]any `json:"values"`
-	NotSupported []string       `json:"not-supported"`
-	Results      []XPathStatus  `json:"results"`
-	Error        string         `json:"error"`
+	Successes    map[string]any `json:"successes"`
+	Failures     map[string]any `json:"failures"`
 	ErrorMessage string         `json:"error_msg"`
+	ErrorCode    any            `json:"error_code"`
 }
 
-func decodeQueryXPathsResult(output []byte, queries []XPathQuery) (*QueryXPathsResult, error) {
-	root, err := decodeXPathResponseObject(output)
+func decodeXPathQuerySuccess(output []byte, queries []XPathQuery) (*QueryXPathsResult, error) {
+	root, err := decodeJSONObject(output)
 	if err != nil {
 		return nil, err
 	}
-	result := &QueryXPathsResult{
-		Status:       "ok",
-		Values:       map[string]map[string]any{},
-		NotSupported: map[string][]string{},
-		Results:      nil,
-		ErrorMessage: "",
-	}
-
-	if isXPathResponseEnvelope(root) {
-		response, err := decodeXPathResponse(root)
+	result := &QueryXPathsResult{Status: "ok", Values: make(map[string]map[string]any, len(queries))}
+	if len(queries) == 1 {
+		values, err := decodeValues(output)
 		if err != nil {
 			return nil, err
 		}
-		if len(queries) != 1 {
-			if response.Status == "ok" {
-				return nil, fmt.Errorf("unkeyed successful dms-cli response is ambiguous for %d query paths", len(queries))
-			}
-			result.Status = response.Status
-			result.Results = append(result.Results, response.Results...)
-			result.ErrorMessage = responseErrorMessage(response)
-			return result, nil
-		}
-		mergeQueryResponse(result, queries[0].Path, response)
-		result.Status = response.Status
-		if result.Status == "ok" && len(response.NotSupported) > 0 {
-			result.Status = xpathStatusPartial
-		}
+		result.Values[queries[0].Path] = values
 		return result, nil
 	}
-	if len(queries) == 1 {
-		if _, found := root[queries[0].Path]; !found && !hasXPathKey(root) {
-			values := map[string]any{}
-			if err := decodeJSON(output, &values); err != nil {
-				return nil, err
-			}
-			result.Values[queries[0].Path] = values
-			return result, nil
-		}
-	}
-
-	succeeded := 0
-	failed := 0
-	hasPartial := false
 	for _, query := range queries {
 		raw, found := root[query.Path]
 		if !found {
 			return nil, fmt.Errorf("dms-cli response does not contain query path %q", query.Path)
 		}
-		response, err := decodeKeyedQueryResponse(raw)
+		values, err := decodeValues(raw)
 		if err != nil {
 			return nil, fmt.Errorf("decode response for query path %q: %w", query.Path, err)
 		}
-		mergeQueryResponse(result, query.Path, response)
-		if queryResponseFailed(response) {
-			failed++
-			hasPartial = hasPartial || response.Status == xpathStatusPartial
-		} else {
-			succeeded++
-		}
-	}
-	switch {
-	case failed == 0:
-		result.Status = "ok"
-	case succeeded > 0 || hasPartial:
-		result.Status = xpathStatusPartial
-	default:
-		result.Status = xpathStatusError
+		result.Values[query.Path] = values
 	}
 	return result, nil
 }
 
-func hasXPathKey(object map[string]json.RawMessage) bool {
-	for key := range object {
-		if strings.HasPrefix(key, "/") {
-			return true
-		}
+func decodeXPathSetSuccess(output []byte) (*SetXPathsResult, error) {
+	var response struct {
+		Status string `json:"status"`
 	}
-	return false
+	if err := decodeJSON(output, &response); err != nil {
+		return nil, err
+	}
+	if response.Status != "ok" {
+		return nil, fmt.Errorf("dms-cli response has unexpected status %q", response.Status)
+	}
+	return &SetXPathsResult{Status: response.Status}, nil
 }
 
-func isXPathResponseEnvelope(object map[string]json.RawMessage) bool {
-	if rawStatus, found := object["status"]; found {
-		var status string
-		if err := json.Unmarshal(rawStatus, &status); err == nil {
-			switch status {
-			case "ok", xpathStatusError, xpathStatusPartial:
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func decodeKeyedQueryResponse(raw json.RawMessage) (xpathResponse, error) {
-	object := map[string]json.RawMessage{}
-	if err := decodeJSON(raw, &object); err != nil {
-		return xpathResponse{}, err
-	}
-	if isXPathResponseEnvelope(object) {
-		var response xpathResponse
-		if err := decodeJSON(raw, &response); err != nil {
-			return xpathResponse{}, err
-		}
-		return response, nil
-	}
-
-	values := map[string]any{}
-	if err := decodeJSON(raw, &values); err != nil {
-		return xpathResponse{}, err
-	}
-	return xpathResponse{Status: "ok", Values: values}, nil
-}
-
-func decodeSetXPathsResult(output []byte) (*SetXPathsResult, error) {
-	root, err := decodeXPathResponseObject(output)
+func decodeXPathFailure(output []byte, queries []XPathQuery) (*QueryXPathsResult, error) {
+	envelope, err := decodeFailureEnvelope(output)
 	if err != nil {
 		return nil, err
 	}
-	result := &SetXPathsResult{Status: "ok", Results: nil, ErrorMessage: ""}
-	if _, hasStatus := root["status"]; hasStatus {
-		response, err := decodeXPathResponse(root)
-		if err != nil {
-			return nil, err
-		}
-		result.Status = response.Status
-		result.Results = response.Results
-		result.ErrorMessage = response.ErrorMessage
-		if result.ErrorMessage == "" {
-			result.ErrorMessage = response.Error
-		}
-		return result, nil
+	result := &QueryXPathsResult{
+		Status:       envelope.Status,
+		Values:       make(map[string]map[string]any, len(queries)),
+		Failures:     envelope.Failures,
+		ErrorMessage: failureMessage(envelope),
+		ErrorCode:    envelope.ErrorCode,
 	}
-
-	paths := make([]string, 0, len(root))
-	for path := range root {
-		paths = append(paths, path)
+	for _, query := range queries {
+		result.Values[query.Path] = map[string]any{}
 	}
-	sort.Strings(paths)
-	failed := 0
-	for _, path := range paths {
-		var response xpathResponse
-		if err := decodeJSON(root[path], &response); err != nil {
-			return nil, fmt.Errorf("decode response for set path %q: %w", path, err)
+	for path, value := range envelope.Successes {
+		queryPath, leaf, found := matchingQuery(path, queries)
+		if !found {
+			return nil, fmt.Errorf("dms-cli response contains unexpected success path %q", path)
 		}
-		status := XPathStatus{
-			Path:         path,
-			Status:       response.Status,
-			Error:        response.Error,
-			ErrorMessage: response.ErrorMessage,
-		}
-		result.Results = append(result.Results, status)
-		if response.Status != "ok" {
-			failed++
-			if result.ErrorMessage == "" {
-				result.ErrorMessage = response.ErrorMessage
-				if result.ErrorMessage == "" {
-					result.ErrorMessage = response.Error
-				}
-			}
-		}
-	}
-	if failed == len(paths) {
-		result.Status = xpathStatusError
-	} else if failed > 0 {
-		result.Status = xpathStatusPartial
+		result.Values[queryPath][leaf] = value
 	}
 	return result, nil
 }
 
-func decodeXPathResponseObject(output []byte) (map[string]json.RawMessage, error) {
+func decodeXPathSetFailure(output []byte) (*SetXPathsResult, error) {
+	envelope, err := decodeFailureEnvelope(output)
+	if err != nil {
+		return nil, err
+	}
+	return &SetXPathsResult{
+		Status:       envelope.Status,
+		Successes:    envelope.Successes,
+		Failures:     envelope.Failures,
+		ErrorMessage: failureMessage(envelope),
+		ErrorCode:    envelope.ErrorCode,
+	}, nil
+}
+
+func decodeFailureEnvelope(output []byte) (xpathFailureEnvelope, error) {
+	var envelope xpathFailureEnvelope
+	if err := decodeJSON(output, &envelope); err != nil {
+		return envelope, err
+	}
+	if envelope.Status != "error" && envelope.Status != "partial" {
+		return envelope, fmt.Errorf("dms-cli failure response has unexpected status %q", envelope.Status)
+	}
+	return envelope, nil
+}
+
+func failureMessage(envelope xpathFailureEnvelope) string {
+	if envelope.ErrorMessage != "" {
+		return envelope.ErrorMessage
+	}
+	if len(envelope.Failures) == 0 {
+		return ""
+	}
+	paths := make([]string, 0, len(envelope.Failures))
+	for path := range envelope.Failures {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return formatFailureValue(envelope.Failures[paths[0]])
+}
+
+func formatFailureValue(value any) string {
+	if message, ok := value.(string); ok {
+		return message
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Sprint(value)
+	}
+	return string(encoded)
+}
+
+func matchingQuery(path string, queries []XPathQuery) (string, string, bool) {
+	for _, query := range queries {
+		prefix := query.Path + "/"
+		if !strings.HasPrefix(path, prefix) {
+			continue
+		}
+		leaf := strings.TrimPrefix(path, prefix)
+		for _, requestedLeaf := range query.Leaves {
+			if leaf == requestedLeaf {
+				return query.Path, leaf, true
+			}
+		}
+	}
+	return "", "", false
+}
+
+func decodeJSONObject(output []byte) (map[string]json.RawMessage, error) {
 	if len(bytes.TrimSpace(output)) == 0 {
 		return nil, fmt.Errorf("dms-cli returned an empty response")
 	}
@@ -512,22 +457,15 @@ func decodeXPathResponseObject(output []byte) (map[string]json.RawMessage, error
 	if err := decodeJSON(output, &root); err != nil {
 		return nil, fmt.Errorf("invalid dms-cli JSON response: %w", err)
 	}
-	if len(root) == 0 {
-		return nil, fmt.Errorf("dms-cli returned an empty JSON object")
-	}
 	return root, nil
 }
 
-func decodeXPathResponse(root map[string]json.RawMessage) (xpathResponse, error) {
-	encoded, err := json.Marshal(root)
-	if err != nil {
-		return xpathResponse{}, err
+func decodeValues(raw []byte) (map[string]any, error) {
+	values := map[string]any{}
+	if err := decodeJSON(raw, &values); err != nil {
+		return nil, err
 	}
-	var response xpathResponse
-	if err := decodeJSON(encoded, &response); err != nil {
-		return xpathResponse{}, err
-	}
-	return response, nil
+	return values, nil
 }
 
 func decodeJSON(content []byte, value any) error {
@@ -546,86 +484,7 @@ func decodeJSON(content []byte, value any) error {
 	return nil
 }
 
-func mergeQueryResponse(result *QueryXPathsResult, path string, response xpathResponse) {
-	result.Values[path] = response.Values
-	if len(response.NotSupported) > 0 {
-		result.NotSupported[path] = append([]string(nil), response.NotSupported...)
-	}
-	result.Results = append(result.Results, response.Results...)
-	if response.ErrorMessage != "" && result.ErrorMessage == "" {
-		result.ErrorMessage = response.ErrorMessage
-	}
-	if response.Error != "" && result.ErrorMessage == "" {
-		result.ErrorMessage = response.Error
-	}
-}
-
-func queryResponseFailed(response xpathResponse) bool {
-	if response.Status != "ok" || len(response.NotSupported) > 0 {
-		return true
-	}
-	for _, result := range response.Results {
-		if result.Status != "ok" {
-			return true
-		}
-	}
-	return false
-}
-
-func responseErrorMessage(response xpathResponse) string {
-	if response.ErrorMessage != "" {
-		return response.ErrorMessage
-	}
-	return response.Error
-}
-
-func queryResultFailed(result *QueryXPathsResult) bool {
-	if result == nil || result.Status != "ok" {
-		return true
-	}
-	for _, unsupported := range result.NotSupported {
-		if len(unsupported) > 0 {
-			return true
-		}
-	}
-	for _, status := range result.Results {
-		if status.Status != "ok" {
-			return true
-		}
-	}
-	return false
-}
-
-func setResultFailed(result *SetXPathsResult) bool {
-	if result == nil || result.Status != "ok" {
-		return true
-	}
-	for _, status := range result.Results {
-		if status.Status != "ok" {
-			return true
-		}
-	}
-	return false
-}
-
-func resultErrorMessage(result *QueryXPathsResult) string {
-	if result == nil {
-		return ""
-	}
-	return result.ErrorMessage
-}
-
-func setResultErrorMessage(result *SetXPathsResult) string {
-	if result == nil {
-		return ""
-	}
-	return result.ErrorMessage
-}
-
-func xpathCommandError(operation, target string, output []byte, detail string, commandErr error) error {
-	if detail == "" {
-		detail = strings.TrimSpace(string(output))
-	}
+func xpathCommandError(operation, target, detail string, commandErr error) error {
 	if detail != "" {
 		return fmt.Errorf("%s XPaths on target %q: %w: %s", operation, target, commandErr, detail)
 	}

--- a/pkg/dmscli/xpath_test.go
+++ b/pkg/dmscli/xpath_test.go
@@ -35,10 +35,10 @@ var _ = Describe("typed XPath operations", func() {
 	})
 
 	Describe("QueryXPaths", func() {
-		It("batches query paths and decodes keyed values", func() {
+		It("batches query paths and decodes the public keyed response", func() {
 			executor := fakeExecutor([]byte(`{
-				"/nvidia/link/ipg":{"status":"ok","values":{"admin":25}},
-				"/nvidia/link/physical":{"status":"ok","values":{"admin-status":"up"}}
+				"/nvidia/link/ipg":{"admin":25},
+				"/nvidia/link/physical":{"admin-status":"up"}
 			}`), nil, &commands)
 
 			result, err := QueryXPaths(context.Background(), executor, target, []XPathQuery{
@@ -50,7 +50,6 @@ var _ = Describe("typed XPath operations", func() {
 			Expect(result.Status).To(Equal("ok"))
 			Expect(result.Values).To(HaveKeyWithValue("/nvidia/link/ipg", map[string]any{"admin": json.Number("25")}))
 			Expect(result.Values).To(HaveKeyWithValue("/nvidia/link/physical", map[string]any{"admin-status": "up"}))
-			Expect(result.NotSupported).To(BeEmpty())
 			Expect(commands).To(HaveLen(1))
 			Expect(commands[0].args).To(Equal([]string{
 				"--json", "-t", target,
@@ -59,120 +58,85 @@ var _ = Describe("typed XPath operations", func() {
 			}))
 		})
 
-		It("decodes one unkeyed query response", func() {
-			executor := fakeExecutor([]byte(`{"status":"ok","values":{"enabled":true}}`), nil, &commands)
+		It("decodes the public flat single-container response", func() {
+			executor := fakeExecutor([]byte(`{"operating-mode":"dpu","status":"ready"}`), nil, &commands)
 
 			result, err := QueryXPaths(context.Background(), executor, target, []XPathQuery{
-				{Path: "/nvidia/data-direct", Leaves: []string{"enabled"}},
+				{Path: "/nvidia/mode", Leaves: []string{"operating-mode", "status"}},
 			})
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Values).To(Equal(map[string]map[string]any{
-				"/nvidia/data-direct": {"enabled": true},
+				"/nvidia/mode": {"operating-mode": "dpu", "status": "ready"},
 			}))
 		})
 
-		It("decodes the documented flat single-container JSON response", func() {
-			executor := fakeExecutor([]byte(`{"operating-mode":"dpu"}`), nil, &commands)
+		It("decodes JSON stdout independently from diagnostics on stderr", func() {
+			executor := fakeExecutorWithStderr(
+				[]byte(`{"admin":25}`), []byte("DMS warning\n"), nil, &commands)
 
 			result, err := QueryXPaths(context.Background(), executor, target, []XPathQuery{
-				{Path: "/nvidia/mode", Leaves: []string{"operating-mode"}},
+				{Path: "/nvidia/link/ipg", Leaves: []string{"admin"}},
 			})
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Values).To(Equal(map[string]map[string]any{
-				"/nvidia/mode": {"operating-mode": "dpu"},
-			}))
+			Expect(result.Values["/nvidia/link/ipg"]).To(HaveKeyWithValue("admin", json.Number("25")))
 		})
 
-		It("does not confuse a flat status leaf with response metadata", func() {
-			executor := fakeExecutor([]byte(`{"status":"ready"}`), nil, &commands)
-
-			result, err := QueryXPaths(context.Background(), executor, target, []XPathQuery{
-				{Path: "/nvidia/reset", Leaves: []string{"status"}},
-			})
-
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Values).To(Equal(map[string]map[string]any{
-				"/nvidia/reset": {"status": "ready"},
-			}))
-		})
-
-		It("decodes flat values nested below keyed query paths", func() {
-			executor := fakeExecutor([]byte(`{
-				"/nvidia/pci":{"sriov-enabled":true},
-				"/nvidia/roce":{"adaptive-routing":true}
-			}`), nil, &commands)
-
-			result, err := QueryXPaths(context.Background(), executor, target, []XPathQuery{
-				{Path: "/nvidia/pci", Leaves: []string{"sriov-enabled"}},
-				{Path: "/nvidia/roce", Leaves: []string{"adaptive-routing"}},
-			})
-
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Values).To(HaveKeyWithValue("/nvidia/pci", map[string]any{"sriov-enabled": true}))
-			Expect(result.Values).To(HaveKeyWithValue("/nvidia/roce", map[string]any{"adaptive-routing": true}))
-		})
-
-		It("returns capability filtering as a query error", func() {
-			executor := fakeExecutor([]byte(`{
-				"status":"ok",
-				"values":{"adaptive-routing":true},
-				"not-supported":["cc-steering-ext"]
-			}`), nil, &commands)
-
-			result, err := QueryXPaths(context.Background(), executor, target, []XPathQuery{
-				{Path: "/nvidia/roce", Leaves: []string{"adaptive-routing", "cc-steering-ext"}},
-			})
-
-			Expect(result.Status).To(Equal("partial"))
-			Expect(result.NotSupported).To(HaveKeyWithValue("/nvidia/roce", []string{"cc-steering-ext"}))
-			Expect(err).To(MatchError(ContainSubstring("unexpected status \"partial\"")))
-		})
-
-		It("preserves a structured partial result and command error", func() {
+		It("preserves successes and failures from a partial response", func() {
 			commandErr := errors.New("exit status 10")
 			executor := fakeExecutor([]byte(`{
 				"status":"partial",
-				"results":[
-					{"path":"/nvidia/mode/operating-mode","status":"error","error_code":4,"error":"not-supported"},
-					{"path":"/nvidia/pci/sriov-enabled","status":"ok"}
-				]
+				"successes":{"/nvidia/pci/sriov-enabled":true},
+				"failures":{"/nvidia/lag/resource-allocation":"not-supported"},
+				"error_code":"E10"
 			}`), commandErr, &commands)
-
-			result, err := QueryXPaths(context.Background(), executor, target, []XPathQuery{
-				{Path: "/nvidia/mode", Leaves: []string{"operating-mode"}},
-				{Path: "/nvidia/pci", Leaves: []string{"sriov-enabled"}},
-			})
-
-			Expect(result.Status).To(Equal("partial"))
-			Expect(result.Results).To(HaveLen(2))
-			Expect(errors.Is(err, commandErr)).To(BeTrue())
-		})
-
-		It("normalizes mixed keyed query results as partial", func() {
-			executor := fakeExecutor([]byte(`{
-				"/nvidia/pci":{"status":"ok","values":{"sriov-enabled":true}},
-				"/nvidia/lag":{"status":"error","error":"not-supported","values":{}}
-			}`), nil, &commands)
 
 			result, err := QueryXPaths(context.Background(), executor, target, []XPathQuery{
 				{Path: "/nvidia/pci", Leaves: []string{"sriov-enabled"}},
 				{Path: "/nvidia/lag", Leaves: []string{"resource-allocation"}},
 			})
 
+			Expect(errors.Is(err, commandErr)).To(BeTrue())
 			Expect(result.Status).To(Equal("partial"))
-			Expect(result.Values).To(HaveKey("/nvidia/pci"))
-			Expect(result.Values).To(HaveKey("/nvidia/lag"))
-			Expect(err).To(MatchError(ContainSubstring("not-supported")))
+			Expect(result.Values["/nvidia/pci"]).To(HaveKeyWithValue("sriov-enabled", true))
+			Expect(result.Failures).To(Equal(map[string]any{
+				"/nvidia/lag/resource-allocation": "not-supported",
+			}))
+			Expect(result.ErrorCode).To(Equal("E10"))
+		})
+
+		It("returns the structured total failure and preserves the command error", func() {
+			commandErr := errors.New("exit status 7")
+			executor := fakeExecutor(
+				[]byte(`{"status":"error","error_msg":"device unavailable","error_code":5}`),
+				commandErr, &commands)
+
+			result, err := QueryXPaths(context.Background(), executor, target, []XPathQuery{
+				{Path: "/nvidia/pci", Leaves: []string{"sriov-enabled"}},
+			})
+
+			Expect(errors.Is(err, commandErr)).To(BeTrue())
+			Expect(err).To(MatchError(ContainSubstring("device unavailable")))
+			Expect(result.Status).To(Equal("error"))
+			Expect(result.ErrorMessage).To(Equal("device unavailable"))
+		})
+
+		It("rejects malformed JSON returned by a successful command", func() {
+			executor := fakeExecutor([]byte("not-json"), nil, &commands)
+
+			result, err := QueryXPaths(context.Background(), executor, target, []XPathQuery{
+				{Path: "/nvidia/pci", Leaves: []string{"sriov-enabled"}},
+			})
+
+			Expect(result).To(BeNil())
+			Expect(err).To(MatchError(ContainSubstring("invalid dms-cli JSON response")))
 		})
 
 		DescribeTable("validates query input before execution",
 			func(targetValue string, queries []XPathQuery, expected string) {
-				executor := fakeExecutor([]byte(`{"status":"ok","values":{}}`), nil, &commands)
-
+				executor := fakeExecutor([]byte(`{}`), nil, &commands)
 				result, err := QueryXPaths(context.Background(), executor, targetValue, queries)
-
 				Expect(result).To(BeNil())
 				Expect(err).To(MatchError(ContainSubstring(expected)))
 				Expect(commands).To(BeEmpty())
@@ -193,7 +157,6 @@ var _ = Describe("typed XPath operations", func() {
 			result, err := QueryXPaths(context.Background(), nil, target, []XPathQuery{
 				{Path: "/nvidia/pci", Leaves: []string{"num-pfs"}},
 			})
-
 			Expect(result).To(BeNil())
 			Expect(err).To(MatchError("command executor must not be nil"))
 		})
@@ -204,13 +167,9 @@ var _ = Describe("typed XPath operations", func() {
 			executor := fakeExecutor([]byte(`{"status":"ok"}`), nil, &commands)
 
 			result, err := SetXPaths(context.Background(), executor, target, []XPathOperation{
-				{
-					Path: "/nvidia/roce",
-					Values: map[string]any{
-						"tx-sched-locality-mode": "accumulative",
-						"adaptive-routing":       true,
-					},
-				},
+				{Path: "/nvidia/roce", Values: map[string]any{
+					"tx-sched-locality-mode": "accumulative", "adaptive-routing": true,
+				}},
 				{Path: "/nvidia/link/physical", Values: map[string]any{"admin-status": "down"}},
 				{Path: "/nvidia/link/physical", Values: map[string]any{"admin-status": "up"}},
 				{Path: "/nvidia/link/breakout/module/[0]/port/[1]", Values: map[string]any{"lanes": []int{0, 1, 2, 3}}},
@@ -218,7 +177,6 @@ var _ = Describe("typed XPath operations", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Status).To(Equal("ok"))
-			Expect(commands).To(HaveLen(1))
 			Expect(commands[0].args).To(Equal([]string{
 				"--json", "-t", target,
 				"/nvidia/roce", "adaptive-routing=true", "tx-sched-locality-mode=accumulative",
@@ -228,43 +186,32 @@ var _ = Describe("typed XPath operations", func() {
 			}))
 		})
 
-		It("returns a partial set result with the command error", func() {
+		It("returns a normalized partial failure", func() {
 			commandErr := errors.New("exit status 10")
 			executor := fakeExecutor([]byte(`{
 				"status":"partial",
-				"results":[
-					{"path":"/nvidia/roce/cc-steering-ext","status":"error","error_code":4,"error":"not-supported"},
-					{"path":"/nvidia/roce/adaptive-routing","status":"ok"}
-				]
+				"successes":{"/nvidia/roce/adaptive-routing":true},
+				"failures":{"/nvidia/roce/cc-steering-ext":"not-supported"}
 			}`), commandErr, &commands)
 
 			result, err := SetXPaths(context.Background(), executor, target, []XPathOperation{
-				{Path: "/nvidia/roce", Values: map[string]any{"adaptive-routing": true, "cc-steering-ext": "enabled"}},
+				{Path: "/nvidia/roce", Values: map[string]any{
+					"adaptive-routing": true, "cc-steering-ext": "enabled",
+				}},
 			})
 
-			Expect(result.Status).To(Equal("partial"))
-			Expect(result.Results).To(HaveLen(2))
 			Expect(errors.Is(err, commandErr)).To(BeTrue())
-		})
-
-		It("normalizes keyed multi-container statuses", func() {
-			executor := fakeExecutor([]byte(`{
-				"/nvidia/pci":{"status":"ok"},
-				"/nvidia/lag":{"status":"error","error":"not-supported"}
-			}`), nil, &commands)
-
-			result, err := SetXPaths(context.Background(), executor, target, []XPathOperation{
-				{Path: "/nvidia/pci", Values: map[string]any{"sriov-enabled": true}},
-				{Path: "/nvidia/lag", Values: map[string]any{"resource-allocation": "pre-allocation"}},
-			})
-
 			Expect(result.Status).To(Equal("partial"))
-			Expect(result.Results).To(HaveLen(2))
-			Expect(err).To(MatchError(ContainSubstring("not-supported")))
+			Expect(result.Successes).To(Equal(map[string]any{
+				"/nvidia/roce/adaptive-routing": true,
+			}))
+			Expect(result.Failures).To(Equal(map[string]any{
+				"/nvidia/roce/cc-steering-ext": "not-supported",
+			}))
 		})
 
-		It("logs the exact command and combined output", func() {
-			executor := fakeExecutor([]byte(`{"status":"ok"}`), nil, &commands)
+		It("logs the exact command and separate output streams", func() {
+			executor := fakeExecutorWithStderr([]byte(`{"status":"ok"}`), []byte("warning\n"), nil, &commands)
 			entries := []capturedLogEntry{}
 			ctx := logr.NewContext(context.Background(), logr.New(&capturingLogSink{entries: &entries}))
 
@@ -276,15 +223,14 @@ var _ = Describe("typed XPath operations", func() {
 			Expect(entries).To(HaveLen(1))
 			Expect(entries[0].fields).To(HaveKeyWithValue("command", append([]string{dmsCLIExecutable}, commands[0].args...)))
 			Expect(entries[0].fields).To(HaveKeyWithValue("target", target))
-			Expect(entries[0].fields).To(HaveKeyWithValue("output", `{"status":"ok"}`))
+			Expect(entries[0].fields).To(HaveKeyWithValue("stdout", `{"status":"ok"}`))
+			Expect(entries[0].fields).To(HaveKeyWithValue("stderr", "warning"))
 		})
 
 		DescribeTable("rejects invalid set input before execution",
 			func(targetValue string, operations []XPathOperation, expected string) {
 				executor := fakeExecutor([]byte(`{"status":"ok"}`), nil, &commands)
-
 				result, err := SetXPaths(context.Background(), executor, targetValue, operations)
-
 				Expect(result).To(BeNil())
 				Expect(err).To(MatchError(ContainSubstring(expected)))
 				Expect(commands).To(BeEmpty())
@@ -304,7 +250,6 @@ var _ = Describe("typed XPath operations", func() {
 			result, err := SetXPaths(context.Background(), nil, target, []XPathOperation{
 				{Path: "/nvidia/pci", Values: map[string]any{"num-pfs": 2}},
 			})
-
 			Expect(result).To(BeNil())
 			Expect(err).To(MatchError("command executor must not be nil"))
 		})

--- a/pkg/nvconfig/utils_test.go
+++ b/pkg/nvconfig/utils_test.go
@@ -620,7 +620,7 @@ Result: Device configuration does NOT match the system configuration.
 			commandErr = nil
 
 			cmd := &execTesting.FakeCmd{}
-			cmd.CombinedOutputScript = append(cmd.CombinedOutputScript, func() ([]byte, []byte, error) {
+			cmd.RunScript = append(cmd.RunScript, func() ([]byte, []byte, error) {
 				return commandOutput, nil, commandErr
 			})
 			fakeExec = &execTesting.FakeExec{}

--- a/pkg/spectrumx/blueprintsdata.go
+++ b/pkg/spectrumx/blueprintsdata.go
@@ -83,6 +83,7 @@ func (m *spectrumXConfigManager) InstallBlueprintsData(archive []byte) error {
 	if err := installBlueprintsDataArchive(archive, m.dospcxDataRoot); err != nil {
 		return err
 	}
+	clear(m.preparedPlans)
 	m.dospcxDataDigest = digest
 	return nil
 }
@@ -105,6 +106,7 @@ func (m *spectrumXConfigManager) RemoveBlueprintsData() error {
 	if err := removeBlueprintsDataDirectory(m.dospcxDataRoot); err != nil {
 		return fmt.Errorf("remove doSPCX data directory %q: %w", m.dospcxDataRoot, err)
 	}
+	clear(m.preparedPlans)
 	m.dospcxDataDigest = ""
 	return nil
 }

--- a/pkg/spectrumx/blueprintsdata_test.go
+++ b/pkg/spectrumx/blueprintsdata_test.go
@@ -86,6 +86,7 @@ func validBlueprintsArchive(extra ...blueprintsArchiveEntry) []byte {
 func newBlueprintsDataManager(dataRoot string) *spectrumXConfigManager {
 	return &spectrumXConfigManager{
 		spectrumXConfigs:   nil,
+		preparedPlans:      make(map[string]*preparedPlan),
 		dmsManager:         nil,
 		execInterface:      nil,
 		blueprintsRoot:     "",
@@ -104,6 +105,7 @@ var _ = Describe("doSPCX data archive installation", func() {
 		Expect(os.WriteFile(filepath.Join(dataRoot, "obsolete"), []byte("old"), 0o644)).To(Succeed())
 		archive := validBlueprintsArchive()
 		manager := newBlueprintsDataManager(dataRoot)
+		manager.preparedPlans["old-plan"] = &preparedPlan{plan: &Plan{Name: "old-plan"}}
 
 		Expect(manager.InstallBlueprintsData(archive)).To(Succeed())
 
@@ -116,6 +118,7 @@ var _ = Describe("doSPCX data archive installation", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(info.Mode().Perm()).To(Equal(os.FileMode(0o755)))
 		Expect(manager.dospcxDataDigest).To(Equal(sha256Digest(archive)))
+		Expect(manager.preparedPlans).To(BeEmpty())
 	})
 
 	It("accepts the global PAX metadata emitted by git archive", func() {
@@ -228,6 +231,7 @@ var _ = Describe("doSPCX data archive installation", func() {
 		dataRoot := filepath.Join(GinkgoT().TempDir(), "doSpcx", "data")
 		manager := newBlueprintsDataManager(dataRoot)
 		Expect(manager.InstallBlueprintsData(validBlueprintsArchive())).To(Succeed())
+		manager.preparedPlans["old-plan"] = &preparedPlan{plan: &Plan{Name: "old-plan"}}
 		updatedArchive := validBlueprintsArchive(blueprintsArchiveEntry{
 			name: "data/new-profile-marker", typeFlag: tar.TypeReg, mode: 0o644, content: "new",
 		})
@@ -244,16 +248,19 @@ var _ = Describe("doSPCX data archive installation", func() {
 		Expect(cleanupAttempted).To(BeTrue())
 		Expect(filepath.Join(dataRoot, "new-profile-marker")).To(BeAnExistingFile())
 		Expect(manager.dospcxDataDigest).To(Equal(sha256Digest(updatedArchive)))
+		Expect(manager.preparedPlans).To(BeEmpty())
 	})
 
 	It("removes data installed from a ConfigMap and clears its digest", func() {
 		dataRoot := filepath.Join(GinkgoT().TempDir(), "doSpcx", "data")
 		manager := newBlueprintsDataManager(dataRoot)
 		Expect(manager.InstallBlueprintsData(validBlueprintsArchive())).To(Succeed())
+		manager.preparedPlans["old-plan"] = &preparedPlan{plan: &Plan{Name: "old-plan"}}
 
 		Expect(manager.RemoveBlueprintsData()).To(Succeed())
 		Expect(dataRoot).NotTo(BeADirectory())
 		Expect(manager.dospcxDataDigest).To(BeEmpty())
+		Expect(manager.preparedPlans).To(BeEmpty())
 	})
 
 	It("keeps the active digest when removing installed data fails", func() {
@@ -261,6 +268,7 @@ var _ = Describe("doSPCX data archive installation", func() {
 		manager := newBlueprintsDataManager(dataRoot)
 		archive := validBlueprintsArchive()
 		Expect(manager.InstallBlueprintsData(archive)).To(Succeed())
+		manager.preparedPlans["active-plan"] = &preparedPlan{plan: &Plan{Name: "active-plan"}}
 
 		originalRemove := removeBlueprintsDataDirectory
 		DeferCleanup(func() { removeBlueprintsDataDirectory = originalRemove })
@@ -271,6 +279,7 @@ var _ = Describe("doSPCX data archive installation", func() {
 		Expect(manager.RemoveBlueprintsData()).To(MatchError(ContainSubstring("injected removal failure")))
 		Expect(dataRoot).To(BeADirectory())
 		Expect(manager.dospcxDataDigest).To(Equal(sha256Digest(archive)))
+		Expect(manager.preparedPlans).To(HaveKey("active-plan"))
 	})
 
 	It("does not remove image-provided data when no ConfigMap bundle was installed", func() {

--- a/pkg/spectrumx/prepareplan.go
+++ b/pkg/spectrumx/prepareplan.go
@@ -60,12 +60,12 @@ const (
 	PlanStageConfigure PlanStage = "configure"
 )
 
-// Plan is a generated doSPCX plan retrieved from the local plan store.
+// Plan is a compiled, execution-ready view of a generated doSPCX plan.
 type Plan struct {
-	Name     string
-	Stage    PlanStage
-	JSON     json.RawMessage
-	Semantic *SemanticPlan
+	Name          string
+	Stage         PlanStage
+	Groups        []DMSOperationGroup
+	SkippedGroups []SkippedSemanticGroup
 }
 
 // PlanManager owns doSPCX target-map construction, plan generation, caching,
@@ -96,15 +96,14 @@ type preBreakoutTarget struct {
 }
 
 type planConfig struct {
-	nodeName      string
-	platformType  string
-	profile       string
-	version       string
-	multiplane    string
-	overlay       string
-	planes        int
-	targetMap     targetMap
-	selectedCount int
+	nodeName     string
+	platformType string
+	profile      string
+	version      string
+	multiplane   string
+	overlay      string
+	planes       int
+	targetMap    targetMap
 }
 
 // planMetadata contains only the inputs used to generate a doSPCX plan.
@@ -125,6 +124,12 @@ type planMetadata struct {
 	Parameters           []string `json:"parameters"`
 	TargetMapFile        string   `json:"target_map_file"`
 	TargetMapDigest      string   `json:"target_map_digest"`
+}
+
+type preparedPlan struct {
+	metadata  planMetadata
+	targetMap targetMap
+	plan      *Plan
 }
 
 // PreparePlan ensures that a matching node-scoped plan is cached for the
@@ -171,24 +176,20 @@ func (m *spectrumXConfigManager) PreparePlan(
 	}
 	planPath := filepath.Join(stateDir, "plans", generatedPlanName, "plan.json")
 	metadataPath := filepath.Join(filepath.Dir(planPath), "metadata.json")
-	metadata := planMetadata{
-		BlueprintsRoot:       m.blueprintsRoot,
-		BlueprintsStateDir:   stateDir,
-		BlueprintsDataDigest: m.dospcxDataDigest,
-		PlanName:             generatedPlanName,
-		Stage:                string(stage),
-		Profile:              config.profile,
-		PlatformType:         config.platformType,
-		SpectrumXVersion:     config.version,
-		MultiplaneMode:       config.multiplane,
-		Overlay:              config.overlay,
-		Planes:               config.planes,
-		DeploymentMode:       deploymentModeHostK8s,
-		Parameters:           append([]string(nil), params...),
-		TargetMapFile:        targetMapPath,
-		TargetMapDigest:      sha256Digest(targetMapContent),
+	metadata := newPlanMetadata(
+		m, config, stage, stateDir, targetMapPath, params, sha256Digest(targetMapContent))
+	if m.preparedPlans == nil {
+		m.preparedPlans = make(map[string]*preparedPlan)
 	}
-	if reusable, reason := reusablePlan(planPath, metadataPath, targetMapPath, metadata, config); reusable {
+	if cached, found := m.preparedPlans[generatedPlanName]; found && cached != nil && cached.plan != nil &&
+		reflect.DeepEqual(cached.metadata, metadata) {
+		log.FromContext(ctx).V(2).Info("reusing in-memory doSPCX plan",
+			"node", config.nodeName,
+			"stage", stage)
+		return nil
+	}
+	if cached, reason := loadSavedPlan(planPath, metadataPath, targetMapPath, metadata, config); cached != nil {
+		m.preparedPlans[generatedPlanName] = cached
 		log.FromContext(ctx).V(2).Info("reusing saved doSPCX plan",
 			"node", config.nodeName,
 			"stage", stage,
@@ -218,7 +219,8 @@ func (m *spectrumXConfigManager) PreparePlan(
 	if err != nil {
 		return err
 	}
-	if _, err := validateGeneratedPlan(result.PlanJSON, generatedPlanName, config, string(stage)); err != nil {
+	plan, err := validateGeneratedPlan(result.PlanJSON, generatedPlanName, config, stage)
+	if err != nil {
 		return err
 	}
 
@@ -228,12 +230,17 @@ func (m *spectrumXConfigManager) PreparePlan(
 	if err := writeJSONFileAtomic(metadataPath, metadata); err != nil {
 		return fmt.Errorf("write doSPCX %s plan metadata %q: %w", stage, metadataPath, err)
 	}
+	m.preparedPlans[generatedPlanName] = &preparedPlan{
+		metadata:  metadata,
+		targetMap: config.targetMap,
+		plan:      plan,
+	}
 	log.FromContext(ctx).Info("generated doSPCX plan",
 		"node", config.nodeName,
 		"stage", stage,
 		"profile", config.profile,
 		"platformType", config.platformType,
-		"devices", config.selectedCount,
+		"devices", len(config.targetMap.PreBreakout.Targets),
 		"blueprintsRoot", m.blueprintsRoot,
 		"targetMap", targetMapPath,
 		"plan", planPath,
@@ -276,20 +283,82 @@ func (m *spectrumXConfigManager) GetPreparedPlan(device *v1alpha1.NicDevice, sta
 	}
 	generatedPlanName := planName(config.nodeName, stage)
 	targetMapPath := filepath.Join(stateDir, "target-maps", targetMapName(config.nodeName)+".json")
-	metadataPath := filepath.Join(stateDir, "plans", generatedPlanName, "metadata.json")
-	metadataContent, err := os.ReadFile(metadataPath)
-	if err != nil {
-		return nil, fmt.Errorf("read doSPCX %s plan metadata %q: %w", stage, metadataPath, err)
+	cached, found := m.preparedPlans[generatedPlanName]
+	if !found || cached == nil || cached.plan == nil {
+		return nil, fmt.Errorf("doSPCX %s plan is not prepared for device %q", stage, device.Name)
 	}
-	var metadata planMetadata
-	if err := json.Unmarshal(metadataContent, &metadata); err != nil {
-		return nil, fmt.Errorf("decode doSPCX %s plan metadata %q: %w", stage, metadataPath, err)
+	expectedMetadata := newPlanMetadata(
+		m, config, stage, stateDir, targetMapPath, params, cached.metadata.TargetMapDigest)
+	if cached.metadata.TargetMapDigest == "" || !reflect.DeepEqual(cached.metadata, expectedMetadata) {
+		return nil, fmt.Errorf("cached doSPCX %s plan does not match device %q inputs", stage, device.Name)
 	}
-	expectedMetadata := planMetadata{
+	if err := validateDeviceInTargetMap(config, cached.targetMap); err != nil {
+		return nil, fmt.Errorf("cached doSPCX %s plan does not match device %q: %w", stage, device.Name, err)
+	}
+	return clonePlan(cached.plan), nil
+}
+
+func clonePlan(source *Plan) *Plan {
+	if source == nil {
+		return nil
+	}
+	result := &Plan{
+		Name:          source.Name,
+		Stage:         source.Stage,
+		Groups:        make([]DMSOperationGroup, len(source.Groups)),
+		SkippedGroups: append([]SkippedSemanticGroup(nil), source.SkippedGroups...),
+	}
+	for groupIndex, group := range source.Groups {
+		result.Groups[groupIndex] = group
+		result.Groups[groupIndex].Targets = make([]DMSTargetOperations, len(group.Targets))
+		for targetIndex, target := range group.Targets {
+			result.Groups[groupIndex].Targets[targetIndex] = DMSTargetOperations{
+				Target:     target.Target,
+				Queries:    cloneXPathQueries(target.Queries),
+				Desired:    cloneXPathOperations(target.Desired),
+				Operations: cloneXPathOperations(target.Operations),
+			}
+		}
+	}
+	return result
+}
+
+func cloneXPathQueries(source []dmscli.XPathQuery) []dmscli.XPathQuery {
+	result := make([]dmscli.XPathQuery, len(source))
+	for index, query := range source {
+		result[index] = dmscli.XPathQuery{
+			Path:   query.Path,
+			Leaves: append([]string(nil), query.Leaves...),
+		}
+	}
+	return result
+}
+
+func cloneXPathOperations(source []dmscli.XPathOperation) []dmscli.XPathOperation {
+	result := make([]dmscli.XPathOperation, len(source))
+	for index, operation := range source {
+		result[index] = dmscli.XPathOperation{
+			Path:   operation.Path,
+			Values: cloneValueMap(operation.Values),
+		}
+	}
+	return result
+}
+
+func newPlanMetadata(
+	m *spectrumXConfigManager,
+	config *planConfig,
+	stage PlanStage,
+	stateDir string,
+	targetMapPath string,
+	params []string,
+	targetMapDigest string,
+) planMetadata {
+	return planMetadata{
 		BlueprintsRoot:       m.blueprintsRoot,
 		BlueprintsStateDir:   stateDir,
 		BlueprintsDataDigest: m.dospcxDataDigest,
-		PlanName:             generatedPlanName,
+		PlanName:             planName(config.nodeName, stage),
 		Stage:                string(stage),
 		Profile:              config.profile,
 		PlatformType:         config.platformType,
@@ -298,56 +367,10 @@ func (m *spectrumXConfigManager) GetPreparedPlan(device *v1alpha1.NicDevice, sta
 		Overlay:              config.overlay,
 		Planes:               config.planes,
 		DeploymentMode:       deploymentModeHostK8s,
-		Parameters:           params,
+		Parameters:           append([]string(nil), params...),
 		TargetMapFile:        targetMapPath,
-		TargetMapDigest:      metadata.TargetMapDigest,
+		TargetMapDigest:      targetMapDigest,
 	}
-	if metadata.TargetMapDigest == "" || !reflect.DeepEqual(metadata, expectedMetadata) {
-		return nil, fmt.Errorf("cached doSPCX %s plan does not match device %q inputs", stage, device.Name)
-	}
-
-	targetMapContent, err := os.ReadFile(targetMapPath)
-	if err != nil {
-		return nil, fmt.Errorf("read doSPCX target map %q: %w", targetMapPath, err)
-	}
-	if sha256Digest(targetMapContent) != metadata.TargetMapDigest {
-		return nil, fmt.Errorf("cached doSPCX %s plan target map digest does not match", stage)
-	}
-	var savedTargetMap targetMap
-	if err := json.Unmarshal(targetMapContent, &savedTargetMap); err != nil {
-		return nil, fmt.Errorf("decode doSPCX target map %q: %w", targetMapPath, err)
-	}
-	if err := validateDeviceInTargetMap(config, savedTargetMap); err != nil {
-		return nil, fmt.Errorf("cached doSPCX %s plan does not match device %q: %w", stage, device.Name, err)
-	}
-
-	planPath := filepath.Join(stateDir, "plans", generatedPlanName, "plan.json")
-	planContent, err := os.ReadFile(planPath)
-	if err != nil {
-		return nil, fmt.Errorf("read doSPCX %s plan %q: %w", stage, planPath, err)
-	}
-	savedConfig := &planConfig{
-		nodeName:      config.nodeName,
-		platformType:  metadata.PlatformType,
-		profile:       metadata.Profile,
-		version:       metadata.SpectrumXVersion,
-		multiplane:    metadata.MultiplaneMode,
-		overlay:       metadata.Overlay,
-		planes:        metadata.Planes,
-		targetMap:     savedTargetMap,
-		selectedCount: len(savedTargetMap.PreBreakout.Targets),
-	}
-	semanticPlan, err := validateGeneratedPlan(planContent, generatedPlanName, savedConfig, string(stage))
-	if err != nil {
-		return nil, fmt.Errorf("validate cached doSPCX %s plan: %w", stage, err)
-	}
-
-	return &Plan{
-		Name:     generatedPlanName,
-		Stage:    stage,
-		JSON:     append(json.RawMessage(nil), planContent...),
-		Semantic: semanticPlan,
-	}, nil
 }
 
 func planParameters(config *planConfig) ([]string, error) {
@@ -417,41 +440,46 @@ func hasSpectrumXEnabledDevice(devices []*v1alpha1.NicDevice) bool {
 	return false
 }
 
-func reusablePlan(
+func loadSavedPlan(
 	planPath string,
 	metadataPath string,
 	targetMapPath string,
 	expectedMetadata planMetadata,
 	config *planConfig,
-) (bool, string) {
+) (*preparedPlan, string) {
 	metadataContent, err := os.ReadFile(metadataPath)
 	if err != nil {
-		return false, fmt.Sprintf("read metadata: %v", err)
+		return nil, fmt.Sprintf("read metadata: %v", err)
 	}
 	var savedMetadata planMetadata
 	if err := json.Unmarshal(metadataContent, &savedMetadata); err != nil {
-		return false, fmt.Sprintf("decode metadata: %v", err)
+		return nil, fmt.Sprintf("decode metadata: %v", err)
 	}
 	if !reflect.DeepEqual(savedMetadata, expectedMetadata) {
-		return false, "planner inputs changed"
+		return nil, "planner inputs changed"
 	}
 
 	targetMapContent, err := os.ReadFile(targetMapPath)
 	if err != nil {
-		return false, fmt.Sprintf("read target map: %v", err)
+		return nil, fmt.Sprintf("read target map: %v", err)
 	}
 	if sha256Digest(targetMapContent) != expectedMetadata.TargetMapDigest {
-		return false, "target map content changed"
+		return nil, "target map content changed"
+	}
+	var savedTargetMap targetMap
+	if err := json.Unmarshal(targetMapContent, &savedTargetMap); err != nil {
+		return nil, fmt.Sprintf("decode target map: %v", err)
 	}
 
 	planContent, err := os.ReadFile(planPath)
 	if err != nil {
-		return false, fmt.Sprintf("read plan: %v", err)
+		return nil, fmt.Sprintf("read plan: %v", err)
 	}
-	if _, err := validateGeneratedPlan(planContent, expectedMetadata.PlanName, config, expectedMetadata.Stage); err != nil {
-		return false, fmt.Sprintf("validate plan: %v", err)
+	plan, err := validateGeneratedPlan(planContent, expectedMetadata.PlanName, config, PlanStage(expectedMetadata.Stage))
+	if err != nil {
+		return nil, fmt.Sprintf("validate plan: %v", err)
 	}
-	return true, ""
+	return &preparedPlan{metadata: savedMetadata, targetMap: savedTargetMap, plan: plan}, ""
 }
 
 func buildPlanConfig(devices []*v1alpha1.NicDevice) (*planConfig, error) {
@@ -483,14 +511,13 @@ func buildPlanConfig(devices []*v1alpha1.NicDevice) (*planConfig, error) {
 		platformType = defaultDospcxPlatformType
 	}
 	config := &planConfig{
-		nodeName:      nodeName,
-		platformType:  platformType,
-		profile:       profile,
-		version:       firstSpec.Version,
-		multiplane:    normalizedMultiplaneMode(firstSpec.MultiplaneMode),
-		overlay:       firstSpec.Overlay,
-		planes:        planes,
-		selectedCount: len(selected),
+		nodeName:     nodeName,
+		platformType: platformType,
+		profile:      profile,
+		version:      firstSpec.Version,
+		multiplane:   normalizedMultiplaneMode(firstSpec.MultiplaneMode),
+		overlay:      firstSpec.Overlay,
+		planes:       planes,
 		targetMap: targetMap{
 			SchemaVersion: targetMapSchemaVersion,
 			PlatformType:  platformType,
@@ -635,50 +662,21 @@ func validateGeneratedPlan(
 	planJSON []byte,
 	expectedName string,
 	config *planConfig,
-	expectedStage string,
-) (*SemanticPlan, error) {
-	var document struct {
-		Plan struct {
-			Name    string `json:"name"`
-			Family  string `json:"family"`
-			Profile string `json:"profile"`
-			Stage   string `json:"stage"`
-			Params  struct {
-				DeploymentMode string `json:"deployment_mode"`
-				Planes         int    `json:"planes"`
-			} `json:"params"`
-			DetectedHW struct {
-				PlatformType string `json:"platform_type"`
-			} `json:"detected_hw"`
-			Devices  []PlanDevice `json:"devices"`
-			Semantic *struct {
-				Groups []json.RawMessage `json:"groups"`
-			} `json:"semantic"`
-			BareMetal *struct {
-				Groups []json.RawMessage `json:"groups"`
-			} `json:"bare_metal"`
-		} `json:"plan"`
-		Artifacts struct {
-			Manifest []json.RawMessage `json:"manifest"`
-		} `json:"artifacts"`
-	}
-	if err := json.Unmarshal(planJSON, &document); err != nil {
+	expectedStage PlanStage,
+) (*Plan, error) {
+	document, err := decodePlanDocument(planJSON)
+	if err != nil {
 		return nil, fmt.Errorf("decode generated doSPCX %s plan: %w", expectedStage, err)
+	}
+	plan, err := buildDMSPlan(context.Background(), document, expectedStage)
+	if err != nil {
+		return nil, fmt.Errorf("compile generated doSPCX %s semantic plan: %w", expectedStage, err)
 	}
 	if document.Plan.Name != expectedName {
 		return nil, fmt.Errorf("generated doSPCX plan name is %q, expected %q", document.Plan.Name, expectedName)
 	}
-	if document.Plan.Family != "spcx" {
-		return nil, fmt.Errorf("generated doSPCX plan family is %q, expected %q", document.Plan.Family, "spcx")
-	}
 	if document.Plan.Profile != config.profile {
 		return nil, fmt.Errorf("generated doSPCX plan profile is %q, expected %q", document.Plan.Profile, config.profile)
-	}
-	if document.Plan.Stage != expectedStage {
-		return nil, fmt.Errorf("generated doSPCX plan stage is %q, expected %q", document.Plan.Stage, expectedStage)
-	}
-	if document.Plan.Params.DeploymentMode != deploymentModeHostK8s {
-		return nil, fmt.Errorf("generated doSPCX plan deployment mode is %q, expected %q", document.Plan.Params.DeploymentMode, deploymentModeHostK8s)
 	}
 	if document.Plan.Params.Planes != config.planes {
 		return nil, fmt.Errorf("generated doSPCX plan plane count is %d, expected %d", document.Plan.Params.Planes, config.planes)
@@ -686,30 +684,20 @@ func validateGeneratedPlan(
 	if document.Plan.DetectedHW.PlatformType != config.platformType {
 		return nil, fmt.Errorf("generated doSPCX plan platform type is %q, expected %q", document.Plan.DetectedHW.PlatformType, config.platformType)
 	}
-	if document.Plan.Semantic == nil || len(document.Plan.Semantic.Groups) == 0 {
-		return nil, fmt.Errorf("generated doSPCX %s plan does not contain semantic groups", expectedStage)
-	}
 	if document.Plan.BareMetal != nil && len(document.Plan.BareMetal.Groups) > 0 {
 		return nil, fmt.Errorf("generated doSPCX %s plan unexpectedly contains bare-metal groups", expectedStage)
 	}
 	if len(document.Artifacts.Manifest) > 0 {
 		return nil, fmt.Errorf("generated doSPCX %s plan unexpectedly contains rendered artifacts", expectedStage)
 	}
-	if err := validateGeneratedPlanDevices(document.Plan.Devices, config, PlanStage(expectedStage)); err != nil {
+	if err := validateGeneratedPlanDevices(document.Plan.Devices, config, expectedStage); err != nil {
 		return nil, err
 	}
-	semanticPlan, err := ParseSemanticPlan(planJSON, PlanStage(expectedStage))
-	if err != nil {
-		return nil, fmt.Errorf("validate generated doSPCX %s semantic plan: %w", expectedStage, err)
-	}
-	if _, err := semanticPlan.BuildDMSOperationPlan(context.Background()); err != nil {
-		return nil, fmt.Errorf("compile generated doSPCX %s semantic plan: %w", expectedStage, err)
-	}
-	return semanticPlan, nil
+	return plan, nil
 }
 
-func validateGeneratedPlanDevices(actual []PlanDevice, config *planConfig, stage PlanStage) error {
-	expected := make(map[string]PlanDevice, config.selectedCount*config.planes)
+func validateGeneratedPlanDevices(actual []planDevice, config *planConfig, stage PlanStage) error {
+	expected := make(map[string]planDevice, len(config.targetMap.PreBreakout.Targets)*config.planes)
 	for _, target := range config.targetMap.PreBreakout.Targets {
 		planes := 1
 		if stage == PlanStageConfigure {
@@ -720,7 +708,7 @@ func validateGeneratedPlanDevices(actual []PlanDevice, config *planConfig, stage
 			if err != nil {
 				return err
 			}
-			expected[bdf] = PlanDevice{
+			expected[bdf] = planDevice{
 				BDF:       bdf,
 				DeviceID:  target.DeviceID,
 				DMSTarget: "pci/" + bdf,

--- a/pkg/spectrumx/prepareplan_test.go
+++ b/pkg/spectrumx/prepareplan_test.go
@@ -48,6 +48,7 @@ func newTestPlanManager(
 ) PlanManager {
 	return &spectrumXConfigManager{
 		spectrumXConfigs:   nil,
+		preparedPlans:      make(map[string]*preparedPlan),
 		dmsManager:         nil,
 		execInterface:      execInterface,
 		blueprintsRoot:     blueprintsRoot,
@@ -260,9 +261,8 @@ var _ = Describe("doSPCX planning", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(plan.Name).To(Equal(planName))
 		Expect(plan.Stage).To(Equal(PlanStagePrepare))
-		Expect(plan.JSON).NotTo(BeEmpty())
-		Expect(plan.Semantic).NotTo(BeNil())
-		Expect(plan.Semantic.Groups).To(HaveLen(2))
+		Expect(plan.Groups).To(HaveLen(2))
+		Expect(plan.Groups[0].Name).To(Equal("breakout"))
 		planPath := filepath.Join(stateDir, "plans", planName, "plan.json")
 		planContent, err := os.ReadFile(planPath)
 		Expect(err).NotTo(HaveOccurred())
@@ -327,6 +327,33 @@ var _ = Describe("doSPCX planning", func() {
 		Expect(string(metadataContent)).NotTo(ContainSubstring(`"inputs"`))
 	})
 
+	It("serves prepared plans from memory without rereading persisted files", func() {
+		stateDir := GinkgoT().TempDir()
+		commands := []preparePlanCommand{}
+		generatedPlanName := planName(nodeName, prepareStage)
+		manager := newTestPlanManager(
+			preparePlanFakeExecutor(
+				planResponse(generatedPlanName, "SPX_Multiplane", prepareStage, 2, 1), &commands,
+			), blueprintsRoot, stateDir,
+		)
+		device := newDevice("rail-0", "0000:64:00.0", "hwplb")
+		Expect(manager.PreparePlan(context.Background(), []*v1alpha1.NicDevice{device}, PlanStagePrepare)).To(Succeed())
+
+		Expect(os.RemoveAll(filepath.Join(stateDir, "plans"))).To(Succeed())
+		Expect(os.RemoveAll(filepath.Join(stateDir, "target-maps"))).To(Succeed())
+		Expect(manager.PreparePlan(context.Background(), []*v1alpha1.NicDevice{device}, PlanStagePrepare)).To(Succeed())
+		Expect(commands).To(HaveLen(1))
+		plan, err := manager.GetPreparedPlan(device, PlanStagePrepare)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(plan.Name).To(Equal(generatedPlanName))
+		Expect(plan.Groups).To(HaveLen(2))
+		plan.Groups[0].Name = "mutated-by-caller"
+		plan, err = manager.GetPreparedPlan(device, PlanStagePrepare)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(plan.Groups[0].Name).To(Equal("breakout"))
+	})
+
 	It("does not generate a plan when Spectrum-X is not enabled", func() {
 		commands := []preparePlanCommand{}
 		manager := newTestPlanManager(preparePlanFakeExecutor(nil, &commands), blueprintsRoot, GinkgoT().TempDir())
@@ -343,6 +370,16 @@ var _ = Describe("doSPCX planning", func() {
 		_, err := manager.GetPreparedPlan(newDevice("device", "0000:64:00.0", "hwplb"), PlanStage("unknown"))
 
 		Expect(err).To(MatchError(ContainSubstring("unsupported")))
+	})
+
+	It("does not load a persisted plan through the per-device retrieval path", func() {
+		manager := newTestPlanManager(nil, blueprintsRoot, GinkgoT().TempDir())
+		device := newDevice("device", "0000:64:00.0", "hwplb")
+
+		plan, err := manager.GetPreparedPlan(device, PlanStagePrepare)
+
+		Expect(plan).To(BeNil())
+		Expect(err).To(MatchError(ContainSubstring("is not prepared")))
 	})
 
 	DescribeTable("scopes generated plans to the requested node",

--- a/pkg/spectrumx/semanticplan.go
+++ b/pkg/spectrumx/semanticplan.go
@@ -42,104 +42,6 @@ const (
 	rdmaTopologyPerRailBond = "per_rail_bond"
 )
 
-// PlanDevice is one DMS-addressable device emitted by the doSPCX planner.
-type PlanDevice struct {
-	BDF            string   `json:"bdf"`
-	DeviceID       string   `json:"device_id"`
-	HCAType        string   `json:"hca_type"`
-	Netdev         string   `json:"netdev"`
-	RDMADevice     string   `json:"rdma_dev"`
-	DMSTarget      string   `json:"dms_target"`
-	PFIndex        int      `json:"pf_index"`
-	Rail           int      `json:"rail"`
-	Plane          int      `json:"plane"`
-	PlaneExplicit  bool     `json:"plane_explicit"`
-	Network        string   `json:"network"`
-	PhysicalLabel  string   `json:"physical_label"`
-	ResetDomain    string   `json:"reset_domain"`
-	EndpointLabels []string `json:"endpoint_labels"`
-	TargetID       string   `json:"target_id"`
-}
-
-// ExpectedRDMA describes one expected RDMA endpoint emitted by the planner.
-// ControlBDF and ControlTarget are retained for compatibility with older,
-// enriched plans; public doSPCX plans do not require them.
-type ExpectedRDMA struct {
-	Rail          int    `json:"rail"`
-	RDMADevice    string `json:"rdma_dev"`
-	ControlBDF    string `json:"control_bdf"`
-	ControlTarget string `json:"control_target"`
-	Source        string `json:"source"`
-}
-
-// SemanticRuntimeContext contains topology needed to resolve semantic target
-// classes without interpreting rendered bare-metal artifacts.
-type SemanticRuntimeContext struct {
-	DeploymentMode   string         `json:"deployment_mode"`
-	MultiplaneMode   string         `json:"multiplane_mode"`
-	ESwitchMultiport bool           `json:"esw_multiport"`
-	NumVFs           int            `json:"num_vfs"`
-	PostBreakout     bool           `json:"post_breakout"`
-	RDMATopology     string         `json:"rdma_topology"`
-	ExpectedRDMA     []ExpectedRDMA `json:"expected_rdma"`
-}
-
-// ResetPolicy records the reset boundary associated with a semantic operation.
-type ResetPolicy struct {
-	Action        string `json:"action"`
-	Owner         string `json:"owner"`
-	Postcondition string `json:"postcondition"`
-}
-
-// SemanticOperation is one referenced typed operation from plan.operations.
-type SemanticOperation struct {
-	ID             string
-	Path           string
-	Values         map[string]any
-	SourceFeature  string
-	Kind           string
-	TargetClass    string
-	TargetRole     string
-	ExecutionGroup string
-	Scope          string
-	Lifecycle      string
-	Reset          *ResetPolicy
-	Condition      json.RawMessage
-	Context        json.RawMessage
-}
-
-// SemanticGroup preserves the planner's ordered semantic execution boundary.
-type SemanticGroup struct {
-	Name           string
-	Stage          PlanStage
-	Order          int
-	Scope          string
-	DeviceView     string
-	FanoutOrder    string
-	RequiresReboot bool
-	Operations     []SemanticOperation
-}
-
-// SemanticPlan is the NCO-facing doSPCX plan surface. It intentionally omits
-// bare-metal steps, services, and rendered artifacts.
-type SemanticPlan struct {
-	Name           string
-	Profile        string
-	Stage          PlanStage
-	PathDialect    string
-	Devices        []PlanDevice
-	RuntimeContext SemanticRuntimeContext
-	Groups         []SemanticGroup
-}
-
-// DMSOperationPlan contains ordered, target-resolved operations ready for the
-// generic dms-cli query/set transport. It does not execute any operation.
-type DMSOperationPlan struct {
-	Stage         PlanStage
-	Groups        []DMSOperationGroup
-	SkippedGroups []SkippedSemanticGroup
-}
-
 // DMSOperationGroup is one executable group or ordered phase marker.
 type DMSOperationGroup struct {
 	Name           string
@@ -168,7 +70,7 @@ type SkippedSemanticGroup struct {
 	Reason string
 }
 
-type semanticPlanDocument struct {
+type planDocument struct {
 	Plan struct {
 		Name        string `json:"name"`
 		Family      string `json:"family"`
@@ -177,14 +79,38 @@ type semanticPlanDocument struct {
 		PathDialect string `json:"path_dialect"`
 		Params      struct {
 			DeploymentMode string `json:"deployment_mode"`
+			Planes         int    `json:"planes"`
 		} `json:"params"`
-		Devices        []PlanDevice                       `json:"devices"`
-		RuntimeContext SemanticRuntimeContext             `json:"runtime_ctx"`
+		DetectedHW struct {
+			PlatformType string `json:"platform_type"`
+		} `json:"detected_hw"`
+		Devices        []planDevice                       `json:"devices"`
+		RuntimeContext planRuntimeContext                 `json:"runtime_ctx"`
 		Operations     map[string]semanticOperationRecord `json:"operations"`
 		Semantic       *struct {
 			Groups []semanticGroupRecord `json:"groups"`
 		} `json:"semantic"`
+		BareMetal *struct {
+			Groups []json.RawMessage `json:"groups"`
+		} `json:"bare_metal"`
 	} `json:"plan"`
+	Artifacts struct {
+		Manifest []json.RawMessage `json:"manifest"`
+	} `json:"artifacts"`
+}
+
+type planDevice struct {
+	BDF        string `json:"bdf"`
+	DeviceID   string `json:"device_id"`
+	RDMADevice string `json:"rdma_dev"`
+	DMSTarget  string `json:"dms_target"`
+	Rail       int    `json:"rail"`
+	Plane      int    `json:"plane"`
+	Network    string `json:"network"`
+}
+
+type planRuntimeContext struct {
+	RDMATopology string `json:"rdma_topology"`
 }
 
 type semanticGroupRecord struct {
@@ -199,31 +125,20 @@ type semanticGroupRecord struct {
 }
 
 type semanticOperationRecord struct {
-	Path           string          `json:"path"`
-	Values         map[string]any  `json:"values"`
-	SourceFeature  string          `json:"source_feature"`
-	Kind           string          `json:"kind"`
-	TargetClass    string          `json:"target_class"`
-	TargetRole     string          `json:"target_role"`
-	ExecutionGroup string          `json:"execution_group"`
-	Scope          string          `json:"scope"`
-	Lifecycle      string          `json:"lifecycle"`
-	Reset          *ResetPolicy    `json:"reset"`
-	Condition      json.RawMessage `json:"condition"`
-	Context        json.RawMessage `json:"context"`
+	ID          string         `json:"-"`
+	Path        string         `json:"path"`
+	Values      map[string]any `json:"values"`
+	Kind        string         `json:"kind"`
+	TargetClass string         `json:"target_class"`
+	TargetRole  string         `json:"target_role"`
+	Scope       string         `json:"scope"`
 }
 
-// ParseSemanticPlan parses and validates the semantic consumer surface of a
-// generated host-k8s doSPCX plan.
-func ParseSemanticPlan(planJSON json.RawMessage, expectedStage PlanStage) (*SemanticPlan, error) {
-	if err := validatePlanStage(expectedStage); err != nil {
-		return nil, err
-	}
+func decodePlanDocument(planJSON []byte) (*planDocument, error) {
 	if len(bytes.TrimSpace(planJSON)) == 0 {
 		return nil, fmt.Errorf("doSPCX plan must not be empty")
 	}
-
-	var document semanticPlanDocument
+	var document planDocument
 	decoder := json.NewDecoder(bytes.NewReader(planJSON))
 	decoder.UseNumber()
 	if err := decoder.Decode(&document); err != nil {
@@ -236,121 +151,83 @@ func ParseSemanticPlan(planJSON json.RawMessage, expectedStage PlanStage) (*Sema
 		}
 		return nil, fmt.Errorf("decode doSPCX semantic plan trailing data: %w", err)
 	}
-
-	if err := validateSemanticPlanHeader(&document, expectedStage); err != nil {
-		return nil, err
-	}
-	if err := validatePlanDevices(document.Plan.Devices); err != nil {
-		return nil, err
-	}
-
-	groups, err := resolveSemanticGroups(
-		document.Plan.Semantic.Groups,
-		document.Plan.Operations,
-		expectedStage,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return &SemanticPlan{
-		Name:           document.Plan.Name,
-		Profile:        document.Plan.Profile,
-		Stage:          expectedStage,
-		PathDialect:    document.Plan.PathDialect,
-		Devices:        append([]PlanDevice(nil), document.Plan.Devices...),
-		RuntimeContext: document.Plan.RuntimeContext,
-		Groups:         groups,
-	}, nil
+	return &document, nil
 }
 
-// BuildDMSOperationPlan applies NCO execution policy and resolves semantic
-// target classes. The eswitch and vf-lifecycle groups are intentionally skipped
-// in this phase; unknown groups fail closed.
-func (p *SemanticPlan) BuildDMSOperationPlan(ctx context.Context) (*DMSOperationPlan, error) {
-	if p == nil {
-		return nil, fmt.Errorf("semantic plan must not be nil")
-	}
-	if err := validatePlanStage(p.Stage); err != nil {
+func buildDMSPlan(ctx context.Context, document *planDocument, expectedStage PlanStage) (*Plan, error) {
+	if err := validateSemanticPlan(document, expectedStage); err != nil {
 		return nil, err
 	}
 
-	result := &DMSOperationPlan{
-		Stage:         p.Stage,
-		Groups:        make([]DMSOperationGroup, 0, len(p.Groups)),
+	records := append([]semanticGroupRecord(nil), document.Plan.Semantic.Groups...)
+	sort.SliceStable(records, func(left, right int) bool {
+		return records[left].Order < records[right].Order
+	})
+	result := &Plan{
+		Name:          document.Plan.Name,
+		Stage:         expectedStage,
+		Groups:        make([]DMSOperationGroup, 0, len(records)),
 		SkippedGroups: nil,
 	}
-	for _, group := range p.Groups {
-		disposition, reason, err := semanticGroupDisposition(p.Stage, group.Name)
+	names := make(map[string]struct{}, len(records))
+	for index, group := range records {
+		if err := validateSemanticGroup(group, index, expectedStage, names); err != nil {
+			return nil, err
+		}
+		operations, err := resolveGroupOperations(group, document.Plan.Operations)
 		if err != nil {
 			return nil, err
 		}
-		switch disposition {
-		case groupDispositionSkip:
-			skipped := SkippedSemanticGroup{Name: group.Name, Order: group.Order, Reason: reason}
-			result.SkippedGroups = append(result.SkippedGroups, skipped)
+		disposition, reason, err := semanticGroupDisposition(expectedStage, group.Name)
+		if err != nil {
+			return nil, err
+		}
+		if disposition == groupDispositionSkip {
+			result.SkippedGroups = append(result.SkippedGroups, SkippedSemanticGroup{
+				Name: group.Name, Order: group.Order, Reason: reason,
+			})
 			logr.FromContextOrDiscard(ctx).V(2).Info("skipping doSPCX semantic group",
-				"plan", p.Name,
-				"stage", p.Stage,
-				"group", group.Name,
-				"order", group.Order,
-				"reason", reason)
+				"plan", document.Plan.Name, "stage", expectedStage,
+				"group", group.Name, "order", group.Order, "reason", reason)
 			continue
-		case groupDispositionMarker:
-			if len(group.Operations) != 0 {
+		}
+
+		compiled := DMSOperationGroup{
+			Name:           group.Name,
+			Order:          group.Order,
+			Scope:          group.Scope,
+			DeviceView:     group.DeviceView,
+			FanoutOrder:    group.FanoutOrder,
+			RequiresReboot: group.RequiresReboot,
+			PhaseMarker:    disposition == groupDispositionMarker,
+		}
+		if compiled.PhaseMarker {
+			if len(operations) != 0 {
 				return nil, fmt.Errorf("doSPCX semantic phase marker %q unexpectedly contains operations", group.Name)
 			}
-			result.Groups = append(result.Groups, DMSOperationGroup{
-				Name:           group.Name,
-				Order:          group.Order,
-				Scope:          group.Scope,
-				DeviceView:     group.DeviceView,
-				FanoutOrder:    group.FanoutOrder,
-				RequiresReboot: group.RequiresReboot,
-				PhaseMarker:    true,
-				Targets:        nil,
-			})
-			continue
-		case groupDispositionExecute:
-			if err := validateExecutableGroupPolicy(group); err != nil {
+		} else {
+			if err := validateExecutableOperations(group.Name, operations); err != nil {
 				return nil, err
 			}
-			targets, err := p.resolveGroupTargets(group)
+			compiled.Targets, err = resolveGroupTargets(
+				document.Plan.Devices, document.Plan.RuntimeContext.RDMATopology,
+				operations, expectedStage)
 			if err != nil {
 				return nil, fmt.Errorf("resolve doSPCX semantic group %q: %w", group.Name, err)
 			}
-			result.Groups = append(result.Groups, DMSOperationGroup{
-				Name:           group.Name,
-				Order:          group.Order,
-				Scope:          group.Scope,
-				DeviceView:     group.DeviceView,
-				FanoutOrder:    group.FanoutOrder,
-				RequiresReboot: group.RequiresReboot,
-				PhaseMarker:    false,
-				Targets:        targets,
-			})
-		default:
-			return nil, fmt.Errorf("unsupported doSPCX semantic group disposition %q", disposition)
 		}
+		result.Groups = append(result.Groups, compiled)
 	}
 	return result, nil
 }
 
-func validateExecutableGroupPolicy(group SemanticGroup) error {
-	for _, operation := range group.Operations {
-		if operation.TargetClass == targetClassPerESwitch ||
-			operation.TargetClass == targetClassVFRepresentor ||
-			operation.Scope == "per_vf" ||
-			strings.HasPrefix(operation.Path, "/nvidia/eswitch") {
-			return fmt.Errorf(
-				"doSPCX semantic group %q contains operation %q outside the current NCO execution scope",
-				group.Name, operation.ID)
-		}
+func validateSemanticPlan(document *planDocument, expectedStage PlanStage) error {
+	if document == nil {
+		return fmt.Errorf("doSPCX plan must not be nil")
 	}
-	return nil
-}
-
-func validateSemanticPlanHeader(document *semanticPlanDocument, expectedStage PlanStage) error {
+	if err := validatePlanStage(expectedStage); err != nil {
+		return err
+	}
 	if strings.TrimSpace(document.Plan.Name) == "" {
 		return fmt.Errorf("doSPCX semantic plan name must not be empty")
 	}
@@ -375,10 +252,10 @@ func validateSemanticPlanHeader(document *semanticPlanDocument, expectedStage Pl
 	if document.Plan.Semantic == nil || len(document.Plan.Semantic.Groups) == 0 {
 		return fmt.Errorf("doSPCX semantic plan does not contain semantic groups")
 	}
-	return nil
+	return validatePlanDevices(document.Plan.Devices)
 }
 
-func validatePlanDevices(devices []PlanDevice) error {
+func validatePlanDevices(devices []planDevice) error {
 	bdfs := make(map[string]struct{}, len(devices))
 	targets := make(map[string]struct{}, len(devices))
 	for index, device := range devices {
@@ -389,7 +266,7 @@ func validatePlanDevices(devices []PlanDevice) error {
 			return fmt.Errorf("doSPCX plan device BDF %q is duplicated", device.BDF)
 		}
 		bdfs[device.BDF] = struct{}{}
-		if !strings.HasPrefix(device.DMSTarget, "pci/") || strings.TrimPrefix(device.DMSTarget, "pci/") != device.BDF {
+		if device.DMSTarget != "pci/"+device.BDF {
 			return fmt.Errorf("doSPCX plan device %q has invalid DMS target %q", device.BDF, device.DMSTarget)
 		}
 		if _, found := targets[device.DMSTarget]; found {
@@ -403,86 +280,56 @@ func validatePlanDevices(devices []PlanDevice) error {
 	return nil
 }
 
-func resolveSemanticGroups(
-	records []semanticGroupRecord,
-	operations map[string]semanticOperationRecord,
+func validateSemanticGroup(
+	group semanticGroupRecord,
+	index int,
 	expectedStage PlanStage,
-) ([]SemanticGroup, error) {
-	groups := make([]SemanticGroup, 0, len(records))
-	names := make(map[string]struct{}, len(records))
-	for groupIndex, record := range records {
-		if strings.TrimSpace(record.Name) == "" {
-			return nil, fmt.Errorf("doSPCX semantic group at index %d has no name", groupIndex)
-		}
-		if _, found := names[record.Name]; found {
-			return nil, fmt.Errorf("doSPCX semantic group %q is duplicated", record.Name)
-		}
-		names[record.Name] = struct{}{}
-		if record.Stage != string(expectedStage) {
-			return nil, fmt.Errorf("doSPCX semantic group %q stage is %q, expected %q", record.Name, record.Stage, expectedStage)
-		}
-
-		group := SemanticGroup{
-			Name:           record.Name,
-			Stage:          expectedStage,
-			Order:          record.Order,
-			Scope:          record.Scope,
-			DeviceView:     record.DeviceView,
-			FanoutOrder:    record.FanoutOrder,
-			RequiresReboot: record.RequiresReboot,
-			Operations:     make([]SemanticOperation, 0, len(record.OperationRefs)),
-		}
-		refs := make(map[string]struct{}, len(record.OperationRefs))
-		for refIndex, ref := range record.OperationRefs {
-			if strings.TrimSpace(ref) == "" {
-				return nil, fmt.Errorf("doSPCX semantic group %q operation reference at index %d is empty", record.Name, refIndex)
-			}
-			if _, found := refs[ref]; found {
-				return nil, fmt.Errorf("doSPCX semantic group %q operation reference %q is duplicated", record.Name, ref)
-			}
-			refs[ref] = struct{}{}
-			operation, found := operations[ref]
-			if !found {
-				return nil, fmt.Errorf("doSPCX semantic group %q references missing operation %q", record.Name, ref)
-			}
-			if operation.Kind == "" {
-				// DMS treats an omitted kind as a SET operation. The planner only
-				// emits kind when YANG-based classification is available.
-				operation.Kind = "set"
-			}
-			if operation.TargetClass == "" {
-				operation.TargetClass = targetClassPFNetdevAll
-			}
-			// Group membership is defined by semantic.groups.operation_refs in
-			// the public plan. Keep the derived value on the exported operation
-			// for compatibility with callers of this package.
-			operation.ExecutionGroup = record.Name
-			if err := validateSemanticOperation(ref, operation); err != nil {
-				return nil, err
-			}
-			group.Operations = append(group.Operations, SemanticOperation{
-				ID:             ref,
-				Path:           operation.Path,
-				Values:         cloneValueMap(operation.Values),
-				SourceFeature:  operation.SourceFeature,
-				Kind:           operation.Kind,
-				TargetClass:    operation.TargetClass,
-				TargetRole:     operation.TargetRole,
-				ExecutionGroup: operation.ExecutionGroup,
-				Scope:          operation.Scope,
-				Lifecycle:      operation.Lifecycle,
-				Reset:          operation.Reset,
-				Condition:      append(json.RawMessage(nil), operation.Condition...),
-				Context:        append(json.RawMessage(nil), operation.Context...),
-			})
-		}
-		groups = append(groups, group)
+	names map[string]struct{},
+) error {
+	if strings.TrimSpace(group.Name) == "" {
+		return fmt.Errorf("doSPCX semantic group at index %d has no name", index)
 	}
+	if _, found := names[group.Name]; found {
+		return fmt.Errorf("doSPCX semantic group %q is duplicated", group.Name)
+	}
+	names[group.Name] = struct{}{}
+	if group.Stage != string(expectedStage) {
+		return fmt.Errorf("doSPCX semantic group %q stage is %q, expected %q", group.Name, group.Stage, expectedStage)
+	}
+	return nil
+}
 
-	sort.SliceStable(groups, func(left, right int) bool {
-		return groups[left].Order < groups[right].Order
-	})
-	return groups, nil
+func resolveGroupOperations(
+	group semanticGroupRecord,
+	operations map[string]semanticOperationRecord,
+) ([]semanticOperationRecord, error) {
+	result := make([]semanticOperationRecord, 0, len(group.OperationRefs))
+	refs := make(map[string]struct{}, len(group.OperationRefs))
+	for index, ref := range group.OperationRefs {
+		if strings.TrimSpace(ref) == "" {
+			return nil, fmt.Errorf("doSPCX semantic group %q operation reference at index %d is empty", group.Name, index)
+		}
+		if _, found := refs[ref]; found {
+			return nil, fmt.Errorf("doSPCX semantic group %q operation reference %q is duplicated", group.Name, ref)
+		}
+		refs[ref] = struct{}{}
+		operation, found := operations[ref]
+		if !found {
+			return nil, fmt.Errorf("doSPCX semantic group %q references missing operation %q", group.Name, ref)
+		}
+		if operation.Kind == "" {
+			operation.Kind = "set"
+		}
+		if operation.TargetClass == "" {
+			operation.TargetClass = targetClassPFNetdevAll
+		}
+		operation.ID = ref
+		if err := validateSemanticOperation(ref, operation); err != nil {
+			return nil, err
+		}
+		result = append(result, operation)
+	}
+	return result, nil
 }
 
 func validateSemanticOperation(id string, operation semanticOperationRecord) error {
@@ -511,6 +358,20 @@ func validateSemanticOperation(id string, operation semanticOperationRecord) err
 	return nil
 }
 
+func validateExecutableOperations(group string, operations []semanticOperationRecord) error {
+	for _, operation := range operations {
+		if operation.TargetClass == targetClassPerESwitch ||
+			operation.TargetClass == targetClassVFRepresentor ||
+			operation.Scope == "per_vf" ||
+			strings.HasPrefix(operation.Path, "/nvidia/eswitch") {
+			return fmt.Errorf(
+				"doSPCX semantic group %q contains operation %q outside the current NCO execution scope",
+				group, operation.ID)
+		}
+	}
+	return nil
+}
+
 func validSemanticValue(value any) bool {
 	if value == nil {
 		return false
@@ -526,13 +387,17 @@ func validSemanticValue(value any) bool {
 		reflect.Float32, reflect.Float64:
 		return true
 	case reflect.Array, reflect.Slice:
+		if reflected.Len() == 0 {
+			return false
+		}
 		for index := 0; index < reflected.Len(); index++ {
 			item := reflected.Index(index).Interface()
 			if item == nil {
 				return false
 			}
 			kind := reflect.ValueOf(item).Kind()
-			if kind == reflect.Array || kind == reflect.Slice || kind == reflect.Map || kind == reflect.Struct || kind == reflect.Pointer {
+			if kind == reflect.Array || kind == reflect.Slice || kind == reflect.Map ||
+				kind == reflect.Struct || kind == reflect.Pointer {
 				return false
 			}
 			if !validSemanticValue(item) {
@@ -575,11 +440,16 @@ func semanticGroupDisposition(stage PlanStage, name string) (groupDisposition, s
 	return "", "", fmt.Errorf("unsupported doSPCX semantic group %q for stage %q", name, stage)
 }
 
-func (p *SemanticPlan) resolveGroupTargets(group SemanticGroup) ([]DMSTargetOperations, error) {
-	targetOrder := make([]string, 0, len(p.Devices))
-	operationsByTarget := make(map[string][]dmscli.XPathOperation, len(p.Devices))
-	for _, operation := range group.Operations {
-		targets, err := p.resolveOperationTargets(operation)
+func resolveGroupTargets(
+	devices []planDevice,
+	rdmaTopology string,
+	operations []semanticOperationRecord,
+	stage PlanStage,
+) ([]DMSTargetOperations, error) {
+	targetOrder := make([]string, 0, len(devices))
+	operationsByTarget := make(map[string][]dmscli.XPathOperation, len(devices))
+	for _, operation := range operations {
+		targets, err := resolveOperationTargets(devices, rdmaTopology, operation)
 		if err != nil {
 			return nil, fmt.Errorf("operation %q: %w", operation.ID, err)
 		}
@@ -588,83 +458,60 @@ func (p *SemanticPlan) resolveGroupTargets(group SemanticGroup) ([]DMSTargetOper
 				targetOrder = append(targetOrder, target)
 			}
 			operationsByTarget[target] = append(operationsByTarget[target], dmscli.XPathOperation{
-				Path:   operation.Path,
-				Values: cloneValueMap(operation.Values),
+				Path: operation.Path, Values: cloneValueMap(operation.Values),
 			})
 		}
 	}
-
-	if len(group.Operations) > 0 && len(targetOrder) == 0 {
+	if len(operations) > 0 && len(targetOrder) == 0 {
 		return nil, fmt.Errorf("no DMS targets resolved")
 	}
 	result := make([]DMSTargetOperations, 0, len(targetOrder))
 	for _, target := range targetOrder {
-		operations := operationsByTarget[target]
-		desired := finalDesiredState(operations)
+		ordered := operationsByTarget[target]
+		desired := finalDesiredState(ordered)
 		result = append(result, DMSTargetOperations{
-			Target:     target,
-			Queries:    queriesForDesiredState(desired, p.Stage == PlanStagePrepare),
-			Desired:    desired,
-			Operations: operations,
+			Target: target, Queries: queriesForDesiredState(desired, stage == PlanStagePrepare),
+			Desired: desired, Operations: ordered,
 		})
 	}
 	return result, nil
 }
 
-func (p *SemanticPlan) resolveOperationTargets(operation SemanticOperation) ([]string, error) {
-	eligible := make([]PlanDevice, 0, len(p.Devices))
-	for _, device := range p.Devices {
-		// target_role is not part of the public doSPCX operation schema. If
-		// an enriched plan supplies it, retain the historical filtering;
-		// otherwise the operation targets all plan devices.
+func resolveOperationTargets(
+	devices []planDevice,
+	rdmaTopology string,
+	operation semanticOperationRecord,
+) ([]string, error) {
+	result := make([]string, 0, len(devices))
+	for _, device := range devices {
 		if operation.TargetRole != "" && device.Network != operation.TargetRole {
 			continue
 		}
-		eligible = append(eligible, device)
+		switch operation.TargetClass {
+		case targetClassPFNetdevAll:
+			result = append(result, device.DMSTarget)
+		case targetClassPFRDMAScope:
+			switch rdmaTopology {
+			case rdmaTopologyPerPF:
+				if strings.TrimSpace(device.RDMADevice) != "" {
+					result = append(result, device.DMSTarget)
+				}
+			case rdmaTopologyPerRailBond:
+				if device.Plane == 0 {
+					result = append(result, device.DMSTarget)
+				}
+			default:
+				return nil, fmt.Errorf("unsupported RDMA topology %q", rdmaTopology)
+			}
+		}
 	}
-	if len(eligible) == 0 {
+	if len(result) == 0 {
 		if operation.TargetRole != "" {
 			return nil, fmt.Errorf("no plan devices match target role %q", operation.TargetRole)
 		}
 		return nil, fmt.Errorf("doSPCX plan does not contain eligible devices")
 	}
-
-	switch operation.TargetClass {
-	case targetClassPFNetdevAll:
-		result := make([]string, 0, len(eligible))
-		for _, device := range eligible {
-			result = append(result, device.DMSTarget)
-		}
-		return result, nil
-	case targetClassPFRDMAScope:
-		switch p.RuntimeContext.RDMATopology {
-		case rdmaTopologyPerPF:
-			result := make([]string, 0, len(eligible))
-			for _, device := range eligible {
-				if strings.TrimSpace(device.RDMADevice) == "" {
-					continue
-				}
-				result = append(result, device.DMSTarget)
-			}
-			return result, nil
-		case rdmaTopologyPerRailBond:
-			// This mirrors DMS FilterOpsForDevice: a per-rail bond is
-			// controlled through the plane-zero PF. expected_rdma describes
-			// the bond but does not carry a DMS control target in the public
-			// plan schema.
-			result := make([]string, 0, len(eligible))
-			for _, device := range eligible {
-				if device.Plane == 0 {
-					result = append(result, device.DMSTarget)
-				}
-			}
-			return result, nil
-		default:
-			return nil, fmt.Errorf("unsupported RDMA topology %q", p.RuntimeContext.RDMATopology)
-		}
-	default:
-		return nil, fmt.Errorf("target class %q is not executable in this phase", operation.TargetClass)
-	}
+	return result, nil
 }
 
 func finalDesiredState(operations []dmscli.XPathOperation) []dmscli.XPathOperation {
@@ -692,11 +539,7 @@ func finalDesiredState(operations []dmscli.XPathOperation) []dmscli.XPathOperati
 func queriesForDesiredState(desired []dmscli.XPathOperation, includePending bool) []dmscli.XPathQuery {
 	result := make([]dmscli.XPathQuery, 0, len(desired))
 	for _, operation := range desired {
-		leafCapacity := len(operation.Values)
-		if includePending {
-			leafCapacity *= 2
-		}
-		leaves := make([]string, 0, leafCapacity)
+		leaves := make([]string, 0, len(operation.Values)*2)
 		for leaf := range operation.Values {
 			leaves = append(leaves, leaf)
 			if includePending {
@@ -710,9 +553,6 @@ func queriesForDesiredState(desired []dmscli.XPathOperation, includePending bool
 }
 
 func cloneValueMap(values map[string]any) map[string]any {
-	if values == nil {
-		return nil
-	}
 	result := make(map[string]any, len(values))
 	for key, value := range values {
 		result[key] = cloneSemanticValue(value)
@@ -721,15 +561,12 @@ func cloneValueMap(values map[string]any) map[string]any {
 }
 
 func cloneSemanticValue(value any) any {
-	if value == nil {
-		return nil
-	}
 	reflected := reflect.ValueOf(value)
 	if reflected.Kind() != reflect.Array && reflected.Kind() != reflect.Slice {
 		return value
 	}
 	result := make([]any, reflected.Len())
-	for index := 0; index < reflected.Len(); index++ {
+	for index := range result {
 		result[index] = cloneSemanticValue(reflected.Index(index).Interface())
 	}
 	return result

--- a/pkg/spectrumx/semanticplan_test.go
+++ b/pkg/spectrumx/semanticplan_test.go
@@ -17,7 +17,6 @@ package spectrumx
 
 import (
 	"context"
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -35,323 +34,252 @@ var _ = Describe("doSPCX semantic plans", func() {
 		return content
 	}
 
-	parseFixture := func(name string, stage PlanStage) *SemanticPlan {
-		plan, err := ParseSemanticPlan(readFixture(name), stage)
+	decodeFixture := func(name string) *planDocument {
+		document, err := decodePlanDocument(readFixture(name))
+		Expect(err).NotTo(HaveOccurred())
+		return document
+	}
+
+	compileFixture := func(name string, stage PlanStage) *Plan {
+		document := decodeFixture(name)
+		plan, err := buildDMSPlan(context.Background(), document, stage)
 		Expect(err).NotTo(HaveOccurred())
 		return plan
 	}
 
-	Describe("ParseSemanticPlan", func() {
-		It("parses the generated host-k8s prepare semantic surface", func() {
-			plan := parseFixture("prepare-plan.json", PlanStagePrepare)
+	It("builds prepare batches and retains the post-breakout phase marker", func() {
+		plan := compileFixture("prepare-plan.json", PlanStagePrepare)
 
-			Expect(plan.Name).To(Equal("nco-parser-semantic-prepare"))
-			Expect(plan.Profile).To(Equal("SPX_Multiplane"))
-			Expect(plan.PathDialect).To(Equal(semanticPathDialect))
-			Expect(plan.Devices).To(HaveLen(2))
-			Expect(plan.RuntimeContext.RDMATopology).To(Equal(rdmaTopologyPerPF))
-			Expect(plan.Groups).To(HaveLen(2))
-			Expect(plan.Groups[0].Name).To(Equal("breakout"))
-			Expect(plan.Groups[0].Operations).To(HaveLen(15))
-			Expect(plan.Groups[0].Operations[0].ID).To(Equal("spcx-base-nvconfig.roce.adaptive-routing-cc-steering-ext-tx-sched-locality-mode"))
-			Expect(plan.Groups[0].Operations[0].Path).To(Equal("/nvidia/roce"))
-			Expect(plan.Groups[0].Operations[0].Kind).To(Equal("set"))
-			Expect(plan.Groups[0].Operations[0].ExecutionGroup).To(Equal("breakout"))
-			Expect(plan.Groups[0].Operations[0].TargetRole).To(BeEmpty())
-			Expect(plan.Groups[1].Name).To(Equal("post-breakout"))
-			Expect(plan.Groups[1].Operations).To(BeEmpty())
-			Expect(plan.Groups[1].RequiresReboot).To(BeTrue())
-		})
-
-		It("parses all generated configure groups before applying execution policy", func() {
-			plan := parseFixture("configure-plan.json", PlanStageConfigure)
-
-			Expect(plan.Devices).To(HaveLen(4))
-			Expect(plan.RuntimeContext.RDMATopology).To(Equal(rdmaTopologyPerRailBond))
-			Expect(plan.Groups).To(HaveLen(5))
-			Expect(groupNames(plan.Groups)).To(Equal([]string{
-				"link-runtime", "eswitch", "vf-lifecycle", "cc", "link-event",
-			}))
-			Expect(plan.Groups[0].Operations).To(HaveLen(4))
-			Expect(plan.Groups[0].Operations[1].Values).To(HaveKeyWithValue("admin-status", "down"))
-			Expect(plan.Groups[0].Operations[2].Values).To(HaveKeyWithValue("admin-status", "up"))
-			Expect(plan.Groups[1].FanoutOrder).To(Equal("per_step_barrier"))
-			Expect(plan.Groups[2].Operations[0].TargetClass).To(Equal(targetClassVFRepresentor))
-		})
-
-		DescribeTable("rejects malformed semantic contracts",
-			func(mutate func(map[string]any), expected string) {
-				var document map[string]any
-				Expect(json.Unmarshal(readFixture("prepare-plan.json"), &document)).To(Succeed())
-				mutate(document)
-				content, err := json.Marshal(document)
-				Expect(err).NotTo(HaveOccurred())
-
-				plan, err := ParseSemanticPlan(content, PlanStagePrepare)
-
-				Expect(plan).To(BeNil())
-				Expect(err).To(MatchError(ContainSubstring(expected)))
-			},
-			Entry("missing semantic groups", func(document map[string]any) {
-				delete(document["plan"].(map[string]any), "semantic")
-			}, "semantic groups"),
-			Entry("wrong path dialect", func(document map[string]any) {
-				document["plan"].(map[string]any)["path_dialect"] = "legacy"
-			}, "path dialect"),
-			Entry("missing operation reference", func(document map[string]any) {
-				groups := document["plan"].(map[string]any)["semantic"].(map[string]any)["groups"].([]any)
-				groups[0].(map[string]any)["operation_refs"] = []any{"missing-operation"}
-			}, "references missing operation"),
-			Entry("unsupported operation kind", func(document map[string]any) {
-				operations := document["plan"].(map[string]any)["operations"].(map[string]any)
-				for _, value := range operations {
-					value.(map[string]any)["kind"] = "delete"
-					break
-				}
-			}, "unsupported kind"),
-			Entry("unsupported target class", func(document map[string]any) {
-				operations := document["plan"].(map[string]any)["operations"].(map[string]any)
-				for _, value := range operations {
-					value.(map[string]any)["target_class"] = "host_global"
-					break
-				}
-			}, "unsupported target class"),
-			Entry("duplicated group", func(document map[string]any) {
-				semantic := document["plan"].(map[string]any)["semantic"].(map[string]any)
-				groups := semantic["groups"].([]any)
-				semantic["groups"] = append(groups, groups[0])
-			}, "group \"breakout\" is duplicated"),
-			Entry("invalid device target", func(document map[string]any) {
-				devices := document["plan"].(map[string]any)["devices"].([]any)
-				devices[0].(map[string]any)["dms_target"] = "pci/0000:ff:00.0"
-			}, "invalid DMS target"),
-		)
-
-		It("rejects a stage mismatch", func() {
-			plan, err := ParseSemanticPlan(readFixture("configure-plan.json"), PlanStagePrepare)
-
-			Expect(plan).To(BeNil())
-			Expect(err).To(MatchError(ContainSubstring(`stage is "configure", expected "prepare"`)))
-		})
-
-		It("uses the documented pf_netdev_all default when target_class is omitted", func() {
-			var document map[string]any
-			Expect(json.Unmarshal(readFixture("prepare-plan.json"), &document)).To(Succeed())
-			planObject := document["plan"].(map[string]any)
-			firstRef := planObject["semantic"].(map[string]any)["groups"].([]any)[0].(map[string]any)["operation_refs"].([]any)[0].(string)
-			delete(planObject["operations"].(map[string]any)[firstRef].(map[string]any), "target_class")
-			content, err := json.Marshal(document)
-			Expect(err).NotTo(HaveOccurred())
-
-			plan, err := ParseSemanticPlan(content, PlanStagePrepare)
-
-			Expect(err).NotTo(HaveOccurred())
-			Expect(plan.Groups[0].Operations[0].TargetClass).To(Equal(targetClassPFNetdevAll))
-		})
-
-		It("uses semantic operation references as the authoritative group membership", func() {
-			var document map[string]any
-			Expect(json.Unmarshal(readFixture("prepare-plan.json"), &document)).To(Succeed())
-			planObject := document["plan"].(map[string]any)
-			firstRef := planObject["semantic"].(map[string]any)["groups"].([]any)[0].(map[string]any)["operation_refs"].([]any)[0].(string)
-			planObject["operations"].(map[string]any)[firstRef].(map[string]any)["execution_group"] = "ignored-producer-detail"
-			content, err := json.Marshal(document)
-			Expect(err).NotTo(HaveOccurred())
-
-			plan, err := ParseSemanticPlan(content, PlanStagePrepare)
-
-			Expect(err).NotTo(HaveOccurred())
-			Expect(plan.Groups[0].Operations[0].ExecutionGroup).To(Equal("breakout"))
-		})
-
-		It("sorts semantic groups by their declared order", func() {
-			var document map[string]any
-			Expect(json.Unmarshal(readFixture("prepare-plan.json"), &document)).To(Succeed())
-			semantic := document["plan"].(map[string]any)["semantic"].(map[string]any)
-			groups := semantic["groups"].([]any)
-			semantic["groups"] = []any{groups[1], groups[0]}
-			content, err := json.Marshal(document)
-			Expect(err).NotTo(HaveOccurred())
-
-			plan, err := ParseSemanticPlan(content, PlanStagePrepare)
-
-			Expect(err).NotTo(HaveOccurred())
-			Expect(groupNames(plan.Groups)).To(Equal([]string{"breakout", "post-breakout"}))
-		})
-
-		It("rejects nil input without panicking", func() {
-			plan, err := ParseSemanticPlan(nil, PlanStagePrepare)
-
-			Expect(plan).To(BeNil())
-			Expect(err).To(MatchError("doSPCX plan must not be empty"))
-		})
-	})
-
-	Describe("BuildDMSOperationPlan", func() {
-		It("builds prepare batches and retains the post-breakout phase marker", func() {
-			semantic := parseFixture("prepare-plan.json", PlanStagePrepare)
-
-			plan, err := semantic.BuildDMSOperationPlan(context.Background())
-
-			Expect(err).NotTo(HaveOccurred())
-			Expect(plan.Stage).To(Equal(PlanStagePrepare))
-			Expect(plan.SkippedGroups).To(BeEmpty())
-			Expect(plan.Groups).To(HaveLen(2))
-			Expect(plan.Groups[0].Name).To(Equal("breakout"))
-			Expect(plan.Groups[0].Targets).To(HaveLen(2))
-			for _, target := range plan.Groups[0].Targets {
-				Expect(target.Operations).To(HaveLen(15))
-				Expect(target.Desired).To(HaveLen(12))
-				Expect(target.Queries).To(HaveLen(12))
-				for _, query := range target.Queries {
-					desired := findDesiredOperation(target.Desired, query.Path)
-					Expect(desired.Path).To(Equal(query.Path))
-					Expect(query.Leaves).To(HaveLen(2 * len(desired.Values)))
-					for _, leaf := range query.Leaves {
-						if strings.HasSuffix(leaf, "-pending") {
-							continue
-						}
+		Expect(plan.Name).To(Equal("nco-parser-semantic-prepare"))
+		Expect(plan.Stage).To(Equal(PlanStagePrepare))
+		Expect(plan.SkippedGroups).To(BeEmpty())
+		Expect(plan.Groups).To(HaveLen(2))
+		Expect(plan.Groups[0].Name).To(Equal("breakout"))
+		Expect(plan.Groups[0].Targets).To(HaveLen(2))
+		for _, target := range plan.Groups[0].Targets {
+			Expect(target.Operations).To(HaveLen(15))
+			Expect(target.Desired).To(HaveLen(12))
+			Expect(target.Queries).To(HaveLen(12))
+			for _, query := range target.Queries {
+				desired := findDesiredOperation(target.Desired, query.Path)
+				Expect(desired.Path).To(Equal(query.Path))
+				Expect(query.Leaves).To(HaveLen(2 * len(desired.Values)))
+				for _, leaf := range query.Leaves {
+					if !strings.HasSuffix(leaf, "-pending") {
 						Expect(query.Leaves).To(ContainElement(leaf + "-pending"))
 					}
 				}
 			}
-			Expect(plan.Groups[1].Name).To(Equal("post-breakout"))
-			Expect(plan.Groups[1].PhaseMarker).To(BeTrue())
-			Expect(plan.Groups[1].Targets).To(BeEmpty())
-		})
+		}
+		Expect(plan.Groups[1].Name).To(Equal("post-breakout"))
+		Expect(plan.Groups[1].RequiresReboot).To(BeTrue())
+		Expect(plan.Groups[1].PhaseMarker).To(BeTrue())
+		Expect(plan.Groups[1].Targets).To(BeEmpty())
+	})
 
-		It("skips eswitch and vf-lifecycle while compiling the remaining configure groups", func() {
-			semantic := parseFixture("configure-plan.json", PlanStageConfigure)
+	It("skips eswitch and vf-lifecycle while compiling configure groups", func() {
+		plan := compileFixture("configure-plan.json", PlanStageConfigure)
 
-			plan, err := semantic.BuildDMSOperationPlan(context.Background())
+		Expect(groupOperationNames(plan.Groups)).To(Equal([]string{"link-runtime", "cc", "link-event"}))
+		Expect(plan.SkippedGroups).To(Equal([]SkippedSemanticGroup{
+			{Name: "eswitch", Order: 40, Reason: "eSwitch lifecycle is outside the current NCO plan execution scope"},
+			{Name: "vf-lifecycle", Order: 60, Reason: "VF representor lifecycle is outside the current NCO plan execution scope"},
+		}))
+	})
 
-			Expect(err).NotTo(HaveOccurred())
-			Expect(groupOperationNames(plan.Groups)).To(Equal([]string{"link-runtime", "cc", "link-event"}))
-			Expect(plan.SkippedGroups).To(Equal([]SkippedSemanticGroup{
-				{Name: "eswitch", Order: 40, Reason: "eSwitch lifecycle is outside the current NCO plan execution scope"},
-				{Name: "vf-lifecycle", Order: 60, Reason: "VF representor lifecycle is outside the current NCO plan execution scope"},
-			}))
-		})
+	It("preserves ordered SET transitions but queries only final desired state", func() {
+		document := decodeFixture("configure-plan.json")
+		findGroupRecord(document, "link-runtime").FanoutOrder = "per_target"
 
-		It("preserves ordered SET transitions but queries only the final desired state", func() {
-			semantic := parseFixture("configure-plan.json", PlanStageConfigure)
-			semantic.Groups[0].FanoutOrder = "per_target"
-			plan, err := semantic.BuildDMSOperationPlan(context.Background())
-			Expect(err).NotTo(HaveOccurred())
+		plan, err := buildDMSPlan(context.Background(), document, PlanStageConfigure)
 
-			linkRuntime := plan.Groups[0]
-			Expect(linkRuntime.Name).To(Equal("link-runtime"))
-			Expect(linkRuntime.FanoutOrder).To(Equal("per_target"))
-			Expect(linkRuntime.Targets).To(HaveLen(4))
-			batch := linkRuntime.Targets[0]
-			Expect(batch.Operations).To(HaveLen(4))
-			Expect(batch.Operations[1].Values).To(HaveKeyWithValue("admin-status", "down"))
-			Expect(batch.Operations[2].Values).To(HaveKeyWithValue("admin-status", "up"))
-			Expect(batch.Desired).To(HaveLen(3))
-			Expect(batch.Desired[1].Path).To(Equal("/nvidia/link/physical"))
-			Expect(batch.Desired[1].Values).To(HaveKeyWithValue("admin-status", "up"))
-			Expect(batch.Queries[1]).To(Equal(dmsQuery("/nvidia/link/physical", "admin-status")))
-		})
+		Expect(err).NotTo(HaveOccurred())
+		linkRuntime := plan.Groups[0]
+		Expect(linkRuntime.FanoutOrder).To(Equal("per_target"))
+		Expect(linkRuntime.Targets).To(HaveLen(4))
+		batch := linkRuntime.Targets[0]
+		Expect(batch.Operations).To(HaveLen(4))
+		Expect(batch.Operations[1].Values).To(HaveKeyWithValue("admin-status", "down"))
+		Expect(batch.Operations[2].Values).To(HaveKeyWithValue("admin-status", "up"))
+		Expect(batch.Desired).To(HaveLen(3))
+		Expect(batch.Desired[1].Values).To(HaveKeyWithValue("admin-status", "up"))
+		Expect(batch.Queries[1]).To(Equal(dmsQuery("/nvidia/link/physical", "admin-status")))
+	})
 
-		It("resolves bonded RDMA operations to each plane-zero target", func() {
-			semantic := parseFixture("configure-plan.json", PlanStageConfigure)
-			for _, endpoint := range semantic.RuntimeContext.ExpectedRDMA {
-				Expect(endpoint.ControlBDF).To(BeEmpty())
-				Expect(endpoint.ControlTarget).To(BeEmpty())
-			}
-			plan, err := semantic.BuildDMSOperationPlan(context.Background())
-			Expect(err).NotTo(HaveOccurred())
+	It("resolves bonded RDMA operations to each plane-zero target", func() {
+		plan := compileFixture("configure-plan.json", PlanStageConfigure)
 
-			cc := plan.Groups[1]
-			Expect(cc.Name).To(Equal("cc"))
-			Expect(cc.Targets).To(HaveLen(2))
-			Expect([]string{cc.Targets[0].Target, cc.Targets[1].Target}).To(Equal([]string{
-				"pci/0000:64:00.0", "pci/0001:15:00.0",
-			}))
-			Expect(cc.Targets[0].Operations).To(HaveLen(24))
-		})
+		cc := plan.Groups[1]
+		Expect(cc.Name).To(Equal("cc"))
+		Expect(cc.Targets).To(HaveLen(2))
+		Expect([]string{cc.Targets[0].Target, cc.Targets[1].Target}).To(Equal([]string{
+			"pci/0000:64:00.0", "pci/0001:15:00.0",
+		}))
+		Expect(cc.Targets[0].Operations).To(HaveLen(24))
+	})
 
-		It("combines per-device and RDMA-scoped operations without widening bonded targets", func() {
-			semantic := parseFixture("configure-plan.json", PlanStageConfigure)
-			plan, err := semantic.BuildDMSOperationPlan(context.Background())
-			Expect(err).NotTo(HaveOccurred())
+	It("combines per-device and RDMA-scoped operations without widening bonded targets", func() {
+		plan := compileFixture("configure-plan.json", PlanStageConfigure)
 
-			linkEvent := plan.Groups[2]
-			Expect(linkEvent.Name).To(Equal("link-event"))
-			Expect(linkEvent.Targets).To(HaveLen(4))
-			Expect(linkEvent.Targets[0].Operations).To(HaveLen(21))
-			Expect(linkEvent.Targets[1].Operations).To(HaveLen(2))
-			Expect(linkEvent.Targets[2].Operations).To(HaveLen(21))
-			Expect(linkEvent.Targets[3].Operations).To(HaveLen(2))
-		})
+		linkEvent := plan.Groups[2]
+		Expect(linkEvent.Name).To(Equal("link-event"))
+		Expect(linkEvent.Targets).To(HaveLen(4))
+		Expect(linkEvent.Targets[0].Operations).To(HaveLen(21))
+		Expect(linkEvent.Targets[1].Operations).To(HaveLen(2))
+		Expect(linkEvent.Targets[2].Operations).To(HaveLen(21))
+		Expect(linkEvent.Targets[3].Operations).To(HaveLen(2))
+	})
 
-		It("fails closed for an unknown semantic group", func() {
-			semantic := parseFixture("configure-plan.json", PlanStageConfigure)
-			semantic.Groups[0].Name = "new-runtime-phase"
+	It("sorts semantic groups by declared order", func() {
+		document := decodeFixture("prepare-plan.json")
+		groups := document.Plan.Semantic.Groups
+		document.Plan.Semantic.Groups = []semanticGroupRecord{groups[1], groups[0]}
 
-			plan, err := semantic.BuildDMSOperationPlan(context.Background())
+		plan, err := buildDMSPlan(context.Background(), document, PlanStagePrepare)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(groupOperationNames(plan.Groups)).To(Equal([]string{"breakout", "post-breakout"}))
+	})
+
+	It("uses documented defaults for omitted kind and target class", func() {
+		document := decodeFixture("prepare-plan.json")
+		operationID := findGroupRecord(document, "breakout").OperationRefs[0]
+		operation := document.Plan.Operations[operationID]
+		operation.Kind = ""
+		operation.TargetClass = ""
+		document.Plan.Operations[operationID] = operation
+
+		plan, err := buildDMSPlan(context.Background(), document, PlanStagePrepare)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(plan.Groups[0].Targets).To(HaveLen(2))
+	})
+
+	It("validates references in intentionally skipped groups", func() {
+		document := decodeFixture("configure-plan.json")
+		findGroupRecord(document, "eswitch").OperationRefs = []string{"missing-operation"}
+
+		plan, err := buildDMSPlan(context.Background(), document, PlanStageConfigure)
+
+		Expect(plan).To(BeNil())
+		Expect(err).To(MatchError(ContainSubstring("references missing operation")))
+	})
+
+	DescribeTable("rejects malformed plan contracts",
+		func(mutate func(*planDocument), stage PlanStage, expected string) {
+			document := decodeFixture("prepare-plan.json")
+			mutate(document)
+			plan, err := buildDMSPlan(context.Background(), document, stage)
+			Expect(plan).To(BeNil())
+			Expect(err).To(MatchError(ContainSubstring(expected)))
+		},
+		Entry("missing semantic groups", func(document *planDocument) {
+			document.Plan.Semantic = nil
+		}, PlanStagePrepare, "semantic groups"),
+		Entry("wrong path dialect", func(document *planDocument) {
+			document.Plan.PathDialect = "legacy"
+		}, PlanStagePrepare, "path dialect"),
+		Entry("missing operation reference", func(document *planDocument) {
+			document.Plan.Semantic.Groups[0].OperationRefs = []string{"missing-operation"}
+		}, PlanStagePrepare, "references missing operation"),
+		Entry("unsupported operation kind", func(document *planDocument) {
+			operationID := document.Plan.Semantic.Groups[0].OperationRefs[0]
+			operation := document.Plan.Operations[operationID]
+			operation.Kind = "delete"
+			document.Plan.Operations[operationID] = operation
+		}, PlanStagePrepare, "unsupported kind"),
+		Entry("unsupported target class", func(document *planDocument) {
+			operationID := document.Plan.Semantic.Groups[0].OperationRefs[0]
+			operation := document.Plan.Operations[operationID]
+			operation.TargetClass = "host_global"
+			document.Plan.Operations[operationID] = operation
+		}, PlanStagePrepare, "unsupported target class"),
+		Entry("empty leaf list", func(document *planDocument) {
+			operationID := document.Plan.Semantic.Groups[0].OperationRefs[0]
+			operation := document.Plan.Operations[operationID]
+			operation.Values = map[string]any{"invalid": []string{}}
+			document.Plan.Operations[operationID] = operation
+		}, PlanStagePrepare, "unsupported value"),
+		Entry("nested leaf list", func(document *planDocument) {
+			operationID := document.Plan.Semantic.Groups[0].OperationRefs[0]
+			operation := document.Plan.Operations[operationID]
+			operation.Values = map[string]any{"invalid": [][]int{{1}}}
+			document.Plan.Operations[operationID] = operation
+		}, PlanStagePrepare, "unsupported value"),
+		Entry("duplicated group", func(document *planDocument) {
+			document.Plan.Semantic.Groups = append(document.Plan.Semantic.Groups, document.Plan.Semantic.Groups[0])
+		}, PlanStagePrepare, `group "breakout" is duplicated`),
+		Entry("invalid device target", func(document *planDocument) {
+			document.Plan.Devices[0].DMSTarget = "pci/0000:ff:00.0"
+		}, PlanStagePrepare, "invalid DMS target"),
+		Entry("stage mismatch", func(_ *planDocument) {}, PlanStageConfigure, `stage is "prepare", expected "configure"`),
+		Entry("unknown group", func(document *planDocument) {
+			document.Plan.Semantic.Groups[0].Name = "new-runtime-phase"
+		}, PlanStagePrepare, "unsupported doSPCX semantic group"),
+	)
+
+	DescribeTable("does not allow excluded operation classes in executable groups",
+		func(mutate func(*semanticOperationRecord)) {
+			document := decodeFixture("configure-plan.json")
+			group := findGroupRecord(document, "link-runtime")
+			operationID := group.OperationRefs[0]
+			operation := document.Plan.Operations[operationID]
+			mutate(&operation)
+			document.Plan.Operations[operationID] = operation
+
+			plan, err := buildDMSPlan(context.Background(), document, PlanStageConfigure)
 
 			Expect(plan).To(BeNil())
-			Expect(err).To(MatchError(ContainSubstring(`unsupported doSPCX semantic group "new-runtime-phase"`)))
-		})
+			Expect(err).To(MatchError(ContainSubstring("outside the current NCO execution scope")))
+		},
+		Entry("eSwitch path", func(operation *semanticOperationRecord) {
+			operation.Path = "/nvidia/eswitch"
+		}),
+		Entry("eSwitch target class", func(operation *semanticOperationRecord) {
+			operation.TargetClass = targetClassPerESwitch
+		}),
+		Entry("VF target class", func(operation *semanticOperationRecord) {
+			operation.TargetClass = targetClassVFRepresentor
+		}),
+		Entry("per-VF scope", func(operation *semanticOperationRecord) {
+			operation.Scope = "per_vf"
+		}),
+	)
 
-		DescribeTable("does not allow excluded operation classes in executable groups",
-			func(mutate func(*SemanticOperation)) {
-				semantic := parseFixture("configure-plan.json", PlanStageConfigure)
-				mutate(&semantic.Groups[0].Operations[0])
+	It("resolves per-PF RDMA operations only to devices with an RDMA endpoint", func() {
+		document := decodeFixture("configure-plan.json")
+		document.Plan.RuntimeContext.RDMATopology = rdmaTopologyPerPF
+		document.Plan.Devices[1].RDMADevice = ""
+		document.Plan.Devices[3].RDMADevice = ""
 
-				plan, err := semantic.BuildDMSOperationPlan(context.Background())
+		plan, err := buildDMSPlan(context.Background(), document, PlanStageConfigure)
 
-				Expect(plan).To(BeNil())
-				Expect(err).To(MatchError(ContainSubstring("outside the current NCO execution scope")))
-			},
-			Entry("eSwitch path", func(operation *SemanticOperation) {
-				operation.Path = "/nvidia/eswitch"
-			}),
-			Entry("eSwitch target class", func(operation *SemanticOperation) {
-				operation.TargetClass = targetClassPerESwitch
-			}),
-			Entry("VF target class", func(operation *SemanticOperation) {
-				operation.TargetClass = targetClassVFRepresentor
-			}),
-			Entry("per-VF scope", func(operation *SemanticOperation) {
-				operation.Scope = "per_vf"
-			}),
-		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(plan.Groups[1].Name).To(Equal("cc"))
+		Expect(plan.Groups[1].Targets).To(HaveLen(2))
+		Expect([]string{plan.Groups[1].Targets[0].Target, plan.Groups[1].Targets[1].Target}).To(Equal([]string{
+			"pci/0000:64:00.0", "pci/0001:15:00.0",
+		}))
+	})
 
-		It("resolves per-PF RDMA operations only to devices with an RDMA endpoint", func() {
-			semantic := parseFixture("configure-plan.json", PlanStageConfigure)
-			semantic.RuntimeContext.RDMATopology = rdmaTopologyPerPF
-			semantic.Devices[1].RDMADevice = ""
-			semantic.Devices[3].RDMADevice = ""
+	It("rejects empty and nil plans without panicking", func() {
+		document, err := decodePlanDocument(nil)
+		Expect(document).To(BeNil())
+		Expect(err).To(MatchError("doSPCX plan must not be empty"))
 
-			plan, err := semantic.BuildDMSOperationPlan(context.Background())
-
-			Expect(err).NotTo(HaveOccurred())
-			Expect(plan.Groups[1].Name).To(Equal("cc"))
-			Expect(plan.Groups[1].Targets).To(HaveLen(2))
-			Expect([]string{plan.Groups[1].Targets[0].Target, plan.Groups[1].Targets[1].Target}).To(Equal([]string{
-				"pci/0000:64:00.0", "pci/0001:15:00.0",
-			}))
-		})
-
-		It("rejects a nil semantic plan", func() {
-			var semantic *SemanticPlan
-
-			plan, err := semantic.BuildDMSOperationPlan(context.Background())
-
-			Expect(plan).To(BeNil())
-			Expect(err).To(MatchError("semantic plan must not be nil"))
-		})
+		plan, err := buildDMSPlan(context.Background(), nil, PlanStagePrepare)
+		Expect(plan).To(BeNil())
+		Expect(err).To(MatchError("doSPCX plan must not be nil"))
 	})
 })
 
-func groupNames(groups []SemanticGroup) []string {
-	result := make([]string, 0, len(groups))
-	for _, group := range groups {
-		result = append(result, group.Name)
+func findGroupRecord(document *planDocument, name string) *semanticGroupRecord {
+	for index := range document.Plan.Semantic.Groups {
+		if document.Plan.Semantic.Groups[index].Name == name {
+			return &document.Plan.Semantic.Groups[index]
+		}
 	}
-	return result
+	return nil
 }
 
 func groupOperationNames(groups []DMSOperationGroup) []string {

--- a/pkg/spectrumx/spectrumx.go
+++ b/pkg/spectrumx/spectrumx.go
@@ -84,6 +84,7 @@ type spectrumXConfigManager struct {
 	configMutex        sync.RWMutex
 	spectrumXConfigs   map[string]*types.SpectrumXConfig
 	planMutex          sync.RWMutex
+	preparedPlans      map[string]*preparedPlan
 	dmsManager         dms.DMSManager
 	execInterface      execUtils.Interface
 	blueprintsRoot     string
@@ -860,6 +861,7 @@ func NewSpectrumXConfigManager(
 	return &spectrumXConfigManager{
 		dmsManager:         dmsManager,
 		spectrumXConfigs:   spectrumXConfigs,
+		preparedPlans:      make(map[string]*preparedPlan),
 		execInterface:      execUtils.New(),
 		blueprintsRoot:     defaultBlueprintsRoot,
 		blueprintsStateDir: "",

--- a/pkg/spectrumx/spectrumx_test.go
+++ b/pkg/spectrumx/spectrumx_test.go
@@ -226,6 +226,7 @@ var _ = Describe("SpectrumXConfigManager", func() {
 		manager = &spectrumXConfigManager{
 			dmsManager:         &dmsMgr,
 			spectrumXConfigs:   cfgs,
+			preparedPlans:      make(map[string]*preparedPlan),
 			execInterface:      execFake,
 			blueprintsRoot:     defaultBlueprintsRoot,
 			blueprintsStateDir: "",

--- a/pkg/utils/runcommand.go
+++ b/pkg/utils/runcommand.go
@@ -24,6 +24,24 @@ import (
 	execUtils "k8s.io/utils/exec"
 )
 
+// CommandOutput contains the two output streams produced by a command.
+type CommandOutput struct {
+	Stdout []byte
+	Stderr []byte
+}
+
+// RunCommandWithStreams executes a command while keeping stdout and stderr
+// separate. This is required for commands whose stdout is a machine-readable
+// protocol and whose stderr contains diagnostics.
+func RunCommandWithStreams(cmd execUtils.Cmd) (CommandOutput, error) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetStdout(&stdout)
+	cmd.SetStderr(&stderr)
+	err := cmd.Run()
+	return CommandOutput{Stdout: stdout.Bytes(), Stderr: stderr.Bytes()}, err
+}
+
 // RunCommand runs a command and captures stderr separately for better error reporting
 // Returns stdout, error (with stderr included in the error message if command fails)
 func RunCommand(cmd execUtils.Cmd) ([]byte, error) {


### PR DESCRIPTION
## Summary

- compile doSPCX semantic plans directly into the execution-ready representation and cache it in memory
- load and compile persisted plans only once after process startup, while keeping per-device retrieval filesystem-free
- align typed XPath query/set decoding with the public `dms-cli --json` contract
- preserve partial successes and failures and bound stdout/stderr diagnostics
- remove the duplicate exported semantic-plan representation and builder API

This follow-up reduces the implementation by 310 net lines while retaining the existing prepare-only behavior; it does not execute plan operations.

## Verification

- `go build ./...`
- `go test ./pkg/dmscli ./pkg/spectrumx ./pkg/configuration ./pkg/nvconfig`
- `go test -race ./pkg/dmscli ./pkg/spectrumx`
- `KUBEBUILDER_ASSETS=... go test ./internal/controller`
- `bin/golangci-lint-v2.11.4 run`
- `git diff --check`