### PR TITLE
fix: align doSPCX plan integration contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,16 +230,19 @@ per-device apply. The compiled form includes current plus pending queries for pr
 NVConfig and retains the planner's fanout order. This translation remains execution-free. Semantic
 group references are authoritative; public doSPCX
 operations do not need to repeat group or network-role fields, and an omitted operation kind means
-`set`, matching DMS. Configure groups `eswitch` and `vf-lifecycle` are intentionally excluded from
-the current operation plan and reported as skipped; unknown groups fail closed.
+`set`, matching DMS. Prepare groups use the pre-breakout or post-breakout device view implied by
+their group name when the current doSPCX schema omits that metadata. Post-breakout targets retain
+the operation's explicit DMS port, or default to port 1 for an explicitly expanded PF. Configure
+groups `eswitch` and `vf-lifecycle` are intentionally excluded from the current operation plan and
+reported as skipped; unknown groups fail closed.
 
 NCO translates its CRD multiplane modes to the public profiles supplied by the doSPCX data bundle:
 `none` selects `single-plane`, `swplb` selects `SPX_NetPlugin`, and `hwplb` selects
 `SPX_Multiplane`.
 
-The manager creates its command executor internally and points the `dms-cli` child process at the
-Blueprints action tree fixed at `/opt/nvidia/blueprints`. The executable DMS planner remains part of
-the daemon base image, while the labeled doSPCX data ConfigMap restores its authored catalog under
+The manager creates its command executor internally. The executable DMS planner remains part of
+the daemon base image and resolves its authored catalog from the native DMS location where the
+labeled doSPCX data ConfigMap restores it:
 `/opt/mellanox/doca/services/dms/doSpcx/data`. When `PreparePlan` is called, files are written to:
 
 ```text

--- a/docs/nic-configuration-library.md
+++ b/docs/nic-configuration-library.md
@@ -344,7 +344,6 @@ func ApplyNVConfig(
 ) (*ApplyNVConfigResult, error)
 
 type BlueprintPlanRequest struct {
-	BlueprintsRoot     string
 	BlueprintsStateDir string
 	Profile            string
 	Name               string
@@ -415,18 +414,18 @@ dms-cli --json /nvidia/blueprints/plan profile=<profile> name=<name> \
   params=deployment_mode=host-k8s,planes=<count>
 ```
 
-For Blueprints planning, the wrapper sets `BLUEPRINTS_ROOT` and the DMS
-`BP_STATE_DIR` variable only on the `dms-cli` child process.
+For Blueprints planning, the wrapper sets the DMS `BP_STATE_DIR` variable only
+on the `dms-cli` child process.
 All JSON-based `dms-cli` wrappers capture stdout and stderr separately because
 stdout is the protocol while DMS diagnostics are written to stderr. Successful calls log the
 exact command, result status, and plan size without repeating the embedded plan;
 failure output is bounded before logging or adding it to a returned error.
-`SpectrumXConfigManager` supplies the fixed `/opt/nvidia/blueprints` path and
-creates its command executor internally. The executable DMS Blueprints action
-tree remains part of the daemon image. Authored doSPCX data is supplied
-separately through a labeled ConfigMap and installed at
+`SpectrumXConfigManager` creates its command executor internally. The executable
+DMS Blueprints action tree remains part of the daemon image. Authored doSPCX
+data is supplied separately through a labeled ConfigMap and installed at the
+DMS planner's native data location,
 `/opt/mellanox/doca/services/dms/doSpcx/data`. Existing process environment
-entries are preserved, and inherited entries for either variable are replaced.
+entries are preserved, and an inherited `BP_STATE_DIR` entry is replaced.
 
 `pkg/dmscli` is the low-level command wrapper. `pkg/spectrumx.PlanManager` is the
 plan lifecycle abstraction included by `SpectrumXManager`; it owns
@@ -632,6 +631,12 @@ type NVConfigUtils interface {
 ```go
 func NewNVConfigUtils() NVConfigUtils
 ```
+
+The built-in implementation also provides
+`SetNvConfigParametersBatchWithContext(ctx, port, params, withDefault, force) (types.ApplyStatus, error)`.
+`ConfigurationManager` uses that optional extension so reconcile cancellation reaches
+`dms-cli`, while retaining the public `NVConfigUtils` interface for existing library
+implementations. Implementations without the extension continue through the legacy method.
 
 **Batch command format:**
 ```

--- a/internal/controller/nicdevice_controller.go
+++ b/internal/controller/nicdevice_controller.go
@@ -203,8 +203,13 @@ func (r *NicDeviceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	if configStatuses.nvConfigUpdateRequired() {
-		log.Log.Info("nv config update required for some devices, scheduling maintenance")
+		log.Log.Info("nv config update required for some devices")
+		err = r.prepareSpectrumXPlan(ctx, configStatuses, spectrumx.PlanStagePrepare)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("prepare doSPCX NV configuration plan: %w", err)
+		}
 
+		log.Log.Info("scheduling maintenance for nv config update")
 		result, err := r.ensureMaintenance(ctx)
 		if err != nil {
 			log.Log.V(2).Error(err, "failed to schedule maintenance")
@@ -215,11 +220,6 @@ func (r *NicDeviceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 
 		log.Log.Info("maintenance allowed, applying nv config")
-
-		err = r.prepareSpectrumXPlan(ctx, configStatuses, spectrumx.PlanStagePrepare)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("prepare doSPCX NV configuration plan: %w", err)
-		}
 
 		err = runInParallel(ctx, configStatuses, r.applyNvConfig)
 		if err != nil {

--- a/internal/controller/nicdevice_controller_test.go
+++ b/internal/controller/nicdevice_controller_test.go
@@ -370,7 +370,11 @@ var _ = Describe("NicDeviceReconciler", func() {
 	})
 
 	Describe("reconcile a single device without firmware spec", func() {
-		var createDevice = func(setLastSpecAnnotation bool, initialStatusCondition *metav1.Condition) *v1alpha1.NicDevice {
+		var createDevice = func(
+			setLastSpecAnnotation bool,
+			initialStatusCondition *metav1.Condition,
+			spectrumXEnabled ...bool,
+		) *v1alpha1.NicDevice {
 			device := &v1alpha1.NicDevice{
 				ObjectMeta: metav1.ObjectMeta{Name: deviceName, Namespace: namespaceName},
 				Spec: v1alpha1.NicDeviceSpec{
@@ -387,11 +391,18 @@ var _ = Describe("NicDeviceReconciler", func() {
 					},
 				},
 			}
+			if len(spectrumXEnabled) > 0 && spectrumXEnabled[0] {
+				device.Spec.Configuration.Template.NumVfs = 1
+				device.Spec.Configuration.Template.SpectrumXOptimized = &v1alpha1.SpectrumXOptimizedSpec{
+					Enabled:      true,
+					PlatformType: "gb300",
+				}
+			}
 			if setLastSpecAnnotation {
 				device.SetAnnotations(map[string]string{consts.LastAppliedStateAnnotation: "some-state"})
 			}
 
-			Expect(k8sClient.Create(ctx, device))
+			Expect(k8sClient.Create(ctx, device)).To(Succeed())
 			device.Status = v1alpha1.NicDeviceStatus{
 				Node: nodeName,
 				Ports: []v1alpha1.NicDevicePortSpec{{
@@ -526,6 +537,25 @@ var _ = Describe("NicDeviceReconciler", func() {
 			}))
 
 			configurationManager.AssertNotCalled(GinkgoT(), "ResetNicFirmware", mock.Anything, mock.Anything)
+		})
+		It("Should prepare the Spectrum-X NV plan before requesting maintenance", func() {
+			planErr := errors.New("plan generation failed")
+			configurationManager.On("ValidateDeviceNvSpec", mock.Anything, mock.Anything).Return(true, false, nil, nil)
+			spectrumXManager.On("PreparePlan", mock.Anything, mock.Anything, spectrumx.PlanStagePrepare).
+				Return(planErr).Maybe()
+
+			createDevice(false, nil, true)
+
+			Eventually(func() bool {
+				for _, call := range spectrumXManager.Calls {
+					if call.Method == "PreparePlan" {
+						return true
+					}
+				}
+				return false
+			}, timeout).Should(BeTrue())
+			maintenanceManager.AssertNotCalled(GinkgoT(), "ScheduleMaintenance", mock.Anything)
+			maintenanceManager.AssertNotCalled(GinkgoT(), "MaintenanceAllowed", mock.Anything)
 		})
 		It("Should keep in UpdateStarted status if maintenance fails to schedule", func() {
 			errorText := "maintenance request failed"

--- a/pkg/configuration/manager.go
+++ b/pkg/configuration/manager.go
@@ -66,6 +66,18 @@ type configurationManager struct {
 	spectrumXConfigManager spectrumx.SpectrumXManager
 }
 
+// contextualNVConfigBatchSetter is an optional extension implemented by the built-in NVConfig
+// utility. Keeping it separate preserves the public NVConfigUtils contract for library consumers.
+type contextualNVConfigBatchSetter interface {
+	SetNvConfigParametersBatchWithContext(
+		ctx context.Context,
+		port v1alpha1.NicDevicePortSpec,
+		params map[string]string,
+		withDefault bool,
+		force bool,
+	) (types.ApplyStatus, error)
+}
+
 // ValidateDeviceNvSpec will validate device's non-volatile spec against already applied configuration on the host
 // returns bool - nv config update required
 // returns bool - reboot required
@@ -321,7 +333,7 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 			continue
 		}
 		log.Log.V(2).Info("applying nv config batch", "device", device.Name, "target", target, "params", batch, "force", options.Force)
-		applyStatus, err := h.nvConfigUtils.SetNvConfigParametersBatch(port, batch, options.WithDefault, options.Force)
+		applyStatus, err := h.setNvConfigParametersBatch(ctx, port, batch, options.WithDefault, options.Force)
 		if err != nil {
 			log.Log.Error(err, "Failed to apply nv config parameters", "device", device.Name, "params", batch)
 			return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
@@ -373,6 +385,19 @@ func extrapolatePortParamsFromNumOfPF(params map[string]string) {
 			}
 		}
 	}
+}
+
+func (h configurationManager) setNvConfigParametersBatch(
+	ctx context.Context,
+	port v1alpha1.NicDevicePortSpec,
+	params map[string]string,
+	withDefault bool,
+	force bool,
+) (types.ApplyStatus, error) {
+	if contextual, ok := h.nvConfigUtils.(contextualNVConfigBatchSetter); ok {
+		return contextual.SetNvConfigParametersBatchWithContext(ctx, port, params, withDefault, force)
+	}
+	return h.nvConfigUtils.SetNvConfigParametersBatch(port, params, withDefault, force)
 }
 
 // setSystemConf stages the requested Network Bay set_system_conf for the device's ASIC (the

--- a/pkg/configuration/manager_test.go
+++ b/pkg/configuration/manager_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/Mellanox/nic-configuration-operator/api/v1alpha1"
 	"github.com/Mellanox/nic-configuration-operator/pkg/configuration/mocks"
 	"github.com/Mellanox/nic-configuration-operator/pkg/consts"
+	"github.com/Mellanox/nic-configuration-operator/pkg/nvconfig"
 	nvconfigmocks "github.com/Mellanox/nic-configuration-operator/pkg/nvconfig/mocks"
 	"github.com/Mellanox/nic-configuration-operator/pkg/spectrumx"
 	spcxmocks "github.com/Mellanox/nic-configuration-operator/pkg/spectrumx/mocks"
@@ -34,6 +35,12 @@ import (
 
 const pciAddress = "0000:3b:00.0"
 const pciAddress2 = "0000:3b:00.1"
+
+// legacyNVConfigUtils deliberately exposes only the public NVConfigUtils interface. It verifies
+// that ConfigurationManager supports implementations without the optional context-aware extension.
+type legacyNVConfigUtils struct {
+	nvconfig.NVConfigUtils
+}
 
 func portSpec(pciAddr string) v1alpha1.NicDevicePortSpec {
 	return v1alpha1.NicDevicePortSpec{PCI: pciAddr}
@@ -715,7 +722,7 @@ var _ = Describe("ConfigurationManager", func() {
 							Return(nvConfig, nil)
 						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 							Return(desiredConfig, nil)
-						mockNV.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"param1": "value2"}, false, false).
+						mockNV.On("SetNvConfigParametersBatchWithContext", mock.Anything, portSpec(pciAddress), map[string]string{"param1": "value2"}, false, false).
 							Return(types.ApplyStatusSuccess, nil)
 
 						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
@@ -782,7 +789,7 @@ var _ = Describe("ConfigurationManager", func() {
 						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 							Return(desiredConfig, nil)
 						setParamErr := errors.New("failed to set param1")
-						mockNV.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"param1": "value3"}, false, false).
+						mockNV.On("SetNvConfigParametersBatchWithContext", mock.Anything, portSpec(pciAddress), map[string]string{"param1": "value3"}, false, false).
 							Return(types.ApplyStatusFailed, setParamErr)
 
 						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
@@ -814,7 +821,7 @@ var _ = Describe("ConfigurationManager", func() {
 						mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress2), []string(nil)).Return(nvConfig1, nil)
 						mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig0).Return(map[string]string{"TRACER_ENABLED": "1"}, nil)
 						// Only port2 should be updated
-						mockNV.On("SetNvConfigParametersBatch", portSpec(pciAddress2), map[string]string{"TRACER_ENABLED": "1"}, false, false).
+						mockNV.On("SetNvConfigParametersBatchWithContext", mock.Anything, portSpec(pciAddress2), map[string]string{"TRACER_ENABLED": "1"}, false, false).
 							Return(types.ApplyStatusSuccess, nil)
 
 						result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
@@ -867,7 +874,7 @@ var _ = Describe("ConfigurationManager", func() {
 						Return(nvConfig, nil)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 						Return(desiredConfig, nil)
-					mockNV.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"param1": "newValue3", "param2": "newValue3"}, false, false).
+					mockNV.On("SetNvConfigParametersBatchWithContext", mock.Anything, portSpec(pciAddress), map[string]string{"param1": "newValue3", "param2": "newValue3"}, false, false).
 						Return(types.ApplyStatusSuccess, nil)
 
 					result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
@@ -1486,7 +1493,7 @@ var _ = Describe("ConfigurationManager", func() {
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(map[string]string{"NUM_OF_PF": "2", "LINK_TYPE_P1": "2"}, nil)
 				// NUM_OF_PF differs (1 != 2) and is applied; LINK_TYPE_P1 already matches and is skipped.
-				mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, false, false).
+				mockNVConfigUtils.On("SetNvConfigParametersBatchWithContext", mock.Anything, portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, false, false).
 					Return(types.ApplyStatusSuccess, nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
@@ -1494,11 +1501,27 @@ var _ = Describe("ConfigurationManager", func() {
 				Expect(result.RebootRequired).To(BeTrue())
 			})
 
+			It("falls back to the public batch method when the context-aware extension is absent", func() {
+				manager.nvConfigUtils = legacyNVConfigUtils{NVConfigUtils: mockNVConfigUtils}
+				mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(
+					types.NvConfigQuery{NextBootConfig: map[string][]string{"NUM_OF_PF": {"1"}}}, nil)
+				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
+					Return(map[string]string{"NUM_OF_PF": "2"}, nil)
+				mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress),
+					map[string]string{"NUM_OF_PF": "2"}, false, false).Return(types.ApplyStatusSuccess, nil)
+
+				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Status).To(Equal(types.ApplyStatusSuccess))
+				Expect(result.RebootRequired).To(BeTrue())
+			})
+
 			It("force=true applies all combined params in a single --force batch", func() {
 				mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(types.NvConfigQuery{}, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(map[string]string{"NUM_OF_PF": "2", "LINK_TYPE_P1": "2"}, nil)
-				mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress),
+				mockNVConfigUtils.On("SetNvConfigParametersBatchWithContext", mock.Anything, portSpec(pciAddress),
 					map[string]string{"NUM_OF_PF": "2", "LINK_TYPE_P1": "2", "LINK_TYPE_P2": "2"}, false, true).Return(types.ApplyStatusSuccess, nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{Force: true})
@@ -1512,15 +1535,15 @@ var _ = Describe("ConfigurationManager", func() {
 				mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress2), []string(nil)).Return(types.NvConfigQuery{}, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(map[string]string{"NUM_OF_PF": "2"}, nil)
-				mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, false, true).
+				mockNVConfigUtils.On("SetNvConfigParametersBatchWithContext", mock.Anything, portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, false, true).
 					Return(types.ApplyStatusSuccess, nil)
-				mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress2), map[string]string{"NUM_OF_PF": "2"}, false, true).
+				mockNVConfigUtils.On("SetNvConfigParametersBatchWithContext", mock.Anything, portSpec(pciAddress2), map[string]string{"NUM_OF_PF": "2"}, false, true).
 					Return(types.ApplyStatusSuccess, nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{Force: true})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.RebootRequired).To(BeTrue())
-				mockNVConfigUtils.AssertCalled(GinkgoT(), "SetNvConfigParametersBatch", portSpec(pciAddress2), map[string]string{"NUM_OF_PF": "2"}, false, true)
+				mockNVConfigUtils.AssertCalled(GinkgoT(), "SetNvConfigParametersBatchWithContext", mock.Anything, portSpec(pciAddress2), map[string]string{"NUM_OF_PF": "2"}, false, true)
 			})
 
 			It("propagates WithDefault=true to the combined batch", func() {
@@ -1528,7 +1551,7 @@ var _ = Describe("ConfigurationManager", func() {
 					types.NvConfigQuery{NextBootConfig: map[string][]string{"NUM_OF_PF": {"1"}}}, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(map[string]string{"NUM_OF_PF": "2"}, nil)
-				mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, true, false).
+				mockNVConfigUtils.On("SetNvConfigParametersBatchWithContext", mock.Anything, portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, true, false).
 					Return(types.ApplyStatusSuccess, nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{WithDefault: true})
@@ -1541,7 +1564,7 @@ var _ = Describe("ConfigurationManager", func() {
 					types.NvConfigQuery{NextBootConfig: map[string][]string{"NUM_OF_PF": {"2"}}}, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(map[string]string{"NUM_OF_PF": "2"}, nil)
-				mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, true, false).
+				mockNVConfigUtils.On("SetNvConfigParametersBatchWithContext", mock.Anything, portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, true, false).
 					Return(types.ApplyStatusNothingToDo, nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{WithDefault: true})
@@ -1554,7 +1577,7 @@ var _ = Describe("ConfigurationManager", func() {
 				mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(types.NvConfigQuery{}, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(map[string]string{"NUM_OF_PF": "2"}, nil)
-				mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, true, true).
+				mockNVConfigUtils.On("SetNvConfigParametersBatchWithContext", mock.Anything, portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, true, true).
 					Return(types.ApplyStatusNothingToDo, nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{Force: true, WithDefault: true})
@@ -1598,7 +1621,7 @@ var _ = Describe("ConfigurationManager", func() {
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 						Return(map[string]string{"NUM_OF_PF": "2"}, nil)
 					mockNVConfigUtils.On("SetSystemConf", ctx, portSpec(pciAddress), "conf3", 0, true).Return(nil)
-					mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, false, true).
+					mockNVConfigUtils.On("SetNvConfigParametersBatchWithContext", mock.Anything, portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, false, true).
 						Return(types.ApplyStatusSuccess, nil)
 
 					result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{Force: true})
@@ -1612,7 +1635,7 @@ var _ = Describe("ConfigurationManager", func() {
 						Return(mismatchSystemConf("NUM_OF_PF")...)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 						Return(map[string]string{"NUM_OF_PF": "2"}, nil)
-					mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, false, true).
+					mockNVConfigUtils.On("SetNvConfigParametersBatchWithContext", mock.Anything, portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, false, true).
 						Return(types.ApplyStatusSuccess, nil)
 					mockNVConfigUtils.AssertNotCalled(GinkgoT(), "SetSystemConf", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 
@@ -1786,7 +1809,7 @@ var _ = Describe("ConfigurationManager", func() {
 					Return(map[string]string{"param1": "value2"}, nil)
 				setSystemConfCall := mockNV.On("SetSystemConf", ctx, portSpec(pciAddress), "conf3", 0, false).Return(nil)
 				// set_system_conf is the baseline and must be staged before the override batch.
-				mockNV.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"param1": "value2"}, false, false).
+				mockNV.On("SetNvConfigParametersBatchWithContext", mock.Anything, portSpec(pciAddress), map[string]string{"param1": "value2"}, false, false).
 					Return(types.ApplyStatusSuccess, nil).NotBefore(setSystemConfCall)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
@@ -1878,7 +1901,7 @@ var _ = Describe("ConfigurationManager", func() {
 				Expect(result.Status).To(Equal(types.ApplyStatusNothingToDo))
 				Expect(result.RebootRequired).To(BeFalse())
 				fullFlowNV.AssertNotCalled(GinkgoT(), "SetSystemConf", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
-				fullFlowNV.AssertNotCalled(GinkgoT(), "SetNvConfigParametersBatch", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+				fullFlowNV.AssertNotCalled(GinkgoT(), "SetNvConfigParametersBatchWithContext", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 			})
 
 			// 2) system_conf mismatch, no overrides → set_system_conf re-applied.
@@ -1899,7 +1922,7 @@ var _ = Describe("ConfigurationManager", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.Status).To(Equal(types.ApplyStatusSuccess))
 				Expect(result.RebootRequired).To(BeTrue())
-				fullFlowNV.AssertNotCalled(GinkgoT(), "SetNvConfigParametersBatch", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+				fullFlowNV.AssertNotCalled(GinkgoT(), "SetNvConfigParametersBatchWithContext", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 			})
 
 			// 3) system_conf mismatch, rawNvConfig covers it and the value is already staged → converged.
@@ -1920,7 +1943,7 @@ var _ = Describe("ConfigurationManager", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.Status).To(Equal(types.ApplyStatusNothingToDo))
 				fullFlowNV.AssertNotCalled(GinkgoT(), "SetSystemConf", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
-				fullFlowNV.AssertNotCalled(GinkgoT(), "SetNvConfigParametersBatch", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+				fullFlowNV.AssertNotCalled(GinkgoT(), "SetNvConfigParametersBatchWithContext", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 			})
 
 			// 4) system_conf mismatch covered by rawNvConfig by name, but the override value is not yet staged →
@@ -1932,7 +1955,7 @@ var _ = Describe("ConfigurationManager", func() {
 					types.NvConfigQuery{NextBootConfig: staged, CurrentConfig: staged}, nil)
 				fullFlowNV.On("ValidateSystemConf", fullFlowCtx, portSpec(pciAddress), "conf3", 0).
 					Return(mismatchSystemConf("NUM_OF_PF")...)
-				fullFlowNV.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "8"}, false, false).
+				fullFlowNV.On("SetNvConfigParametersBatchWithContext", mock.Anything, portSpec(pciAddress), map[string]string{"NUM_OF_PF": "8"}, false, false).
 					Return(types.ApplyStatusSuccess, nil)
 
 				updateNeeded, rebootNeeded, _, err := fullFlowManager.ValidateDeviceNvSpec(fullFlowCtx, fullFlowDevice)
@@ -1967,7 +1990,7 @@ var _ = Describe("ConfigurationManager", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.Status).To(Equal(types.ApplyStatusNothingToDo))
 				fullFlowNV.AssertNotCalled(GinkgoT(), "SetSystemConf", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
-				fullFlowNV.AssertNotCalled(GinkgoT(), "SetNvConfigParametersBatch", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+				fullFlowNV.AssertNotCalled(GinkgoT(), "SetNvConfigParametersBatchWithContext", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 			})
 
 			// 6) Spectrum-X params for the mismatched profile params are ALSO overridden by rawNvConfig (raw wins):
@@ -1987,7 +2010,7 @@ var _ = Describe("ConfigurationManager", func() {
 				fullFlowNV.On("ValidateSystemConf", fullFlowCtx, portSpec(pciAddress), "conf3", 0).
 					Return(mismatchSystemConf("NUM_OF_PF", "LINK_TYPE_P1")...)
 				// Only LINK_TYPE_P1 differs from next boot; the raw value 2 wins over the Spectrum-X value 1.
-				fullFlowNV.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"LINK_TYPE_P1": "2"}, false, false).
+				fullFlowNV.On("SetNvConfigParametersBatchWithContext", mock.Anything, portSpec(pciAddress), map[string]string{"LINK_TYPE_P1": "2"}, false, false).
 					Return(types.ApplyStatusSuccess, nil)
 
 				updateNeeded, rebootNeeded, _, err := fullFlowManager.ValidateDeviceNvSpec(fullFlowCtx, fullFlowDevice)
@@ -2025,7 +2048,7 @@ var _ = Describe("ConfigurationManager", func() {
 				fullFlowNV.On("ValidateSystemConf", fullFlowCtx, portSpec(pciAddress), "conf3", 0).
 					Return(mismatchSystemConf("NUM_OF_PF", "LINK_TYPE_P1")...)
 				// Raw wins on both: LINK_TYPE_P1 over Spectrum-X (1→2) and NUM_OF_VFS over template (4→16).
-				fullFlowNV.On("SetNvConfigParametersBatch", portSpec(pciAddress),
+				fullFlowNV.On("SetNvConfigParametersBatchWithContext", mock.Anything, portSpec(pciAddress),
 					map[string]string{"LINK_TYPE_P1": "2", consts.SriovNumOfVfsParam: "16"}, false, false).Return(types.ApplyStatusSuccess, nil)
 
 				updateNeeded, rebootNeeded, _, err := fullFlowManager.ValidateDeviceNvSpec(fullFlowCtx, fullFlowDevice)

--- a/pkg/dmscli/blueprints.go
+++ b/pkg/dmscli/blueprints.go
@@ -34,7 +34,6 @@ const blueprintsPlanPath = "/nvidia/blueprints/plan"
 
 // BlueprintPlanRequest describes one DMS Blueprints planning action.
 type BlueprintPlanRequest struct {
-	BlueprintsRoot     string
 	BlueprintsStateDir string
 	Profile            string
 	Name               string
@@ -81,8 +80,7 @@ func GenerateBlueprintPlan(
 	}
 
 	command := execInterface.CommandContext(ctx, dmsCLIExecutable, args...)
-	environment := environmentWithOverride(os.Environ(), "BLUEPRINTS_ROOT", request.BlueprintsRoot)
-	environment = environmentWithOverride(environment, "BP_STATE_DIR", request.BlueprintsStateDir)
+	environment := environmentWithOverride(os.Environ(), "BP_STATE_DIR", request.BlueprintsStateDir)
 	command.SetEnv(environment)
 	output, commandErr := utils.RunCommandWithStreams(command)
 	commandAndArgs := append([]string{dmsCLIExecutable}, args...)
@@ -125,7 +123,6 @@ func logBlueprintPlanResult(
 	fields := []any{
 		"command", command,
 		"plan", request.Name,
-		"blueprintsRoot", request.BlueprintsRoot,
 		"blueprintsStateDir", request.BlueprintsStateDir,
 	}
 	if result != nil {
@@ -143,12 +140,6 @@ func logBlueprintPlanResult(
 }
 
 func validateBlueprintPlanRequest(request BlueprintPlanRequest) error {
-	if strings.TrimSpace(request.BlueprintsRoot) == "" {
-		return fmt.Errorf("blueprints root must not be empty")
-	}
-	if !filepath.IsAbs(request.BlueprintsRoot) {
-		return fmt.Errorf("blueprints root must be an absolute path")
-	}
 	if strings.TrimSpace(request.BlueprintsStateDir) == "" {
 		return fmt.Errorf("blueprints state directory must not be empty")
 	}

--- a/pkg/dmscli/blueprints_test.go
+++ b/pkg/dmscli/blueprints_test.go
@@ -29,7 +29,6 @@ import (
 var _ = Describe("Blueprint plan", func() {
 	const (
 		planName           = "nco-node-1-spcx-prepare"
-		blueprintsRoot     = "/opt/nvidia/blueprints"
 		blueprintsStateDir = "/var/lib/blueprints"
 	)
 
@@ -37,7 +36,6 @@ var _ = Describe("Blueprint plan", func() {
 
 	newRequest := func() BlueprintPlanRequest {
 		return BlueprintPlanRequest{
-			BlueprintsRoot:     blueprintsRoot,
 			BlueprintsStateDir: blueprintsStateDir,
 			Profile:            "SPX_Multiplane",
 			Name:               planName,
@@ -72,7 +70,6 @@ var _ = Describe("Blueprint plan", func() {
 		}))
 		Expect(commands[0].command.RunCalls).To(Equal(1))
 		Expect(commands[0].command.CombinedOutputCalls).To(BeZero())
-		Expect(commands[0].command.Env).To(ContainElement("BLUEPRINTS_ROOT=" + blueprintsRoot))
 		Expect(commands[0].command.Env).To(ContainElement("BP_STATE_DIR=" + blueprintsStateDir))
 	})
 
@@ -115,7 +112,6 @@ var _ = Describe("Blueprint plan", func() {
 		Expect(entries[0].message).To(Equal("command output"))
 		Expect(entries[0].fields).To(HaveKeyWithValue("command", append([]string{dmsCLIExecutable}, commands[0].args...)))
 		Expect(entries[0].fields).To(HaveKeyWithValue("plan", planName))
-		Expect(entries[0].fields).To(HaveKeyWithValue("blueprintsRoot", blueprintsRoot))
 		Expect(entries[0].fields).To(HaveKeyWithValue("blueprintsStateDir", blueprintsStateDir))
 		Expect(entries[0].fields).NotTo(HaveKey("stdout"))
 		Expect(entries[0].fields).To(HaveKeyWithValue("status", "ok"))
@@ -185,8 +181,6 @@ var _ = Describe("Blueprint plan", func() {
 			Expect(result).To(BeNil())
 			Expect(err).To(MatchError(ContainSubstring(expected)))
 		},
-		Entry("empty Blueprints root", func(request *BlueprintPlanRequest) { request.BlueprintsRoot = "" }, "blueprints root"),
-		Entry("relative Blueprints root", func(request *BlueprintPlanRequest) { request.BlueprintsRoot = "blueprints" }, "absolute path"),
 		Entry("empty Blueprints state directory", func(request *BlueprintPlanRequest) { request.BlueprintsStateDir = "" }, "state directory"),
 		Entry("relative Blueprints state directory", func(request *BlueprintPlanRequest) { request.BlueprintsStateDir = "blueprints-state" }, "absolute path"),
 		Entry("empty profile", func(request *BlueprintPlanRequest) { request.Profile = "" }, "profile"),
@@ -204,20 +198,6 @@ var _ = Describe("Blueprint plan", func() {
 
 		Expect(result).To(BeNil())
 		Expect(err).To(MatchError(ContainSubstring("does not contain plan-json")))
-	})
-
-	It("replaces an inherited Blueprints root without duplicating it", func() {
-		environment := environmentWithOverride([]string{
-			"PATH=/usr/bin",
-			"BLUEPRINTS_ROOT=/old/blueprints",
-			"HOME=/tmp/test-home",
-		}, "BLUEPRINTS_ROOT", blueprintsRoot)
-
-		Expect(environment).To(Equal([]string{
-			"PATH=/usr/bin",
-			"HOME=/tmp/test-home",
-			"BLUEPRINTS_ROOT=" + blueprintsRoot,
-		}))
 	})
 
 	It("replaces an inherited DMS state directory without duplicating it", func() {

--- a/pkg/nvconfig/mocks/NVConfigUtils.go
+++ b/pkg/nvconfig/mocks/NVConfigUtils.go
@@ -108,6 +108,34 @@ func (_m *NVConfigUtils) SetNvConfigParametersBatch(port v1alpha1.NicDevicePortS
 	return r0, r1
 }
 
+// SetNvConfigParametersBatchWithContext provides a mock function with given fields: ctx, port, params, withDefault, force
+func (_m *NVConfigUtils) SetNvConfigParametersBatchWithContext(ctx context.Context, port v1alpha1.NicDevicePortSpec, params map[string]string, withDefault bool, force bool) (types.ApplyStatus, error) {
+	ret := _m.Called(ctx, port, params, withDefault, force)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetNvConfigParametersBatchWithContext")
+	}
+
+	var r0 types.ApplyStatus
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, v1alpha1.NicDevicePortSpec, map[string]string, bool, bool) (types.ApplyStatus, error)); ok {
+		return rf(ctx, port, params, withDefault, force)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, v1alpha1.NicDevicePortSpec, map[string]string, bool, bool) types.ApplyStatus); ok {
+		r0 = rf(ctx, port, params, withDefault, force)
+	} else {
+		r0 = ret.Get(0).(types.ApplyStatus)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, v1alpha1.NicDevicePortSpec, map[string]string, bool, bool) error); ok {
+		r1 = rf(ctx, port, params, withDefault, force)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // SetSystemConf provides a mock function with given fields: ctx, port, conf, asic, force
 func (_m *NVConfigUtils) SetSystemConf(ctx context.Context, port v1alpha1.NicDevicePortSpec, conf string, asic int, force bool) error {
 	ret := _m.Called(ctx, port, conf, asic, force)

--- a/pkg/nvconfig/utils.go
+++ b/pkg/nvconfig/utils.go
@@ -209,8 +209,27 @@ func (h *nvConfigUtils) SetNvConfigParameter(port v1alpha1.NicDevicePortSpec, pa
 	return nil
 }
 
-// SetNvConfigParametersBatch sets multiple nv config parameters for a Mellanox device in one DMS NVConfig action.
-func (h *nvConfigUtils) SetNvConfigParametersBatch(port v1alpha1.NicDevicePortSpec, params map[string]string, withDefault bool, force bool) (types.ApplyStatus, error) {
+// SetNvConfigParametersBatch preserves the NVConfigUtils interface. New internal callers should
+// use SetNvConfigParametersBatchWithContext so cancellation reaches dms-cli.
+func (h *nvConfigUtils) SetNvConfigParametersBatch(
+	port v1alpha1.NicDevicePortSpec,
+	params map[string]string,
+	withDefault bool,
+	force bool,
+) (types.ApplyStatus, error) {
+	ctx := logr.NewContext(context.Background(), log.Log)
+	return h.SetNvConfigParametersBatchWithContext(ctx, port, params, withDefault, force)
+}
+
+// SetNvConfigParametersBatchWithContext sets multiple NVConfig parameters in one DMS NVConfig action
+// and propagates cancellation to the command.
+func (h *nvConfigUtils) SetNvConfigParametersBatchWithContext(
+	ctx context.Context,
+	port v1alpha1.NicDevicePortSpec,
+	params map[string]string,
+	withDefault bool,
+	force bool,
+) (types.ApplyStatus, error) {
 	if len(params) == 0 {
 		return types.ApplyStatusNothingToDo, nil
 	}
@@ -233,7 +252,6 @@ func (h *nvConfigUtils) SetNvConfigParametersBatch(port v1alpha1.NicDevicePortSp
 		raw = append(raw, dmscli.NVConfigParam{Param: name, Value: params[name]})
 	}
 
-	ctx := logr.NewContext(context.Background(), log.Log)
 	result, err := dmscli.ApplyNVConfig(ctx, h.execInterface, dmscli.ApplyNVConfigRequest{
 		Target:      target,
 		Raw:         raw,

--- a/pkg/nvconfig/utils_test.go
+++ b/pkg/nvconfig/utils_test.go
@@ -636,7 +636,7 @@ Result: Device configuration does NOT match the system configuration.
 		})
 
 		It("sends a sorted raw batch and forwards with-default and force", func() {
-			status, err := h.SetNvConfigParametersBatch(nvconfigPort(pciAddress), map[string]string{
+			status, err := h.SetNvConfigParametersBatchWithContext(context.Background(), nvconfigPort(pciAddress), map[string]string{
 				"Z_PARAM": "2",
 				"A_PARAM": "1",
 			}, true, true)
@@ -673,7 +673,7 @@ Result: Device configuration does NOT match the system configuration.
 		})
 
 		It("forwards false flag values explicitly", func() {
-			status, err := h.SetNvConfigParametersBatch(nvconfigPort(pciAddress), map[string]string{"PARAM": "1"}, false, false)
+			status, err := h.SetNvConfigParametersBatchWithContext(context.Background(), nvconfigPort(pciAddress), map[string]string{"PARAM": "1"}, false, false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(status).To(Equal(types.ApplyStatusSuccess))
 
@@ -685,7 +685,7 @@ Result: Device configuration does NOT match the system configuration.
 
 		It("passes the PCI target and does not use fwctl metadata", func() {
 			port := v1alpha1.NicDevicePortSpec{PCI: pciAddress, FwctlDevice: "/dev/fwctl/fwctl3"}
-			status, err := h.SetNvConfigParametersBatch(port, map[string]string{"PARAM": "1"}, false, false)
+			status, err := h.SetNvConfigParametersBatchWithContext(context.Background(), port, map[string]string{"PARAM": "1"}, false, false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(status).To(Equal(types.ApplyStatusSuccess))
 
@@ -693,7 +693,7 @@ Result: Device configuration does NOT match the system configuration.
 		})
 
 		It("does not invoke DMS for an empty batch", func() {
-			status, err := h.SetNvConfigParametersBatch(nvconfigPort(pciAddress), map[string]string{}, true, true)
+			status, err := h.SetNvConfigParametersBatchWithContext(context.Background(), nvconfigPort(pciAddress), map[string]string{}, true, true)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(status).To(Equal(types.ApplyStatusNothingToDo))
 			Expect(fakeExec.CommandCalls).To(BeZero())
@@ -712,7 +712,7 @@ Result: Device configuration does NOT match the system configuration.
 			commandOutput = []byte(`{"status":"error","error_msg":"DMS apply failed"}`)
 			commandErr = applyErr
 
-			status, err := h.SetNvConfigParametersBatch(nvconfigPort(pciAddress), map[string]string{"PARAM": "1"}, false, false)
+			status, err := h.SetNvConfigParametersBatchWithContext(context.Background(), nvconfigPort(pciAddress), map[string]string{"PARAM": "1"}, false, false)
 			Expect(status).To(Equal(types.ApplyStatusFailed))
 			Expect(err).To(MatchError(ContainSubstring("DMS apply failed")))
 			Expect(errors.Is(err, applyErr)).To(BeTrue())
@@ -721,7 +721,7 @@ Result: Device configuration does NOT match the system configuration.
 		It("returns an error when the command executor is not initialized", func() {
 			h.execInterface = nil
 
-			status, err := h.SetNvConfigParametersBatch(nvconfigPort(pciAddress), map[string]string{"PARAM": "1"}, false, false)
+			status, err := h.SetNvConfigParametersBatchWithContext(context.Background(), nvconfigPort(pciAddress), map[string]string{"PARAM": "1"}, false, false)
 			Expect(status).To(Equal(types.ApplyStatusFailed))
 			Expect(err).To(MatchError("command executor must not be nil"))
 		})

--- a/pkg/spectrumx/blueprintsdata_test.go
+++ b/pkg/spectrumx/blueprintsdata_test.go
@@ -89,7 +89,6 @@ func newBlueprintsDataManager(dataRoot string) *spectrumXConfigManager {
 		preparedPlans:      make(map[string]*preparedPlan),
 		dmsManager:         nil,
 		execInterface:      nil,
-		blueprintsRoot:     "",
 		blueprintsStateDir: "",
 		dospcxDataRoot:     dataRoot,
 		dospcxDataDigest:   "",

--- a/pkg/spectrumx/prepareplan.go
+++ b/pkg/spectrumx/prepareplan.go
@@ -38,7 +38,6 @@ import (
 )
 
 const (
-	defaultBlueprintsRoot     = "/opt/nvidia/blueprints"
 	defaultBlueprintsStateDir = "/var/lib/blueprints"
 	defaultDospcxDataRoot     = "/opt/mellanox/doca/services/dms/doSpcx/data"
 	deploymentModeHostK8s     = "host-k8s"
@@ -109,7 +108,6 @@ type planConfig struct {
 // planMetadata contains only the inputs used to generate a doSPCX plan.
 // Exact equality with the current inputs allows the saved plan to be reused.
 type planMetadata struct {
-	BlueprintsRoot       string   `json:"blueprints_root"`
 	BlueprintsStateDir   string   `json:"blueprints_state_dir"`
 	BlueprintsDataDigest string   `json:"blueprints_data_digest,omitempty"`
 	PlanName             string   `json:"plan_name"`
@@ -147,9 +145,6 @@ func (m *spectrumXConfigManager) PreparePlan(
 	}
 	if err := validatePlanStage(stage); err != nil {
 		return err
-	}
-	if strings.TrimSpace(m.blueprintsRoot) == "" || !filepath.IsAbs(m.blueprintsRoot) {
-		return fmt.Errorf("blueprints root must be a non-empty absolute path")
 	}
 	stateDir := m.resolvedStateDir()
 	if !filepath.IsAbs(stateDir) {
@@ -208,7 +203,6 @@ func (m *spectrumXConfigManager) PreparePlan(
 	}
 
 	result, err := dmscli.GenerateBlueprintPlan(ctx, m.execInterface, dmscli.BlueprintPlanRequest{
-		BlueprintsRoot:     m.blueprintsRoot,
 		BlueprintsStateDir: stateDir,
 		Profile:            config.profile,
 		Name:               generatedPlanName,
@@ -241,7 +235,6 @@ func (m *spectrumXConfigManager) PreparePlan(
 		"profile", config.profile,
 		"platformType", config.platformType,
 		"devices", len(config.targetMap.PreBreakout.Targets),
-		"blueprintsRoot", m.blueprintsRoot,
 		"targetMap", targetMapPath,
 		"plan", planPath,
 		"metadata", metadataPath)
@@ -257,9 +250,6 @@ func (m *spectrumXConfigManager) GetPreparedPlan(device *v1alpha1.NicDevice, sta
 	}
 	if err := validatePlanStage(stage); err != nil {
 		return nil, err
-	}
-	if strings.TrimSpace(m.blueprintsRoot) == "" || !filepath.IsAbs(m.blueprintsRoot) {
-		return nil, fmt.Errorf("blueprints root must be a non-empty absolute path")
 	}
 	if !spectrumXEnabledForPlan(device) {
 		return nil, fmt.Errorf("device does not enable Spectrum-X optimization")
@@ -355,7 +345,6 @@ func newPlanMetadata(
 	targetMapDigest string,
 ) planMetadata {
 	return planMetadata{
-		BlueprintsRoot:       m.blueprintsRoot,
 		BlueprintsStateDir:   stateDir,
 		BlueprintsDataDigest: m.dospcxDataDigest,
 		PlanName:             planName(config.nodeName, stage),
@@ -693,16 +682,43 @@ func validateGeneratedPlan(
 	if err := validateGeneratedPlanDevices(document.Plan.Devices, config, expectedStage); err != nil {
 		return nil, err
 	}
+	if len(document.Plan.PostBreakoutDevices) > 0 {
+		if err := validateGeneratedPostBreakoutDevices(document.Plan.PostBreakoutDevices, config); err != nil {
+			return nil, err
+		}
+	}
 	return plan, nil
 }
 
 func validateGeneratedPlanDevices(actual []planDevice, config *planConfig, stage PlanStage) error {
+	planes := 1
+	if stage == PlanStageConfigure {
+		planes = config.planes
+	}
+	return validateGeneratedDeviceView(actual, config, planes, string(stage), false)
+}
+
+func validateGeneratedPostBreakoutDevices(actual []planDevice, config *planConfig) error {
+	if err := validateGeneratedDeviceView(actual, config, config.planes, "post-breakout", true); err != nil {
+		return err
+	}
+	for _, device := range actual {
+		if !device.PlaneExplicit {
+			return fmt.Errorf("generated doSPCX post-breakout device %q does not identify an explicit plane", device.BDF)
+		}
+	}
+	return nil
+}
+
+func validateGeneratedDeviceView(
+	actual []planDevice,
+	config *planConfig,
+	planes int,
+	view string,
+	allowMissingDeviceID bool,
+) error {
 	expected := make(map[string]planDevice, len(config.targetMap.PreBreakout.Targets)*config.planes)
 	for _, target := range config.targetMap.PreBreakout.Targets {
-		planes := 1
-		if stage == PlanStageConfigure {
-			planes = config.planes
-		}
 		for plane := 0; plane < planes; plane++ {
 			bdf, err := bdfForPlane(target.BDF, plane)
 			if err != nil {
@@ -719,16 +735,17 @@ func validateGeneratedPlanDevices(actual []planDevice, config *planConfig, stage
 		}
 	}
 	if len(actual) != len(expected) {
-		return fmt.Errorf("generated doSPCX %s plan has %d devices, expected %d", stage, len(actual), len(expected))
+		return fmt.Errorf("generated doSPCX %s device view has %d devices, expected %d", view, len(actual), len(expected))
 	}
 	for _, device := range actual {
 		want, found := expected[device.BDF]
 		if !found {
-			return fmt.Errorf("generated doSPCX %s plan contains unexpected device BDF %q", stage, device.BDF)
+			return fmt.Errorf("generated doSPCX %s device view contains unexpected device BDF %q", view, device.BDF)
 		}
-		if device.DMSTarget != want.DMSTarget || device.DeviceID != want.DeviceID ||
+		deviceIDMatches := device.DeviceID == want.DeviceID || (allowMissingDeviceID && device.DeviceID == "")
+		if device.DMSTarget != want.DMSTarget || !deviceIDMatches ||
 			device.Rail != want.Rail || device.Plane != want.Plane || device.Network != want.Network {
-			return fmt.Errorf("generated doSPCX %s plan device %q topology does not match the target map", stage, device.BDF)
+			return fmt.Errorf("generated doSPCX %s device %q topology does not match the target map", view, device.BDF)
 		}
 	}
 	return nil

--- a/pkg/spectrumx/prepareplan_test.go
+++ b/pkg/spectrumx/prepareplan_test.go
@@ -39,11 +39,11 @@ type preparePlanCommand struct {
 const (
 	prepareStage   = "prepare"
 	configureStage = "configure"
+	b300Platform   = "b300"
 )
 
 func newTestPlanManager(
 	execInterface execUtils.Interface,
-	blueprintsRoot string,
 	stateDir string,
 ) PlanManager {
 	return &spectrumXConfigManager{
@@ -51,7 +51,6 @@ func newTestPlanManager(
 		preparedPlans:      make(map[string]*preparedPlan),
 		dmsManager:         nil,
 		execInterface:      execInterface,
-		blueprintsRoot:     blueprintsRoot,
 		blueprintsStateDir: stateDir,
 		dospcxDataRoot:     filepath.Join(stateDir, "dospcx-data"),
 		dospcxDataDigest:   "",
@@ -65,10 +64,9 @@ func generatePreparePlan(
 	execInterface execUtils.Interface,
 	nodeName string,
 	devices []*v1alpha1.NicDevice,
-	blueprintsRoot string,
 	stateDir string,
 ) (string, error) {
-	manager := newTestPlanManager(execInterface, blueprintsRoot, stateDir)
+	manager := newTestPlanManager(execInterface, stateDir)
 	for _, device := range devices {
 		device.Status.Node = nodeName
 	}
@@ -87,10 +85,9 @@ func generateConfigurePlan(
 	execInterface execUtils.Interface,
 	nodeName string,
 	devices []*v1alpha1.NicDevice,
-	blueprintsRoot string,
 	stateDir string,
 ) (string, error) {
-	manager := newTestPlanManager(execInterface, blueprintsRoot, stateDir)
+	manager := newTestPlanManager(execInterface, stateDir)
 	for _, device := range devices {
 		device.Status.Node = nodeName
 	}
@@ -125,9 +122,8 @@ func preparePlanFakeExecutor(output []byte, commands *[]preparePlanCommand) *exe
 
 var _ = Describe("doSPCX planning", func() {
 	const (
-		nodeName       = "worker-01"
-		blueprintsRoot = "/opt/nvidia/blueprints"
-		secondBDF      = "0000:65:00.0"
+		nodeName  = "worker-01"
+		secondBDF = "0000:65:00.0"
 	)
 
 	newDevice := func(name, bdf, mode string) *v1alpha1.NicDevice {
@@ -206,32 +202,52 @@ var _ = Describe("doSPCX planning", func() {
 				"operation_refs":  []string{},
 			})
 		}
+		generatedPlan := map[string]any{
+			"name":         name,
+			"family":       "spcx",
+			"profile":      profile,
+			"stage":        stage,
+			"path_dialect": semanticPathDialect,
+			"params":       map[string]any{"deployment_mode": "host-k8s", "planes": planes},
+			"detected_hw":  map[string]any{"platform_type": platform},
+			"devices":      devices,
+			"runtime_ctx":  map[string]any{"deployment_mode": "host-k8s", "rdma_topology": "per_pf"},
+			"operations": map[string]any{
+				operationID: map[string]any{
+					"path":           "/nvidia/test",
+					"values":         map[string]any{"enabled": true},
+					"source_feature": "test",
+					"target_class":   "pf_netdev_all",
+				},
+			},
+			"semantic": map[string]any{"groups": groups},
+		}
+		if stage == prepareStage {
+			postBreakoutDevices := make([]map[string]any, 0, deviceCount*planes)
+			for rail, device := range devices {
+				for plane := 0; plane < planes; plane++ {
+					bdf, err := bdfForPlane(device["bdf"].(string), plane)
+					Expect(err).NotTo(HaveOccurred())
+					postBreakoutDevices = append(postBreakoutDevices, map[string]any{
+						"bdf":            bdf,
+						"device_id":      "",
+						"dms_target":     "pci/" + bdf,
+						"network":        "ew",
+						"rail":           rail,
+						"plane":          plane,
+						"plane_explicit": true,
+					})
+				}
+			}
+			generatedPlan["post_breakout_devices"] = postBreakoutDevices
+		}
 		response, err := json.Marshal(map[string]any{
 			"plan":    name,
 			"family":  "spcx",
 			"profile": profile,
 			"stage":   stage,
 			"plan-json": map[string]any{
-				"plan": map[string]any{
-					"name":         name,
-					"family":       "spcx",
-					"profile":      profile,
-					"stage":        stage,
-					"path_dialect": semanticPathDialect,
-					"params":       map[string]any{"deployment_mode": "host-k8s", "planes": planes},
-					"detected_hw":  map[string]any{"platform_type": platform},
-					"devices":      devices,
-					"runtime_ctx":  map[string]any{"deployment_mode": "host-k8s", "rdma_topology": "per_pf"},
-					"operations": map[string]any{
-						operationID: map[string]any{
-							"path":           "/nvidia/test",
-							"values":         map[string]any{"enabled": true},
-							"source_feature": "test",
-							"target_class":   "pf_netdev_all",
-						},
-					},
-					"semantic": map[string]any{"groups": groups},
-				},
+				"plan":      generatedPlan,
 				"artifacts": map[string]any{"manifest": []any{}},
 			},
 		})
@@ -253,7 +269,7 @@ var _ = Describe("doSPCX planning", func() {
 			newDevice("first-by-bdf", "0000:64:00.0", "hwplb"),
 		}
 
-		manager := newTestPlanManager(executor, blueprintsRoot, stateDir)
+		manager := newTestPlanManager(executor, stateDir)
 		err := manager.PreparePlan(context.Background(), devices, PlanStagePrepare)
 
 		Expect(err).NotTo(HaveOccurred())
@@ -300,7 +316,6 @@ var _ = Describe("doSPCX planning", func() {
 			"params=deployment_mode=host-k8s,planes=2",
 		))
 		Expect(commands[0].args).NotTo(ContainElement("params=deployment_mode=host-k8s,planes=2,overlay=none"))
-		Expect(commands[0].command.Env).To(ContainElement("BLUEPRINTS_ROOT=" + blueprintsRoot))
 		Expect(commands[0].command.Env).To(ContainElement("BP_STATE_DIR=" + stateDir))
 
 		metadataPath := filepath.Join(stateDir, "plans", planName, "metadata.json")
@@ -309,7 +324,6 @@ var _ = Describe("doSPCX planning", func() {
 		var metadata planMetadata
 		Expect(json.Unmarshal(metadataContent, &metadata)).To(Succeed())
 		Expect(metadata).To(Equal(planMetadata{
-			BlueprintsRoot:     blueprintsRoot,
 			BlueprintsStateDir: stateDir,
 			PlanName:           planName,
 			Stage:              prepareStage,
@@ -334,7 +348,7 @@ var _ = Describe("doSPCX planning", func() {
 		manager := newTestPlanManager(
 			preparePlanFakeExecutor(
 				planResponse(generatedPlanName, "SPX_Multiplane", prepareStage, 2, 1), &commands,
-			), blueprintsRoot, stateDir,
+			), stateDir,
 		)
 		device := newDevice("rail-0", "0000:64:00.0", "hwplb")
 		Expect(manager.PreparePlan(context.Background(), []*v1alpha1.NicDevice{device}, PlanStagePrepare)).To(Succeed())
@@ -356,7 +370,7 @@ var _ = Describe("doSPCX planning", func() {
 
 	It("does not generate a plan when Spectrum-X is not enabled", func() {
 		commands := []preparePlanCommand{}
-		manager := newTestPlanManager(preparePlanFakeExecutor(nil, &commands), blueprintsRoot, GinkgoT().TempDir())
+		manager := newTestPlanManager(preparePlanFakeExecutor(nil, &commands), GinkgoT().TempDir())
 
 		err := manager.PreparePlan(context.Background(), []*v1alpha1.NicDevice{{}}, PlanStagePrepare)
 
@@ -365,7 +379,7 @@ var _ = Describe("doSPCX planning", func() {
 	})
 
 	It("rejects retrieval for an unsupported plan stage", func() {
-		manager := newTestPlanManager(nil, blueprintsRoot, GinkgoT().TempDir())
+		manager := newTestPlanManager(nil, GinkgoT().TempDir())
 
 		_, err := manager.GetPreparedPlan(newDevice("device", "0000:64:00.0", "hwplb"), PlanStage("unknown"))
 
@@ -373,7 +387,7 @@ var _ = Describe("doSPCX planning", func() {
 	})
 
 	It("does not load a persisted plan through the per-device retrieval path", func() {
-		manager := newTestPlanManager(nil, blueprintsRoot, GinkgoT().TempDir())
+		manager := newTestPlanManager(nil, GinkgoT().TempDir())
 		device := newDevice("device", "0000:64:00.0", "hwplb")
 
 		plan, err := manager.GetPreparedPlan(device, PlanStagePrepare)
@@ -399,11 +413,11 @@ var _ = Describe("doSPCX planning", func() {
 			)
 			if stage == PlanStagePrepare {
 				path, err = generatePreparePlan(
-					context.Background(), executor, otherNode, []*v1alpha1.NicDevice{device}, blueprintsRoot, stateDir,
+					context.Background(), executor, otherNode, []*v1alpha1.NicDevice{device}, stateDir,
 				)
 			} else {
 				path, err = generateConfigurePlan(
-					context.Background(), executor, otherNode, []*v1alpha1.NicDevice{device}, blueprintsRoot, stateDir,
+					context.Background(), executor, otherNode, []*v1alpha1.NicDevice{device}, stateDir,
 				)
 			}
 
@@ -429,7 +443,7 @@ var _ = Describe("doSPCX planning", func() {
 			v1alpha1.NicDevicePortSpec{PCI: "0000:64:00.1"})
 
 		planPath, err := generateConfigurePlan(
-			context.Background(), executor, nodeName, devices, blueprintsRoot, stateDir,
+			context.Background(), executor, nodeName, devices, stateDir,
 		)
 
 		Expect(err).NotTo(HaveOccurred())
@@ -460,7 +474,7 @@ var _ = Describe("doSPCX planning", func() {
 
 		firstPath, err := generatePreparePlan(
 			context.Background(), firstExecutor, nodeName,
-			[]*v1alpha1.NicDevice{device}, blueprintsRoot, stateDir,
+			[]*v1alpha1.NicDevice{device}, stateDir,
 		)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(firstCommands).To(HaveLen(1))
@@ -468,7 +482,7 @@ var _ = Describe("doSPCX planning", func() {
 		secondCommands := []preparePlanCommand{}
 		secondPath, err := generatePreparePlan(
 			context.Background(), preparePlanFakeExecutor(nil, &secondCommands), nodeName,
-			[]*v1alpha1.NicDevice{device}, blueprintsRoot, stateDir,
+			[]*v1alpha1.NicDevice{device}, stateDir,
 		)
 
 		Expect(err).NotTo(HaveOccurred())
@@ -484,7 +498,7 @@ var _ = Describe("doSPCX planning", func() {
 		manager := newTestPlanManager(
 			preparePlanFakeExecutor(
 				planResponse(generatedPlanName, "SPX_Multiplane", prepareStage, 2, 1), &firstCommands,
-			), blueprintsRoot, stateDir,
+			), stateDir,
 		).(*spectrumXConfigManager)
 		manager.dospcxDataDigest = "first-bundle"
 
@@ -515,7 +529,7 @@ var _ = Describe("doSPCX planning", func() {
 			manager := newTestPlanManager(
 				preparePlanFakeExecutor(
 					planResponse(generatedPlanName, "SPX_Multiplane", prepareStage, 2, 1), &commands,
-				), blueprintsRoot, stateDir,
+				), stateDir,
 			)
 			Expect(manager.PreparePlan(context.Background(), []*v1alpha1.NicDevice{device}, PlanStagePrepare)).To(Succeed())
 
@@ -525,7 +539,7 @@ var _ = Describe("doSPCX planning", func() {
 			Expect(err).To(MatchError(ContainSubstring(expected)))
 		},
 		Entry("planner inputs changed", func(device *v1alpha1.NicDevice) {
-			device.Spec.Configuration.Template.SpectrumXOptimized.PlatformType = "b300"
+			device.Spec.Configuration.Template.SpectrumXOptimized.PlatformType = b300Platform
 		}, "does not match"),
 		Entry("device is absent from the target map", func(device *v1alpha1.NicDevice) {
 			device.Status.Ports[0].PCI = secondBDF
@@ -544,7 +558,7 @@ var _ = Describe("doSPCX planning", func() {
 			_, err := generatePreparePlan(
 				context.Background(), preparePlanFakeExecutor(
 					planResponse(generatedPlanName, "SPX_Multiplane", prepareStage, 2, 1), &firstCommands,
-				), nodeName, []*v1alpha1.NicDevice{device}, blueprintsRoot, stateDir,
+				), nodeName, []*v1alpha1.NicDevice{device}, stateDir,
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -558,12 +572,20 @@ var _ = Describe("doSPCX planning", func() {
 			planDevices := responseDocument["plan-json"].(map[string]any)["plan"].(map[string]any)["devices"].([]any)
 			planDevices[0].(map[string]any)["bdf"] = device.Status.Ports[0].PCI
 			planDevices[0].(map[string]any)["dms_target"] = "pci/" + device.Status.Ports[0].PCI
+			postBreakoutDevices := responseDocument["plan-json"].(map[string]any)["plan"].(map[string]any)["post_breakout_devices"].([]any)
+			for plane, rawDevice := range postBreakoutDevices {
+				bdf, bdfErr := bdfForPlane(device.Status.Ports[0].PCI, plane)
+				Expect(bdfErr).NotTo(HaveOccurred())
+				postBreakoutDevice := rawDevice.(map[string]any)
+				postBreakoutDevice["bdf"] = bdf
+				postBreakoutDevice["dms_target"] = "pci/" + bdf
+			}
 			secondResponse, err = json.Marshal(responseDocument)
 			Expect(err).NotTo(HaveOccurred())
 			_, err = generatePreparePlan(
 				context.Background(), preparePlanFakeExecutor(
 					secondResponse, &secondCommands,
-				), nodeName, []*v1alpha1.NicDevice{device}, blueprintsRoot, stateDir,
+				), nodeName, []*v1alpha1.NicDevice{device}, stateDir,
 			)
 
 			Expect(err).NotTo(HaveOccurred())
@@ -597,7 +619,7 @@ var _ = Describe("doSPCX planning", func() {
 			_, err := generatePreparePlan(
 				context.Background(), preparePlanFakeExecutor(
 					planResponse(generatedPlanName, "SPX_Multiplane", prepareStage, 2, 1), &firstCommands,
-				), nodeName, []*v1alpha1.NicDevice{device}, blueprintsRoot, stateDir,
+				), nodeName, []*v1alpha1.NicDevice{device}, stateDir,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			corrupt(stateDir, generatedPlanName)
@@ -606,7 +628,7 @@ var _ = Describe("doSPCX planning", func() {
 			_, err = generatePreparePlan(
 				context.Background(), preparePlanFakeExecutor(
 					planResponse(generatedPlanName, "SPX_Multiplane", prepareStage, 2, 1), &secondCommands,
-				), nodeName, []*v1alpha1.NicDevice{device}, blueprintsRoot, stateDir,
+				), nodeName, []*v1alpha1.NicDevice{device}, stateDir,
 			)
 
 			Expect(err).NotTo(HaveOccurred())
@@ -637,7 +659,7 @@ var _ = Describe("doSPCX planning", func() {
 		device := newDevice("SPX_NetPlugin", "0000:64:00.0", "swplb")
 
 		_, err := generatePreparePlan(
-			context.Background(), executor, nodeName, []*v1alpha1.NicDevice{device}, blueprintsRoot, stateDir,
+			context.Background(), executor, nodeName, []*v1alpha1.NicDevice{device}, stateDir,
 		)
 
 		Expect(err).NotTo(HaveOccurred())
@@ -654,7 +676,7 @@ var _ = Describe("doSPCX planning", func() {
 		device.Spec.Configuration.Template.SpectrumXOptimized.NumberOfPlanes = 0
 
 		_, err := generatePreparePlan(
-			context.Background(), executor, nodeName, []*v1alpha1.NicDevice{device}, blueprintsRoot, stateDir,
+			context.Background(), executor, nodeName, []*v1alpha1.NicDevice{device}, stateDir,
 		)
 
 		Expect(err).NotTo(HaveOccurred())
@@ -670,7 +692,7 @@ var _ = Describe("doSPCX planning", func() {
 
 		_, err := generatePreparePlan(
 			context.Background(), preparePlanFakeExecutor(nil, &commands), nodeName,
-			[]*v1alpha1.NicDevice{device}, blueprintsRoot, stateDir,
+			[]*v1alpha1.NicDevice{device}, stateDir,
 		)
 
 		Expect(err).To(MatchError(ContainSubstring("does not support overlay")))
@@ -680,20 +702,19 @@ var _ = Describe("doSPCX planning", func() {
 	})
 
 	DescribeTable("rejects invalid planner paths before writing the target map",
-		func(root, stateDir, expected string) {
+		func(stateDir, expected string) {
 			commands := []preparePlanCommand{}
 			device := newDevice("hwmp", "0000:64:00.0", "hwplb")
 
 			_, err := generatePreparePlan(
 				context.Background(), preparePlanFakeExecutor(nil, &commands), nodeName,
-				[]*v1alpha1.NicDevice{device}, root, stateDir,
+				[]*v1alpha1.NicDevice{device}, stateDir,
 			)
 
 			Expect(err).To(MatchError(ContainSubstring(expected)))
 			Expect(commands).To(BeEmpty())
 		},
-		Entry("relative Blueprints root", "blueprints", "", "blueprints root"),
-		Entry("relative state directory", blueprintsRoot, "blueprints-state", "state directory"),
+		Entry("relative state directory", "blueprints-state", "state directory"),
 	)
 
 	DescribeTable("maps NCO multiplane modes to public doSPCX profiles",
@@ -738,7 +759,7 @@ var _ = Describe("doSPCX planning", func() {
 			Expect(err).To(MatchError(ContainSubstring(expected)))
 		},
 		Entry("inconsistent platform type", func(devices []*v1alpha1.NicDevice) {
-			devices[1].Spec.Configuration.Template.SpectrumXOptimized.PlatformType = "b300"
+			devices[1].Spec.Configuration.Template.SpectrumXOptimized.PlatformType = b300Platform
 		}, "must use the same"),
 		Entry("missing node name", func(devices []*v1alpha1.NicDevice) {
 			devices[0].Status.Node = ""
@@ -812,7 +833,7 @@ var _ = Describe("doSPCX planning", func() {
 		device := newDevice("hwmp", "0000:64:00.0", "hwplb")
 
 		planPath, err := generatePreparePlan(
-			context.Background(), executor, nodeName, []*v1alpha1.NicDevice{device}, blueprintsRoot, stateDir,
+			context.Background(), executor, nodeName, []*v1alpha1.NicDevice{device}, stateDir,
 		)
 
 		Expect(planPath).To(BeEmpty())
@@ -836,7 +857,7 @@ var _ = Describe("doSPCX planning", func() {
 			planPath, err := generatePreparePlan(
 				context.Background(), preparePlanFakeExecutor(response, &commands), nodeName,
 				[]*v1alpha1.NicDevice{newDevice("hwmp", "0000:64:00.0", "hwplb")},
-				blueprintsRoot, stateDir,
+				stateDir,
 			)
 
 			Expect(planPath).To(BeEmpty())
@@ -866,6 +887,15 @@ var _ = Describe("doSPCX planning", func() {
 			device := bundle["plan"].(map[string]any)["devices"].([]any)[0].(map[string]any)
 			device["rail"] = 1
 		}, "topology does not match"),
+		Entry("unexpected post-breakout device BDF", func(bundle map[string]any) {
+			device := bundle["plan"].(map[string]any)["post_breakout_devices"].([]any)[1].(map[string]any)
+			device["bdf"] = secondBDF
+			device["dms_target"] = "pci/" + secondBDF
+		}, "post-breakout device view contains unexpected device BDF"),
+		Entry("post-breakout device without an explicit plane", func(bundle map[string]any) {
+			device := bundle["plan"].(map[string]any)["post_breakout_devices"].([]any)[0].(map[string]any)
+			device["plane_explicit"] = false
+		}, "does not identify an explicit plane"),
 		Entry("unknown semantic group", func(bundle map[string]any) {
 			group := bundle["plan"].(map[string]any)["semantic"].(map[string]any)["groups"].([]any)[0].(map[string]any)
 			group["name"] = "unknown-prepare-group"

--- a/pkg/spectrumx/semanticplan.go
+++ b/pkg/spectrumx/semanticplan.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -40,6 +41,12 @@ const (
 
 	rdmaTopologyPerPF       = "per_pf"
 	rdmaTopologyPerRailBond = "per_rail_bond"
+
+	deviceViewPreBreakout  = "pre_breakout"
+	deviceViewPostBreakout = "post_breakout"
+
+	semanticGroupBreakout     = "breakout"
+	semanticGroupPostBreakout = "post-breakout"
 )
 
 // DMSOperationGroup is one executable group or ordered phase marker.
@@ -84,10 +91,11 @@ type planDocument struct {
 		DetectedHW struct {
 			PlatformType string `json:"platform_type"`
 		} `json:"detected_hw"`
-		Devices        []planDevice                       `json:"devices"`
-		RuntimeContext planRuntimeContext                 `json:"runtime_ctx"`
-		Operations     map[string]semanticOperationRecord `json:"operations"`
-		Semantic       *struct {
+		Devices             []planDevice                       `json:"devices"`
+		PostBreakoutDevices []planDevice                       `json:"post_breakout_devices"`
+		RuntimeContext      planRuntimeContext                 `json:"runtime_ctx"`
+		Operations          map[string]semanticOperationRecord `json:"operations"`
+		Semantic            *struct {
 			Groups []semanticGroupRecord `json:"groups"`
 		} `json:"semantic"`
 		BareMetal *struct {
@@ -100,13 +108,14 @@ type planDocument struct {
 }
 
 type planDevice struct {
-	BDF        string `json:"bdf"`
-	DeviceID   string `json:"device_id"`
-	RDMADevice string `json:"rdma_dev"`
-	DMSTarget  string `json:"dms_target"`
-	Rail       int    `json:"rail"`
-	Plane      int    `json:"plane"`
-	Network    string `json:"network"`
+	BDF           string `json:"bdf"`
+	DeviceID      string `json:"device_id"`
+	RDMADevice    string `json:"rdma_dev"`
+	DMSTarget     string `json:"dms_target"`
+	Rail          int    `json:"rail"`
+	Plane         int    `json:"plane"`
+	PlaneExplicit bool   `json:"plane_explicit"`
+	Network       string `json:"network"`
 }
 
 type planRuntimeContext struct {
@@ -132,6 +141,7 @@ type semanticOperationRecord struct {
 	TargetClass string         `json:"target_class"`
 	TargetRole  string         `json:"target_role"`
 	Scope       string         `json:"scope"`
+	Port        *int           `json:"port"`
 }
 
 func decodePlanDocument(planJSON []byte) (*planDocument, error) {
@@ -178,7 +188,7 @@ func buildDMSPlan(ctx context.Context, document *planDocument, expectedStage Pla
 		if err != nil {
 			return nil, err
 		}
-		disposition, reason, err := semanticGroupDisposition(expectedStage, group.Name)
+		disposition, reason, err := semanticGroupDisposition(expectedStage, group.Name, len(operations))
 		if err != nil {
 			return nil, err
 		}
@@ -192,13 +202,17 @@ func buildDMSPlan(ctx context.Context, document *planDocument, expectedStage Pla
 			continue
 		}
 
+		deviceView, requiresReboot, err := semanticGroupExecutionContract(expectedStage, group)
+		if err != nil {
+			return nil, err
+		}
 		compiled := DMSOperationGroup{
 			Name:           group.Name,
 			Order:          group.Order,
 			Scope:          group.Scope,
-			DeviceView:     group.DeviceView,
+			DeviceView:     deviceView,
 			FanoutOrder:    group.FanoutOrder,
-			RequiresReboot: group.RequiresReboot,
+			RequiresReboot: requiresReboot,
 			PhaseMarker:    disposition == groupDispositionMarker,
 		}
 		if compiled.PhaseMarker {
@@ -209,9 +223,13 @@ func buildDMSPlan(ctx context.Context, document *planDocument, expectedStage Pla
 			if err := validateExecutableOperations(group.Name, operations); err != nil {
 				return nil, err
 			}
+			devices, defaultTargetPort, err := devicesForSemanticGroup(document, deviceView)
+			if err != nil {
+				return nil, fmt.Errorf("resolve doSPCX semantic group %q: %w", group.Name, err)
+			}
 			compiled.Targets, err = resolveGroupTargets(
-				document.Plan.Devices, document.Plan.RuntimeContext.RDMATopology,
-				operations, expectedStage)
+				devices, document.Plan.RuntimeContext.RDMATopology,
+				operations, expectedStage, defaultTargetPort)
 			if err != nil {
 				return nil, fmt.Errorf("resolve doSPCX semantic group %q: %w", group.Name, err)
 			}
@@ -252,7 +270,15 @@ func validateSemanticPlan(document *planDocument, expectedStage PlanStage) error
 	if document.Plan.Semantic == nil || len(document.Plan.Semantic.Groups) == 0 {
 		return fmt.Errorf("doSPCX semantic plan does not contain semantic groups")
 	}
-	return validatePlanDevices(document.Plan.Devices)
+	if err := validatePlanDevices(document.Plan.Devices); err != nil {
+		return err
+	}
+	if len(document.Plan.PostBreakoutDevices) > 0 {
+		if err := validatePlanDevices(document.Plan.PostBreakoutDevices); err != nil {
+			return fmt.Errorf("invalid doSPCX post-breakout device view: %w", err)
+		}
+	}
+	return nil
 }
 
 func validatePlanDevices(devices []planDevice) error {
@@ -355,6 +381,9 @@ func validateSemanticOperation(id string, operation semanticOperationRecord) err
 	default:
 		return fmt.Errorf("doSPCX semantic operation %q has unsupported target class %q", id, operation.TargetClass)
 	}
+	if operation.Port != nil && *operation.Port <= 0 {
+		return fmt.Errorf("doSPCX semantic operation %q has invalid port %d", id, *operation.Port)
+	}
 	return nil
 }
 
@@ -418,14 +447,17 @@ const (
 	groupDispositionSkip    groupDisposition = "skip"
 )
 
-func semanticGroupDisposition(stage PlanStage, name string) (groupDisposition, string, error) {
+func semanticGroupDisposition(stage PlanStage, name string, operationCount int) (groupDisposition, string, error) {
 	switch stage {
 	case PlanStagePrepare:
 		switch name {
-		case "breakout":
+		case semanticGroupBreakout:
 			return groupDispositionExecute, "", nil
-		case "post-breakout":
-			return groupDispositionMarker, "", nil
+		case semanticGroupPostBreakout:
+			if operationCount == 0 {
+				return groupDispositionMarker, "", nil
+			}
+			return groupDispositionExecute, "", nil
 		}
 	case PlanStageConfigure:
 		switch name {
@@ -440,16 +472,54 @@ func semanticGroupDisposition(stage PlanStage, name string) (groupDisposition, s
 	return "", "", fmt.Errorf("unsupported doSPCX semantic group %q for stage %q", name, stage)
 }
 
+func semanticGroupExecutionContract(stage PlanStage, group semanticGroupRecord) (string, bool, error) {
+	expectedDeviceView := ""
+	requiresReboot := group.RequiresReboot
+	if stage == PlanStagePrepare {
+		requiresReboot = true
+		switch group.Name {
+		case semanticGroupBreakout:
+			expectedDeviceView = deviceViewPreBreakout
+		case semanticGroupPostBreakout:
+			expectedDeviceView = deviceViewPostBreakout
+		}
+	}
+	if expectedDeviceView == "" {
+		return group.DeviceView, requiresReboot, nil
+	}
+	if group.DeviceView != "" && group.DeviceView != expectedDeviceView {
+		return "", false, fmt.Errorf(
+			"doSPCX semantic group %q uses device view %q, expected %q",
+			group.Name, group.DeviceView, expectedDeviceView)
+	}
+	return expectedDeviceView, requiresReboot, nil
+}
+
+func devicesForSemanticGroup(document *planDocument, deviceView string) ([]planDevice, bool, error) {
+	switch deviceView {
+	case "", deviceViewPreBreakout:
+		return document.Plan.Devices, false, nil
+	case deviceViewPostBreakout:
+		if len(document.Plan.PostBreakoutDevices) == 0 {
+			return nil, false, fmt.Errorf("post-breakout device view is empty")
+		}
+		return document.Plan.PostBreakoutDevices, true, nil
+	default:
+		return nil, false, fmt.Errorf("unsupported device view %q", deviceView)
+	}
+}
+
 func resolveGroupTargets(
 	devices []planDevice,
 	rdmaTopology string,
 	operations []semanticOperationRecord,
 	stage PlanStage,
+	defaultTargetPort bool,
 ) ([]DMSTargetOperations, error) {
 	targetOrder := make([]string, 0, len(devices))
 	operationsByTarget := make(map[string][]dmscli.XPathOperation, len(devices))
 	for _, operation := range operations {
-		targets, err := resolveOperationTargets(devices, rdmaTopology, operation)
+		targets, err := resolveOperationTargets(devices, rdmaTopology, operation, defaultTargetPort)
 		if err != nil {
 			return nil, fmt.Errorf("operation %q: %w", operation.ID, err)
 		}
@@ -481,6 +551,7 @@ func resolveOperationTargets(
 	devices []planDevice,
 	rdmaTopology string,
 	operation semanticOperationRecord,
+	defaultTargetPort bool,
 ) ([]string, error) {
 	result := make([]string, 0, len(devices))
 	for _, device := range devices {
@@ -489,16 +560,16 @@ func resolveOperationTargets(
 		}
 		switch operation.TargetClass {
 		case targetClassPFNetdevAll:
-			result = append(result, device.DMSTarget)
+			result = append(result, operationTarget(device, operation, defaultTargetPort))
 		case targetClassPFRDMAScope:
 			switch rdmaTopology {
 			case rdmaTopologyPerPF:
 				if strings.TrimSpace(device.RDMADevice) != "" {
-					result = append(result, device.DMSTarget)
+					result = append(result, operationTarget(device, operation, defaultTargetPort))
 				}
 			case rdmaTopologyPerRailBond:
 				if device.Plane == 0 {
-					result = append(result, device.DMSTarget)
+					result = append(result, operationTarget(device, operation, defaultTargetPort))
 				}
 			default:
 				return nil, fmt.Errorf("unsupported RDMA topology %q", rdmaTopology)
@@ -512,6 +583,28 @@ func resolveOperationTargets(
 		return nil, fmt.Errorf("doSPCX plan does not contain eligible devices")
 	}
 	return result, nil
+}
+
+func operationTarget(device planDevice, operation semanticOperationRecord, defaultTargetPort bool) string {
+	port := 0
+	if operation.Port != nil {
+		port = *operation.Port
+	} else if defaultTargetPort && (device.PlaneExplicit || isSplitPCIFunction(device.BDF)) {
+		port = 1
+	}
+	if port == 0 {
+		return device.DMSTarget
+	}
+	return fmt.Sprintf("%s?port=%d", device.DMSTarget, port)
+}
+
+func isSplitPCIFunction(bdf string) bool {
+	dot := strings.LastIndexByte(bdf, '.')
+	if dot == -1 || dot == len(bdf)-1 {
+		return false
+	}
+	function, err := strconv.ParseUint(bdf[dot+1:], 16, 8)
+	return err == nil && function > 0
 }
 
 func finalDesiredState(operations []dmscli.XPathOperation) []dmscli.XPathOperation {

--- a/pkg/spectrumx/semanticplan_test.go
+++ b/pkg/spectrumx/semanticplan_test.go
@@ -17,6 +17,8 @@ package spectrumx
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -76,6 +78,64 @@ var _ = Describe("doSPCX semantic plans", func() {
 		Expect(plan.Groups[1].PhaseMarker).To(BeTrue())
 		Expect(plan.Groups[1].Targets).To(BeEmpty())
 	})
+
+	DescribeTable("compiles SPX_NetPlugin post-breakout operations against the expanded device view",
+		func(planes int) {
+			document := decodeFixture("prepare-plan.json")
+			document.Plan.Profile = dospcxProfileNetPlugin
+			document.Plan.Params.Planes = planes
+			if planes == 4 {
+				document.Plan.DetectedHW.PlatformType = "b300"
+			}
+			document.Plan.Devices = document.Plan.Devices[:1]
+			document.Plan.PostBreakoutDevices = make([]planDevice, planes)
+			postBreakout := findGroupRecord(document, "post-breakout")
+			postBreakout.DeviceView = ""
+			postBreakout.RequiresReboot = false
+			postBreakout.OperationRefs = make([]string, 0, planes)
+			for plane := 0; plane < planes; plane++ {
+				bdf, err := bdfForPlane(document.Plan.Devices[0].BDF, plane)
+				Expect(err).NotTo(HaveOccurred())
+				document.Plan.PostBreakoutDevices[plane] = planDevice{
+					BDF:           bdf,
+					DMSTarget:     "pci/" + bdf,
+					Rail:          0,
+					Plane:         plane,
+					PlaneExplicit: true,
+					Network:       targetRoleEW,
+				}
+				operationID := fmt.Sprintf("post-breakout.port-%d", plane+1)
+				operation := semanticOperationRecord{
+					Path:        "/nvidia/roce/rtt",
+					Values:      map[string]any{"dscp": json.Number("48")},
+					TargetClass: targetClassPFNetdevAll,
+				}
+				if plane > 0 {
+					port := plane + 1
+					operation.Port = &port
+				}
+				document.Plan.Operations[operationID] = operation
+				postBreakout.OperationRefs = append(postBreakout.OperationRefs, operationID)
+			}
+
+			plan, err := buildDMSPlan(context.Background(), document, PlanStagePrepare)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(plan.Groups).To(HaveLen(2))
+			compiled := plan.Groups[1]
+			Expect(compiled.Name).To(Equal("post-breakout"))
+			Expect(compiled.DeviceView).To(Equal(deviceViewPostBreakout))
+			Expect(compiled.RequiresReboot).To(BeTrue())
+			Expect(compiled.PhaseMarker).To(BeFalse())
+			Expect(compiled.Targets).To(HaveLen(planes * planes))
+			Expect(targetNames(compiled.Targets)).To(ContainElements(
+				fmt.Sprintf("pci/%s?port=1", document.Plan.PostBreakoutDevices[planes-1].BDF),
+				fmt.Sprintf("pci/%s?port=%d", document.Plan.PostBreakoutDevices[planes-1].BDF, planes),
+			))
+		},
+		Entry("two planes", 2),
+		Entry("four planes", 4),
+	)
 
 	It("skips eswitch and vf-lifecycle while compiling configure groups", func() {
 		plan := compileFixture("configure-plan.json", PlanStageConfigure)
@@ -212,6 +272,22 @@ var _ = Describe("doSPCX semantic plans", func() {
 		Entry("invalid device target", func(document *planDocument) {
 			document.Plan.Devices[0].DMSTarget = "pci/0000:ff:00.0"
 		}, PlanStagePrepare, "invalid DMS target"),
+		Entry("wrong prepare device view", func(document *planDocument) {
+			document.Plan.Semantic.Groups[0].DeviceView = deviceViewPostBreakout
+		}, PlanStagePrepare, "expected \"pre_breakout\""),
+		Entry("invalid operation port", func(document *planDocument) {
+			operationID := document.Plan.Semantic.Groups[0].OperationRefs[0]
+			operation := document.Plan.Operations[operationID]
+			port := 0
+			operation.Port = &port
+			document.Plan.Operations[operationID] = operation
+		}, PlanStagePrepare, "invalid port"),
+		Entry("missing post-breakout device view for executable operations", func(document *planDocument) {
+			document.Plan.PostBreakoutDevices = nil
+			document.Plan.Semantic.Groups[1].OperationRefs = []string{
+				document.Plan.Semantic.Groups[0].OperationRefs[0],
+			}
+		}, PlanStagePrepare, "post-breakout device view is empty"),
 		Entry("stage mismatch", func(_ *planDocument) {}, PlanStageConfigure, `stage is "prepare", expected "configure"`),
 		Entry("unknown group", func(document *planDocument) {
 			document.Plan.Semantic.Groups[0].Name = "new-runtime-phase"
@@ -286,6 +362,14 @@ func groupOperationNames(groups []DMSOperationGroup) []string {
 	result := make([]string, 0, len(groups))
 	for _, group := range groups {
 		result = append(result, group.Name)
+	}
+	return result
+}
+
+func targetNames(targets []DMSTargetOperations) []string {
+	result := make([]string, len(targets))
+	for index, target := range targets {
+		result[index] = target.Target
 	}
 	return result
 }

--- a/pkg/spectrumx/spectrumx.go
+++ b/pkg/spectrumx/spectrumx.go
@@ -87,7 +87,6 @@ type spectrumXConfigManager struct {
 	preparedPlans      map[string]*preparedPlan
 	dmsManager         dms.DMSManager
 	execInterface      execUtils.Interface
-	blueprintsRoot     string
 	blueprintsStateDir string
 	dospcxDataRoot     string
 	dospcxDataDigest   string
@@ -863,7 +862,6 @@ func NewSpectrumXConfigManager(
 		spectrumXConfigs:   spectrumXConfigs,
 		preparedPlans:      make(map[string]*preparedPlan),
 		execInterface:      execUtils.New(),
-		blueprintsRoot:     defaultBlueprintsRoot,
 		blueprintsStateDir: "",
 		dospcxDataRoot:     defaultDospcxDataRoot,
 		dospcxDataDigest:   "",

--- a/pkg/spectrumx/spectrumx_test.go
+++ b/pkg/spectrumx/spectrumx_test.go
@@ -169,7 +169,6 @@ var _ = Describe("SpectrumXConfigManager", func() {
 
 		Expect(ok).To(BeTrue())
 		Expect(internalManager.execInterface).NotTo(BeNil())
-		Expect(internalManager.blueprintsRoot).To(Equal(defaultBlueprintsRoot))
 		Expect(internalManager.blueprintsStateDir).To(BeEmpty())
 		Expect(internalManager.dospcxDataRoot).To(Equal(defaultDospcxDataRoot))
 		Expect(internalManager.dospcxDataDigest).To(BeEmpty())
@@ -228,7 +227,6 @@ var _ = Describe("SpectrumXConfigManager", func() {
 			spectrumXConfigs:   cfgs,
 			preparedPlans:      make(map[string]*preparedPlan),
 			execInterface:      execFake,
-			blueprintsRoot:     defaultBlueprintsRoot,
 			blueprintsStateDir: "",
 			dospcxDataRoot:     defaultDospcxDataRoot,
 			dospcxDataDigest:   "",


### PR DESCRIPTION
## Summary

- compile executable SPX_NetPlugin post-breakout operations against the planner's expanded device view, preserving explicit DMS ports and the per-function port-1 default
- generate the Spectrum-X prepare plan before requesting NV configuration maintenance
- propagate reconcile cancellation to the built-in DMS NVConfig batch path while preserving the existing `NVConfigUtils` interface for library implementations
- remove the ineffective `BLUEPRINTS_ROOT` request/cache contract and rely on the DMS planner's native doSPCX data location

## Validation

- `go test ./pkg/spectrumx ./pkg/dmscli ./pkg/nvconfig ./pkg/configuration`
- focused controller envtest: 5/5 passed
- `go build ./...`
- `golangci-lint run`: 0 issues
- `git diff --check`

The full controller suite passed 101/102 in one run. The remaining timing-sensitive firmware-status spec (`Should not start firmware update if maintenance is not allowed`) also reproduces on an untouched `upstream/main` worktree; the changed controller path and its focused tests pass.
