### PR TITLE
feat: execute doSPCX NVConfig plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ spec:
 * `spectrumXOptimized`: enables Spectrum-X specific NIC optimizations. When enabled:
   * Requires `linkType=Ethernet` and `numVfs=1`
   * Cannot be combined with `roceOptimized` (RoCE settings are included automatically)
-  * Can be combined with `rawNvConfig` — raw params are merged as overrides on top of Spectrum-X calculated params
+  * Temporarily cannot be combined with `rawNvConfig` or `networkBay`. NCO cannot yet determine which native mlxconfig parameters are owned by typed doSPCX operations, so allowing either combination could create a non-convergent reconcile loop
   * Only supported on ConnectX-7 (`nicType: 1021`), ConnectX-8 (`nicType: 1023`), ConnectX-9 (`nicType: 1025`) and BlueField-3 SuperNIC (`nicType: a2dc`)
   * `version`: Required. Must match the name of a Spectrum-X profile ConfigMap
   * `platformType`: Required. doSPCX platform identifier defined by the supplied Blueprints profile
@@ -222,14 +222,21 @@ Spectrum-X profiles can configure NICs with multiple data planes. Available mode
 `spectrumx.SpectrumXManager` includes the `spectrumx.PlanManager` interface. Before the controller
 starts its existing concurrent per-device NV apply, it calls `PreparePlan` once for the node's
 Spectrum-X device group with the `prepare` stage. It does the same with the `configure` stage before
-the existing concurrent runtime apply. Plan preparation never executes generated plan operations.
+the existing concurrent runtime apply. Plan preparation itself never executes generated plan operations.
 `PreparePlan` parses the host-k8s `plan.semantic.groups` contract once and caches a homogeneous
 configuration plan in memory. The compiled form contains only three execution inputs: ordered
 `breakout` and `post-breakout` XPath operation slices for the prepare stage, and ordered runtime
 operation groups for the configure stage. Device targeting remains the responsibility of the
 configuration manager when it consumes the plan. `GetPreparedPlan` validates the requesting
 device's inputs and membership against the cache; it does not reread or reparse files for every
-per-device apply. Semantic group references are authoritative, and an omitted operation kind means
+per-device apply. During NV validation, the configuration manager separately queries the existing
+template-derived native parameter map and the active doSPCX XPath phase. During NV apply, it sends both inputs
+in one DMS action through the primary PF and passes every available logical port number so DMS can expand
+port-scoped typed mappings.
+Breakout must match current and pending state on all device ports before post-breakout is considered.
+`force` applies the complete breakout plus post-breakout intent immediately; after the breakout
+barrier, `with-default` also resends both phases so default filling cannot undo breakout. Semantic
+group references are authoritative, and an omitted operation kind means
 `set`, matching DMS. Configure groups `eswitch` and `vf-lifecycle` are intentionally omitted from
 the compiled plan; unknown groups fail closed. Plan compilation remains execution-free.
 

--- a/api/v1alpha1/nicconfigurationtemplate_types.go
+++ b/api/v1alpha1/nicconfigurationtemplate_types.go
@@ -178,6 +178,9 @@ type NetworkBaySpec struct {
 // +kubebuilder:validation:XValidation:rule="has(self.networkBay) || has(self.linkType)",message="linkType is required unless networkBay is configured"
 // +kubebuilder:validation:XValidation:rule="!has(self.networkBay) || !has(self.linkType)",message="linkType must not be set when networkBay is configured (the Network Bay link type is governed by the system configuration)"
 // +kubebuilder:validation:XValidation:rule="!has(self.rawNvConfig) || self.rawNvConfig.all(p, !p.name.matches('.*[[][0-9]+[.][.][0-9]+[]].*'))",message="rawNvConfig parameter names must not use index-range syntax like NAME[0..3]; list each index explicitly (NAME[0], NAME[1], ...)"
+// TODO(dospcx-nvconfig): HIGH PRIORITY -- remove the next two temporary restrictions ASAP once DMS can report typed-plan native parameter ownership or validate combined typed/raw state.
+// +kubebuilder:validation:XValidation:rule="!(has(self.spectrumXOptimized) && self.spectrumXOptimized.enabled) || !has(self.rawNvConfig) || size(self.rawNvConfig) == 0",message="rawNvConfig cannot currently be combined with spectrumXOptimized"
+// +kubebuilder:validation:XValidation:rule="!(has(self.spectrumXOptimized) && self.spectrumXOptimized.enabled) || !has(self.networkBay)",message="networkBay cannot currently be combined with spectrumXOptimized"
 type ConfigurationTemplateSpec struct {
 	// Number of VFs to be configured
 	// +required
@@ -195,7 +198,8 @@ type ConfigurationTemplateSpec struct {
 	GpuDirectOptimized *GpuDirectOptimizedSpec `json:"gpuDirectOptimized,omitempty"`
 	// Runtime NIC performance tuning (ring buffers, channels, LRO) applied via ethtool
 	RuntimePerformanceOptimized *RuntimePerformanceOptimizedSpec `json:"runtimePerformanceOptimized,omitempty"`
-	// Spectrum-X optimization settings. Works only with linkType==Ethernet && numVfs==1. RawNvConfig parameters, if provided, are merged as overrides on top of Spectrum-X calculated params.
+	// Spectrum-X optimization settings. Works only with linkType==Ethernet && numVfs==1.
+	// Temporarily cannot be combined with rawNvConfig or networkBay.
 	SpectrumXOptimized *SpectrumXOptimizedSpec `json:"spectrumXOptimized,omitempty"`
 	// NetworkBay configures a ConnectX-9 Network Bay card (per-ASIC set_system_conf). Allowed only for ConnectX-9 (nicType 1025).
 	// +optional

--- a/api/v1alpha1/validation_test.go
+++ b/api/v1alpha1/validation_test.go
@@ -157,11 +157,12 @@ var _ = Describe("NicConfigurationTemplate CEL validation", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("allows SpectrumXOptimized enabled together with non-empty RawNvConfig", func() {
+	It("rejects SpectrumXOptimized enabled together with non-empty RawNvConfig", func() {
 		obj := newNicConfigurationTemplate("spcx-with-rawnv", "Ethernet", 1, &SpectrumXOptimizedSpec{Enabled: true, Version: "RA2.0"})
 		obj.Spec.Template.RawNvConfig = []NvConfigParam{{Name: "FOO", Value: "BAR"}}
 		err := k8sClient.Create(ctx, obj)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("rawNvConfig cannot currently be combined with spectrumXOptimized"))
 	})
 
 	It("allows a rawNvConfig param with an explicit index key", func() {
@@ -262,11 +263,13 @@ var _ = Describe("NicConfigurationTemplate CEL validation", func() {
 			Expect(err.Error()).To(ContainSubstring("linkType is required unless networkBay is configured"))
 		})
 
-		It("allows networkBay together with spectrumXOptimized on ConnectX-9 (linkType unset)", func() {
-			obj := newNicConfigurationTemplate("bay-allow-with-spcx", "", 1, &SpectrumXOptimizedSpec{Enabled: true, Version: "RA2.0"})
+		It("rejects networkBay together with spectrumXOptimized", func() {
+			obj := newNicConfigurationTemplate("bay-reject-with-spcx", "", 1, &SpectrumXOptimizedSpec{Enabled: true, Version: "RA2.0"})
 			obj.Spec.NicSelector.NicType = nicTypeConnectX9
 			obj.Spec.Template.NetworkBay = &NetworkBaySpec{Conf: "3"}
-			Expect(k8sClient.Create(ctx, obj)).To(Succeed())
+			err := k8sClient.Create(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("networkBay cannot currently be combined with spectrumXOptimized"))
 		})
 	})
 

--- a/config/crd/bases/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
+++ b/config/crd/bases/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
@@ -272,10 +272,9 @@ spec:
                     - enabled
                     type: object
                   spectrumXOptimized:
-                    description: Spectrum-X optimization settings. Works only with
-                      linkType==Ethernet && numVfs==1. RawNvConfig parameters, if
-                      provided, are merged as overrides on top of Spectrum-X calculated
-                      params.
+                    description: |-
+                      Spectrum-X optimization settings. Works only with linkType==Ethernet && numVfs==1.
+                      Temporarily cannot be combined with rawNvConfig or networkBay.
                     properties:
                       enabled:
                         description: Optimize Spectrum X
@@ -356,6 +355,12 @@ spec:
                     like NAME[0..3]; list each index explicitly (NAME[0], NAME[1],
                     ...)
                   rule: '!has(self.rawNvConfig) || self.rawNvConfig.all(p, !p.name.matches(''.*[[][0-9]+[.][.][0-9]+[]].*''))'
+                - message: rawNvConfig cannot currently be combined with spectrumXOptimized
+                  rule: '!(has(self.spectrumXOptimized) && self.spectrumXOptimized.enabled)
+                    || !has(self.rawNvConfig) || size(self.rawNvConfig) == 0'
+                - message: networkBay cannot currently be combined with spectrumXOptimized
+                  rule: '!(has(self.spectrumXOptimized) && self.spectrumXOptimized.enabled)
+                    || !has(self.networkBay)'
             required:
             - nicSelector
             - template

--- a/config/crd/bases/configuration.net.nvidia.com_nicdevices.yaml
+++ b/config/crd/bases/configuration.net.nvidia.com_nicdevices.yaml
@@ -241,10 +241,9 @@ spec:
                         - enabled
                         type: object
                       spectrumXOptimized:
-                        description: Spectrum-X optimization settings. Works only
-                          with linkType==Ethernet && numVfs==1. RawNvConfig parameters,
-                          if provided, are merged as overrides on top of Spectrum-X
-                          calculated params.
+                        description: |-
+                          Spectrum-X optimization settings. Works only with linkType==Ethernet && numVfs==1.
+                          Temporarily cannot be combined with rawNvConfig or networkBay.
                         properties:
                           enabled:
                             description: Optimize Spectrum X
@@ -325,6 +324,12 @@ spec:
                         syntax like NAME[0..3]; list each index explicitly (NAME[0],
                         NAME[1], ...)
                       rule: '!has(self.rawNvConfig) || self.rawNvConfig.all(p, !p.name.matches(''.*[[][0-9]+[.][.][0-9]+[]].*''))'
+                    - message: rawNvConfig cannot currently be combined with spectrumXOptimized
+                      rule: '!(has(self.spectrumXOptimized) && self.spectrumXOptimized.enabled)
+                        || !has(self.rawNvConfig) || size(self.rawNvConfig) == 0'
+                    - message: networkBay cannot currently be combined with spectrumXOptimized
+                      rule: '!(has(self.spectrumXOptimized) && self.spectrumXOptimized.enabled)
+                        || !has(self.networkBay)'
                 type: object
               firmware:
                 description: Firmware specifies the fw upgrade policy requested by

--- a/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
+++ b/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
@@ -272,10 +272,9 @@ spec:
                     - enabled
                     type: object
                   spectrumXOptimized:
-                    description: Spectrum-X optimization settings. Works only with
-                      linkType==Ethernet && numVfs==1. RawNvConfig parameters, if
-                      provided, are merged as overrides on top of Spectrum-X calculated
-                      params.
+                    description: |-
+                      Spectrum-X optimization settings. Works only with linkType==Ethernet && numVfs==1.
+                      Temporarily cannot be combined with rawNvConfig or networkBay.
                     properties:
                       enabled:
                         description: Optimize Spectrum X
@@ -356,6 +355,12 @@ spec:
                     like NAME[0..3]; list each index explicitly (NAME[0], NAME[1],
                     ...)
                   rule: '!has(self.rawNvConfig) || self.rawNvConfig.all(p, !p.name.matches(''.*[[][0-9]+[.][.][0-9]+[]].*''))'
+                - message: rawNvConfig cannot currently be combined with spectrumXOptimized
+                  rule: '!(has(self.spectrumXOptimized) && self.spectrumXOptimized.enabled)
+                    || !has(self.rawNvConfig) || size(self.rawNvConfig) == 0'
+                - message: networkBay cannot currently be combined with spectrumXOptimized
+                  rule: '!(has(self.spectrumXOptimized) && self.spectrumXOptimized.enabled)
+                    || !has(self.networkBay)'
             required:
             - nicSelector
             - template

--- a/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicdevices.yaml
+++ b/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicdevices.yaml
@@ -241,10 +241,9 @@ spec:
                         - enabled
                         type: object
                       spectrumXOptimized:
-                        description: Spectrum-X optimization settings. Works only
-                          with linkType==Ethernet && numVfs==1. RawNvConfig parameters,
-                          if provided, are merged as overrides on top of Spectrum-X
-                          calculated params.
+                        description: |-
+                          Spectrum-X optimization settings. Works only with linkType==Ethernet && numVfs==1.
+                          Temporarily cannot be combined with rawNvConfig or networkBay.
                         properties:
                           enabled:
                             description: Optimize Spectrum X
@@ -325,6 +324,12 @@ spec:
                         syntax like NAME[0..3]; list each index explicitly (NAME[0],
                         NAME[1], ...)
                       rule: '!has(self.rawNvConfig) || self.rawNvConfig.all(p, !p.name.matches(''.*[[][0-9]+[.][.][0-9]+[]].*''))'
+                    - message: rawNvConfig cannot currently be combined with spectrumXOptimized
+                      rule: '!(has(self.spectrumXOptimized) && self.spectrumXOptimized.enabled)
+                        || !has(self.rawNvConfig) || size(self.rawNvConfig) == 0'
+                    - message: networkBay cannot currently be combined with spectrumXOptimized
+                      rule: '!(has(self.spectrumXOptimized) && self.spectrumXOptimized.enabled)
+                        || !has(self.networkBay)'
                 type: object
               firmware:
                 description: Firmware specifies the fw upgrade policy requested by

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -61,8 +61,8 @@ ConfigurationTemplateSpec is a set of configurations for the NICs
 <tr>
 <td><code>spectrumXOptimized</code><br />
 <em><a href="#SpectrumXOptimizedSpec">SpectrumXOptimizedSpec</a></em></td>
-<td><p>Spectrum-X optimization settings. Works only with linkType==Ethernet &amp;&amp; numVfs==1. RawNvConfig parameters, if provided, are merged as overrides on top of Spectrum-X calculated
-params.</p></td>
+<td><p>Spectrum-X optimization settings. Works only with linkType==Ethernet &amp;&amp; numVfs==1.
+Temporarily cannot be combined with rawNvConfig or networkBay.</p></td>
 </tr>
 <tr>
 <td><code>networkBay</code><br />

--- a/docs/nic-configuration-library.md
+++ b/docs/nic-configuration-library.md
@@ -163,17 +163,18 @@ func NewConfigurationManager(
 
 #### NV Configuration Flow
 
-1. **Spectrum-X plan precondition** — Spectrum-X devices require a matching cached `prepare` plan; the method returns `ApplyStatusFailed` before querying or changing hardware otherwise
-2. **Query** current NV config via `nvConfigUtils.QueryNvConfig()`
-3. **Network Bay `set_system_conf` (baseline, applied first)** — for ConnectX-9 Network Bay devices (`template.networkBay` set and `status.networkBay` detected), the per-ASIC `set_system_conf <conf>[<asic>]` is applied **before** the regular / Spectrum-X params so those layer on top of it (override priority: `rawNvConfig` > Spectrum-X > system_conf). Drift is detected per-param via `nvconfig.ValidateSystemConf()`, which returns the overall match bit plus the names of the mismatched params; the manager ignores MISMATCH rows for params owned by a higher-priority layer (matched by exact per-index key — `rawNvConfig` index-range syntax like `MODULE_SPLIT_M0[0..3]` is rejected by CRD validation, so keys are always concrete); a change requires a reboot. Skipped for devices with `ResetToDefault`
-4. **Diff** desired vs current parameters. Params not present in the device's next-boot config are unsupported on this device (e.g. hidden because `ADVANCED_PCI_SETTINGS` is off) and are skipped — the operator does **not** auto-manage `ADVANCED_PCI_SETTINGS`; drive it explicitly via `template.rawNvConfig` if needed
-5. **Batch set** via `nvConfigUtils.SetNvConfigParametersBatch()` — one agentless `dms-cli` `/nvidia/nvconfig/apply` action per PCI target. The action carries the existing raw batch plus `with-default` and `force`; DMS compiles it into one `mlxconfig` invocation. The DMS `requires-reset` result maps to `ApplyStatusSuccess` when true and `ApplyStatusNothingToDo` when false. Apply reports `ApplyStatusPartiallyApplied` when any desired param was skipped as unsupported
-6. **Optional reset** — `mlxfwreset` unless `ConfigurationOptions.SkipReset=true`
+1. **Spectrum-X plan precondition** — before per-device validation, the controller generates or reuses one node-scoped `prepare` plan. Spectrum-X devices require a matching cached plan; validation and apply fail closed when it is missing
+2. **Native query and validation** — query current NV config via `nvConfigUtils.QueryNvConfig()` and independently validate the template-derived native parameter map. `rawNvConfig` is temporarily rejected when Spectrum-X is enabled
+3. **Network Bay restriction** — `networkBay` is temporarily rejected when Spectrum-X is enabled because NCO cannot yet resolve native parameter ownership between `set_system_conf` and typed doSPCX operations
+4. **Native diff** — skip hidden/unsupported params as before and preserve the existing `with-default` and `force` behavior
+5. **doSPCX query and barrier** — query each plan leaf and its `-pending` leaf separately through DMS on every discovered PCI function, using `pci/<BDF>?port=1` because split functions expose their NVConfig as port 1. Validate breakout first; post-breakout becomes active only after breakout matches both current and pending state on every function
+6. **Combined NVConfig batch** — send template-derived native parameters and doSPCX typed operations in one `/nvidia/nvconfig/apply` action through the primary PF, with `ports: [1..N]` for every available logical port. Normal apply sends the active phase; `Force` sends breakout plus post-breakout immediately, and post-breakout `WithDefault` resends both phases
+7. **Optional reset** — `mlxfwreset` unless `ConfigurationOptions.SkipReset=true`
 
 **`ConfigurationOptions`:**
 - `SkipReset` — skip `mlxfwreset` after applying NV config
-- `WithDefault` — request `--with_default` through the DMS NVConfig apply action
-- `Force` — request `--force` through the DMS NVConfig apply action and add it to `set_system_conf` (lets mlxconfig accept a batch it would otherwise refuse due to implicit parameter dependencies). When `NUM_OF_PF` and a `_P1` value are present, force mode copies that value to missing higher ports up to the requested PF count before applying; explicit per-port values are preserved
+- `WithDefault` — request `--with_default` through the combined DMS NVConfig action
+- `Force` — request `--force` through the combined DMS NVConfig action and add it to `set_system_conf` (lets mlxconfig accept a batch it would otherwise refuse due to implicit parameter dependencies). When `NUM_OF_PF` and a `_P1` value are present, force mode copies that value to missing higher ports up to the requested PF count before applying; explicit per-port values are preserved
 
 #### Runtime Configuration Flow
 
@@ -383,9 +384,17 @@ dms-cli --json -t pci/<BDF> --input <payload-json> /nvidia/nvconfig/apply
 ```
 
 The payload supports `ports`, `typed`, `raw`, `with-default`, and `force`.
-`Target` is carried by `-t` and is not serialized. The operator currently
-populates only `Raw`, `WithDefault`, and `Force`; semantic prepare operations
-are parsed and translated but are not yet connected to NVConfig execution.
+`Target` is carried by `-t` and is not serialized. For Spectrum-X, the target
+is the primary PF, `ports` contains every available logical port (`[1..N]`),
+and the existing template-derived native parameters and doSPCX prepare operations are
+sent in one action. `with-default` and `force` apply to that combined action;
+both send the complete breakout plus post-breakout intent once the breakout
+barrier is complete, and `force` does so immediately.
+
+The current DMS apply action accepts one primary BDF. Its `ports` field expands
+port-scoped native parameter names but does not target additional split-function
+BDFs. Multi-target apply for those functions therefore depends on a future DMS
+API extension.
 
 Typed GET and SET preserve query/group order and use `;` as a literal argument
 between DMS containers:
@@ -643,22 +652,28 @@ The built-in implementation also provides
 `dms-cli`, while retaining the public `NVConfigUtils` interface for existing library
 implementations. Implementations without the extension continue through the legacy method.
 
+The built-in implementation also supports doSPCX XPath validation and combined
+native/typed apply. It validates each discovered PCI function through
+`pci/<BDF>?port=1` and uses `ports: [1..N]` in the combined apply payload.
+Spectrum-X configuration fails closed when a custom utility does not provide
+these optional methods.
+
 **Batch command format:**
 ```
 dms-cli --json -t pci/<BDF> --input <payload-json> /nvidia/nvconfig/apply
 ```
 Parameter names are sorted before they are encoded as raw DMS entries. The
-target is always `pci/<port.PCI>`; the discovered `FwctlDevice` value is not
-passed to the NVConfig apply action. Query, single-parameter set, reset, and
-Network Bay system-conf operations continue to invoke `mlxconfig` directly in
-this phase.
+apply target is always `pci/<port.PCI>`; the discovered `FwctlDevice` value is
+not passed to the NVConfig apply action. Raw query, single-parameter set, reset,
+and Network Bay system-conf operations continue to invoke `mlxconfig`
+directly; doSPCX XPath validation queries through `dms-cli`.
 
 **System conf command format (ConnectX-9 Network Bay):**
 ```
 mlxconfig -d <device> -y [--force] set_system_conf <conf>[<asic>]
 mlxconfig -d <device> -y validate_system_conf <conf>[<asic>]
 ```
-`ValidateSystemConf` parses the per-param `OK:` / `MISMATCH:` rows plus the `SKIPPED (failed to query:)` list and the trailing `Result:` line, returning the overall match bit and the mismatched param names. The configuration manager uses the mismatched names to treat MISMATCH rows for `rawNvConfig`- or Spectrum-X-owned params as intentional overrides (priority `rawNvConfig` > Spectrum-X > system_conf) rather than drift.
+`ValidateSystemConf` parses the per-param `OK:` / `MISMATCH:` rows plus the `SKIPPED (failed to query:)` list and the trailing `Result:` line, returning the overall match bit and the mismatched param names. The configuration manager uses the mismatched names to treat MISMATCH rows covered by `rawNvConfig` as intentional overrides rather than drift.
 
 ---
 
@@ -985,7 +1000,7 @@ logs and returned errors. Output is not duplicated in error-level logs.
 
 ### Batch Operations
 
-- **NVConfig apply**: `SetNvConfigParametersBatch()` sends one sorted raw batch per PCI target through `dms-cli`; DMS executes the corresponding single `mlxconfig` operation
+- **NVConfig apply**: the non-Spectrum-X path keeps one sorted raw batch per PCI target. The Spectrum-X path sends one combined template-native/typed batch through the primary PF with every available logical port in `ports`; DMS executes one primary-PF `mlxconfig` operation
 - **DMS**: `GetParameters()` batches `--path` entries per concrete interface (with a separate global batch), and `SetParameters()` sends all `--update` entries in a single `dmsc set` command with `--timeout 5m`
 - **IgnoreError**: per-parameter flag; in batch mode, errors are suppressed only if ALL params have `IgnoreError=true`
 

--- a/internal/controller/nicdevice_controller.go
+++ b/internal/controller/nicdevice_controller.go
@@ -195,7 +195,17 @@ func (r *NicDeviceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	log.Log.Info("firmware is ready for all devices, proceeding with NIC configuration")
 
-	// If FW is ready for all devices, proceed with NIC configuration
+	// doSPCX XPath validation requires the node-scoped prepare plan. Build or
+	// retrieve it before validating individual devices.
+	planDevices, err := r.prepareSpectrumXPlan(ctx, configStatuses, spectrumx.PlanStagePrepare)
+	if err != nil {
+		planErr := fmt.Errorf("prepare doSPCX NV configuration plan: %w", err)
+		statusErr := r.updateSpectrumXPlanFailureStatus(
+			ctx, planDevices, consts.SpecValidationFailed, planErr)
+		return ctrl.Result{}, errors.Join(planErr, statusErr)
+	}
+
+	// If FW is ready for all devices, proceed with NIC configuration.
 	err = runInParallel(ctx, configStatuses, r.handleConfigurationSpecValidation)
 	if err != nil {
 		log.Log.Error(err, "failed to validate device's spec")
@@ -204,11 +214,6 @@ func (r *NicDeviceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	if configStatuses.nvConfigUpdateRequired() {
 		log.Log.Info("nv config update required for some devices")
-		err = r.prepareSpectrumXPlan(ctx, configStatuses, spectrumx.PlanStagePrepare)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("prepare doSPCX NV configuration plan: %w", err)
-		}
-
 		log.Log.Info("scheduling maintenance for nv config update")
 		result, err := r.ensureMaintenance(ctx)
 		if err != nil {
@@ -237,9 +242,12 @@ func (r *NicDeviceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	log.Log.Info("applying runtime config")
-	err = r.prepareSpectrumXPlan(ctx, configStatuses, spectrumx.PlanStageConfigure)
+	planDevices, err = r.prepareSpectrumXPlan(ctx, configStatuses, spectrumx.PlanStageConfigure)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("prepare doSPCX runtime configuration plan: %w", err)
+		planErr := fmt.Errorf("prepare doSPCX runtime configuration plan: %w", err)
+		statusErr := r.updateSpectrumXPlanFailureStatus(
+			ctx, planDevices, consts.RuntimeConfigUpdateFailedReason, planErr)
+		return ctrl.Result{}, errors.Join(planErr, statusErr)
 	}
 
 	err = runInParallel(ctx, configStatuses, r.applyRuntimeConfig)
@@ -507,21 +515,47 @@ func (r *NicDeviceReconciler) prepareSpectrumXPlan(
 	ctx context.Context,
 	statuses nicDeviceConfigurationStatuses,
 	stage spectrumx.PlanStage,
-) error {
+) ([]*v1alpha1.NicDevice, error) {
+	devices := spectrumXDevicesForPlan(statuses, stage)
+	if len(devices) == 0 {
+		return nil, nil
+	}
+	return devices, r.SpectrumXManager.PreparePlan(ctx, devices, stage)
+}
+
+func spectrumXDevicesForPlan(
+	statuses nicDeviceConfigurationStatuses,
+	stage spectrumx.PlanStage,
+) []*v1alpha1.NicDevice {
 	devices := make([]*v1alpha1.NicDevice, 0, len(statuses))
 	for _, status := range statuses {
 		device := status.device
 		if device != nil && device.Spec.Configuration != nil &&
+			(stage != spectrumx.PlanStagePrepare || !device.Spec.Configuration.ResetToDefault) &&
 			device.Spec.Configuration.Template != nil &&
 			device.Spec.Configuration.Template.SpectrumXOptimized != nil &&
 			device.Spec.Configuration.Template.SpectrumXOptimized.Enabled {
 			devices = append(devices, device)
 		}
 	}
-	if len(devices) == 0 {
-		return nil
+	return devices
+}
+
+func (r *NicDeviceReconciler) updateSpectrumXPlanFailureStatus(
+	ctx context.Context,
+	devices []*v1alpha1.NicDevice,
+	reason string,
+	planErr error,
+) error {
+	var updateErrors []error
+	for _, device := range devices {
+		if err := r.updateConfigInProgressStatusCondition(
+			ctx, device, reason, metav1.ConditionFalse, planErr.Error()); err != nil {
+			updateErrors = append(updateErrors, fmt.Errorf(
+				"update doSPCX plan failure status for device %q: %w", device.Name, err))
+		}
 	}
-	return r.SpectrumXManager.PreparePlan(ctx, devices, stage)
+	return errors.Join(updateErrors...)
 }
 
 // applyRuntimeConfig applies device's runtime spec

--- a/internal/controller/nicdevice_controller_test.go
+++ b/internal/controller/nicdevice_controller_test.go
@@ -287,8 +287,26 @@ var _ = Describe("NicDeviceReconciler", func() {
 		It("does nothing when no device enables Spectrum-X", func() {
 			statuses := nicDeviceConfigurationStatuses{{device: &v1alpha1.NicDevice{}}}
 
-			Expect(reconciler.prepareSpectrumXPlan(ctx, statuses, spectrumx.PlanStagePrepare)).To(Succeed())
+			devices, err := reconciler.prepareSpectrumXPlan(ctx, statuses, spectrumx.PlanStagePrepare)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(devices).To(BeEmpty())
 			spectrumXManager.AssertNotCalled(GinkgoT(), "PreparePlan", mock.Anything, mock.Anything, mock.Anything)
+		})
+
+		It("excludes devices that are resetting NVConfig to defaults", func() {
+			resetting := newSpectrumXDevice("resetting")
+			resetting.Spec.Configuration.ResetToDefault = true
+			configured := newSpectrumXDevice("configured")
+			spectrumXManager.On(
+				"PreparePlan", mock.Anything, []*v1alpha1.NicDevice{configured}, spectrumx.PlanStagePrepare,
+			).Return(nil).Once()
+
+			_, err := reconciler.prepareSpectrumXPlan(
+				ctx,
+				nicDeviceConfigurationStatuses{{device: resetting}, {device: configured}},
+				spectrumx.PlanStagePrepare,
+			)
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		DescribeTable("prepares one group before the requested configuration stage",
@@ -302,7 +320,9 @@ var _ = Describe("NicDeviceReconciler", func() {
 				}
 				spectrumXManager.On("PreparePlan", mock.Anything, []*v1alpha1.NicDevice{first, second}, stage).Return(nil).Once()
 
-				Expect(reconciler.prepareSpectrumXPlan(ctx, statuses, stage)).To(Succeed())
+				devices, err := reconciler.prepareSpectrumXPlan(ctx, statuses, stage)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(devices).To(Equal([]*v1alpha1.NicDevice{first, second}))
 			},
 			Entry("NV prepare", spectrumx.PlanStagePrepare),
 			Entry("runtime configure", spectrumx.PlanStageConfigure),
@@ -314,9 +334,11 @@ var _ = Describe("NicDeviceReconciler", func() {
 			spectrumXManager.On("PreparePlan", mock.Anything, []*v1alpha1.NicDevice{device}, spectrumx.PlanStagePrepare).
 				Return(planErr).Once()
 
-			Expect(reconciler.prepareSpectrumXPlan(
+			devices, err := reconciler.prepareSpectrumXPlan(
 				ctx, nicDeviceConfigurationStatuses{{device: device}}, spectrumx.PlanStagePrepare,
-			)).To(MatchError(planErr))
+			)
+			Expect(err).To(MatchError(planErr))
+			Expect(devices).To(Equal([]*v1alpha1.NicDevice{device}))
 		})
 	})
 
@@ -554,6 +576,12 @@ var _ = Describe("NicDeviceReconciler", func() {
 				}
 				return false
 			}, timeout).Should(BeTrue())
+			Eventually(getDeviceConditions, timeout).Should(testutils.MatchCondition(metav1.Condition{
+				Type:    consts.ConfigUpdateInProgressCondition,
+				Status:  metav1.ConditionFalse,
+				Reason:  consts.SpecValidationFailed,
+				Message: "prepare doSPCX NV configuration plan: plan generation failed",
+			}))
 			maintenanceManager.AssertNotCalled(GinkgoT(), "ScheduleMaintenance", mock.Anything)
 			maintenanceManager.AssertNotCalled(GinkgoT(), "MaintenanceAllowed", mock.Anything)
 		})

--- a/pkg/configuration/configvalidation.go
+++ b/pkg/configuration/configvalidation.go
@@ -27,16 +27,14 @@ import (
 
 	"github.com/Mellanox/nic-configuration-operator/api/v1alpha1"
 	"github.com/Mellanox/nic-configuration-operator/pkg/consts"
-	"github.com/Mellanox/nic-configuration-operator/pkg/spectrumx"
 	"github.com/Mellanox/nic-configuration-operator/pkg/types"
 )
 
 type configValidation interface {
 	// ConstructNvParamMapFromTemplate builds the full set of desired nvconfig parameters for a device by
-	// combining, in increasing priority order, the Spectrum-X profile (breakout + postBreakout, when
-	// enabled), the spec template params, and rawNvConfig (raw wins on key collisions). For Network Bay
-	// devices these params override the set_system_conf baseline. Operates under the assumption that spec
-	// validation was already carried out.
+	// combining the spec template params and rawNvConfig (raw wins on key collisions). doSPCX plan
+	// operations are validated separately and applied together with template-derived native parameters.
+	// rawNvConfig and Network Bay are temporarily rejected when doSPCX is enabled.
 	ConstructNvParamMapFromTemplate(
 		device *v1alpha1.NicDevice, nvConfigQuery types.NvConfigQuery) (map[string]string, error)
 	// ValidateResetToDefault checks if device's nv config has been reset to default in current and next boots
@@ -51,9 +49,8 @@ type configValidation interface {
 }
 
 type configValidationImpl struct {
-	utils                  ConfigurationUtils
-	eventRecorder          record.EventRecorder
-	spectrumXConfigManager spectrumx.SpectrumXManager
+	utils         ConfigurationUtils
+	eventRecorder record.EventRecorder
 }
 
 func nvParamLinkTypeFromName(linkType string) string {
@@ -77,16 +74,13 @@ func applyDefaultNvConfigValueIfExists(
 	}
 }
 
-// ConstructNvParamMapFromTemplate builds the full set of desired nvconfig parameters for a device by
-// combining, in increasing priority order, the Spectrum-X profile (breakout + postBreakout, when
-// enabled), the spec template params, and rawNvConfig (raw wins on key collisions). Operates under the
-// assumption that spec validation was already carried out.
+// ConstructNvParamMapFromTemplate builds the desired raw nvconfig parameters from the template and
+// rawNvConfig. doSPCX operations remain typed XPaths and are handled separately.
 func (v *configValidationImpl) ConstructNvParamMapFromTemplate(
 	device *v1alpha1.NicDevice, query types.NvConfigQuery) (map[string]string, error) {
 	template := device.Spec.Configuration.Template
 	if template == nil {
-		// No template: nothing to translate. rawNvConfig / Spectrum-X live under the template, so there
-		// are no override params either.
+		// No template: nothing to translate and no rawNvConfig to merge.
 		return map[string]string{}, nil
 	}
 
@@ -206,24 +200,10 @@ func (v *configValidationImpl) ConstructNvParamMapFromTemplate(
 	return v.mergeOverrideLayers(device, desiredParameters)
 }
 
-// mergeOverrideLayers combines the template-derived params with the Spectrum-X profile (breakout +
-// postBreakout, when enabled) and rawNvConfig, in increasing priority order: Spectrum-X < template <
-// rawNvConfig (raw wins on key collisions). All keys are concrete indices (e.g. MODULE_SPLIT_M0[2]);
-// rawNvConfig range syntax is rejected by CEL validation on the CRD.
+// mergeOverrideLayers combines template-derived params with rawNvConfig. Raw values are merged last
+// and therefore win on key collisions. doSPCX plan XPaths are intentionally excluded.
 func (v *configValidationImpl) mergeOverrideLayers(device *v1alpha1.NicDevice, templateParams map[string]string) (map[string]string, error) {
 	combined := map[string]string{}
-	if spectrumXEnabled(device) {
-		breakoutParams, err := v.spectrumXConfigManager.GetBreakoutMlxConfig(device)
-		if err != nil {
-			return nil, err
-		}
-		postBreakoutParams, err := v.spectrumXConfigManager.GetPostBreakoutMlxConfig(device)
-		if err != nil {
-			return nil, err
-		}
-		mergeParams(combined, breakoutParams)
-		mergeParams(combined, postBreakoutParams)
-	}
 	mergeParams(combined, templateParams)
 	// rawNvConfig has the highest priority, so it is merged last. getRawNvConfigParams already drops
 	// _Pn params whose port is beyond the device's port count.
@@ -505,6 +485,6 @@ func (v *configValidationImpl) CalculateDesiredRuntimeConfig(device *v1alpha1.Ni
 	return result
 }
 
-func newConfigValidation(utils ConfigurationUtils, eventRecorder record.EventRecorder, spectrumXConfigManager spectrumx.SpectrumXManager) configValidation {
-	return &configValidationImpl{utils: utils, eventRecorder: eventRecorder, spectrumXConfigManager: spectrumXConfigManager}
+func newConfigValidation(utils ConfigurationUtils, eventRecorder record.EventRecorder) configValidation {
+	return &configValidationImpl{utils: utils, eventRecorder: eventRecorder}
 }

--- a/pkg/configuration/configvalidation_test.go
+++ b/pkg/configuration/configvalidation_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/Mellanox/nic-configuration-operator/api/v1alpha1"
 	"github.com/Mellanox/nic-configuration-operator/pkg/consts"
-	spcxmocks "github.com/Mellanox/nic-configuration-operator/pkg/spectrumx/mocks"
 )
 
 const testVal = "testVal"
@@ -708,11 +707,9 @@ var _ = Describe("ConfigValidationImpl", func() {
 		})
 	})
 
-	Describe("ConstructNvParamMapFromTemplate — override merge & priority", func() {
-		var mockSpcXMgr *spcxmocks.SpectrumXManager
-
+	Describe("ConstructNvParamMapFromTemplate — raw override merge", func() {
 		// newDevice builds a single-port device with an empty template, so ConstructNvParamMapFromTemplate
-		// contributes only its unconditional SRIOV defaults; the override layers under test are added on top.
+		// contributes only its unconditional SRIOV defaults; raw overrides are added on top.
 		newDevice := func() *v1alpha1.NicDevice {
 			return &v1alpha1.NicDevice{
 				Spec: v1alpha1.NicDeviceSpec{
@@ -725,8 +722,7 @@ var _ = Describe("ConfigValidationImpl", func() {
 		}
 
 		BeforeEach(func() {
-			mockSpcXMgr = spcxmocks.NewSpectrumXManager(GinkgoT())
-			validator = &configValidationImpl{utils: &mockConfigurationUtils, spectrumXConfigManager: mockSpcXMgr}
+			validator = &configValidationImpl{utils: &mockConfigurationUtils}
 		})
 
 		It("returns an empty map when the template is nil", func() {
@@ -737,28 +733,16 @@ var _ = Describe("ConfigValidationImpl", func() {
 			Expect(nvParams).To(BeEmpty())
 		})
 
-		It("merges Spectrum-X breakout and postBreakout params", func() {
+		It("keeps doSPCX plan operations out of the native parameter map", func() {
 			device := newDevice()
 			device.Spec.Configuration.Template.SpectrumXOptimized = &v1alpha1.SpectrumXOptimizedSpec{Enabled: true}
-			mockSpcXMgr.On("GetBreakoutMlxConfig", device).Return(map[string]string{"NUM_OF_PF": "2"}, nil)
-			mockSpcXMgr.On("GetPostBreakoutMlxConfig", device).Return(map[string]string{"LINK_TYPE_P1": "2"}, nil)
 
 			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, types.NewNvConfigQuery())
 			Expect(err).NotTo(HaveOccurred())
-			Expect(nvParams).To(HaveKeyWithValue("NUM_OF_PF", "2"))
-			Expect(nvParams).To(HaveKeyWithValue("LINK_TYPE_P1", "2"))
-		})
-
-		It("lets rawNvConfig win over a Spectrum-X param (raw > Spectrum-X)", func() {
-			device := newDevice()
-			device.Spec.Configuration.Template.SpectrumXOptimized = &v1alpha1.SpectrumXOptimizedSpec{Enabled: true}
-			device.Spec.Configuration.Template.RawNvConfig = []v1alpha1.NvConfigParam{{Name: "NUM_OF_PF", Value: "8"}}
-			mockSpcXMgr.On("GetBreakoutMlxConfig", device).Return(map[string]string{"NUM_OF_PF": "2"}, nil)
-			mockSpcXMgr.On("GetPostBreakoutMlxConfig", device).Return(nil, nil)
-
-			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, types.NewNvConfigQuery())
-			Expect(err).NotTo(HaveOccurred())
-			Expect(nvParams).To(HaveKeyWithValue("NUM_OF_PF", "8"))
+			Expect(nvParams).To(Equal(map[string]string{
+				consts.SriovEnabledParam:  consts.NvParamFalse,
+				consts.SriovNumOfVfsParam: "0",
+			}))
 		})
 
 		It("lets rawNvConfig win over a template param (raw > template)", func() {
@@ -771,21 +755,6 @@ var _ = Describe("ConfigValidationImpl", func() {
 			Expect(nvParams).To(HaveKeyWithValue(consts.SriovNumOfVfsParam, "16"))
 		})
 
-		It("lets a rawNvConfig concrete index override a lower-priority Spectrum-X index", func() {
-			// rawNvConfig range syntax is rejected by CEL; both layers use concrete per-index keys, so
-			// priority is a plain key-collision (raw > Spectrum-X).
-			device := newDevice()
-			device.Spec.Configuration.Template.SpectrumXOptimized = &v1alpha1.SpectrumXOptimizedSpec{Enabled: true}
-			device.Spec.Configuration.Template.RawNvConfig = []v1alpha1.NvConfigParam{{Name: "MODULE_SPLIT_M0[2]", Value: "5"}}
-			mockSpcXMgr.On("GetBreakoutMlxConfig", device).Return(map[string]string{"MODULE_SPLIT_M0[2]": "1", "MODULE_SPLIT_M0[3]": "1"}, nil)
-			mockSpcXMgr.On("GetPostBreakoutMlxConfig", device).Return(nil, nil)
-
-			nvParams, err := validator.ConstructNvParamMapFromTemplate(device, types.NewNvConfigQuery())
-			Expect(err).NotTo(HaveOccurred())
-			Expect(nvParams).To(HaveKeyWithValue("MODULE_SPLIT_M0[2]", "5"))
-			Expect(nvParams).To(HaveKeyWithValue("MODULE_SPLIT_M0[3]", "1"))
-		})
-
 		It("drops a rawNvConfig _Pn param whose port is beyond the device port count", func() {
 			device := newDevice() // single port
 			device.Spec.Configuration.Template.RawNvConfig = []v1alpha1.NvConfigParam{
@@ -796,16 +765,6 @@ var _ = Describe("ConfigValidationImpl", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nvParams).To(HaveKey("SOME_PARAM_P1"))
 			Expect(nvParams).ToNot(HaveKey("SOME_PARAM_P2"))
-		})
-
-		It("propagates an error from GetBreakoutMlxConfig", func() {
-			device := newDevice()
-			device.Spec.Configuration.Template.SpectrumXOptimized = &v1alpha1.SpectrumXOptimizedSpec{Enabled: true}
-			mockSpcXMgr.On("GetBreakoutMlxConfig", device).Return(nil, errors.New("config not found"))
-
-			_, err := validator.ConstructNvParamMapFromTemplate(device, types.NewNvConfigQuery())
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("config not found"))
 		})
 	})
 

--- a/pkg/configuration/manager.go
+++ b/pkg/configuration/manager.go
@@ -29,6 +29,7 @@ import (
 	"github.com/Mellanox/nic-configuration-operator/api/v1alpha1"
 	"github.com/Mellanox/nic-configuration-operator/pkg/consts"
 	"github.com/Mellanox/nic-configuration-operator/pkg/dms"
+	"github.com/Mellanox/nic-configuration-operator/pkg/dmscli"
 	"github.com/Mellanox/nic-configuration-operator/pkg/nvconfig"
 	"github.com/Mellanox/nic-configuration-operator/pkg/spectrumx"
 	"github.com/Mellanox/nic-configuration-operator/pkg/types"
@@ -87,12 +88,16 @@ type contextualNVConfigBatchSetter interface {
 // if fully matched next but not current, returns false, true
 // if not fully matched next boot, returns true, true
 func (h configurationManager) ValidateDeviceNvSpec(ctx context.Context, device *v1alpha1.NicDevice) (bool, bool, []string, error) {
-	log.Log.Info("configurationManager.ValidateDeviceNvSpec", "device", device.Name)
+	logger := log.FromContext(ctx)
+	logger.Info("configurationManager.ValidateDeviceNvSpec", "device", device.Name)
+	if err := validateSpectrumXNVConfigCompatibility(device); err != nil {
+		return false, false, nil, err
+	}
 
 	// 1. Query current nv config for every port.
 	nvConfigsForPorts, err := h.queryNvConfigs(ctx, device)
 	if err != nil {
-		log.Log.Error(err, "failed to query nv configs", "device", device.Name)
+		logger.Error(err, "failed to query nv configs", "device", device.Name)
 		return false, false, nil, err
 	}
 	firstPort := device.Status.Ports[0]
@@ -105,7 +110,7 @@ func (h configurationManager) ValidateDeviceNvSpec(ctx context.Context, device *
 		for _, nvConfig := range nvConfigsForPorts {
 			resetNeededForPort, rebootNeededForPort, err := h.configValidation.ValidateResetToDefault(nvConfig)
 			if err != nil {
-				log.Log.Error(err, "failed to validate reset to default", "device", device.Name)
+				logger.Error(err, "failed to validate reset to default", "device", device.Name)
 				return false, false, nil, err
 			}
 			resetNeeded = resetNeeded || resetNeededForPort
@@ -121,37 +126,63 @@ func (h configurationManager) ValidateDeviceNvSpec(ctx context.Context, device *
 		return false, false, nil, err
 	}
 	if len(systemConfMismatched) > 0 {
-		log.Log.V(2).Info("system_conf params mismatched against the profile", "device", device.Name, "params", systemConfMismatched)
+		logger.V(2).Info("system_conf params mismatched against the profile", "device", device.Name, "params", systemConfMismatched)
 	}
 
-	// 4. Combined override config (Spectrum-X breakout + postBreakout + template + rawNvConfig, raw wins).
+	// 4. Existing native NVConfig validation remains independent from the doSPCX plan.
 	//    Validated against the device's next boot, exactly like the apply path — so a value already staged
 	//    for next boot but not yet rebooted reports reboot-required instead of looping.
 	overrides, err := h.configValidation.ConstructNvParamMapFromTemplate(device, firstPortConfig)
 	if err != nil {
-		log.Log.Error(err, "failed to calculate desired nvconfig parameters", "device", device.Name)
+		logger.Error(err, "failed to calculate desired nvconfig parameters", "device", device.Name)
 		return false, false, nil, err
 	}
-	log.Log.V(2).Info("validating combined nv config", "device", device.Name, "params", overrides)
+	logger.V(2).Info("validating native NVConfig parameters", "device", device.Name, "params", overrides)
 
 	configUpdateNeeded, rebootNeeded, unsupportedParams := validateTemplateParamsApplied(nvConfigsForPorts, overrides)
+	logger.V(2).Info("native NVConfig validation complete",
+		"device", device.Name,
+		"configUpdateNeeded", configUpdateNeeded,
+		"rebootNeeded", rebootNeeded,
+		"unsupportedParams", unsupportedParams)
 	if configUpdateNeeded {
-		log.Log.Info("nv config not yet applied to next boot", "device", device.Name)
+		logger.Info("native NVConfig is not yet applied to next boot", "device", device.Name)
 	}
 	if len(unsupportedParams) > 0 {
-		log.Log.Info("some nv config params are unsupported on this device and will be skipped", "device", device.Name, "params", unsupportedParams)
+		logger.Info("some native NVConfig parameters are unsupported on this device and will be skipped", "device", device.Name, "params", unsupportedParams)
 	}
 
 	// 5. system_conf coverage: a mismatched profile param not covered (range-aware) by the override config
 	//    means the baseline itself drifted and set_system_conf must be re-applied (reboot-required).
 	if systemConfDrifted(overrides, systemConfMismatched) {
-		log.Log.Info("Network Bay system_conf drifted, set_system_conf re-apply required",
+		logger.Info("Network Bay system_conf drifted, set_system_conf re-apply required",
 			"device", device.Name, "mismatched", systemConfMismatched)
 		configUpdateNeeded = true
 		rebootNeeded = true
 	}
 
-	log.Log.V(2).Info("nv spec validation result", "device", device.Name,
+	// 6. Validate the prepared doSPCX NVConfig plan separately. Breakout is a
+	// reboot barrier: post-breakout is considered only after breakout matches
+	// both the current and pending device state.
+	plan, err := h.preparedSpectrumXPlan(device, spectrumx.PlanStagePrepare)
+	if err != nil {
+		return false, false, unsupportedParams, err
+	}
+	if plan != nil {
+		phase, planUpdateNeeded, planRebootNeeded, err := h.spectrumXNVConfigPhase(ctx, device, plan)
+		if err != nil {
+			return false, false, unsupportedParams, err
+		}
+		configUpdateNeeded = configUpdateNeeded || planUpdateNeeded
+		rebootNeeded = rebootNeeded || planRebootNeeded
+		logger.V(2).Info("doSPCX NVConfig phase validation complete",
+			"device", device.Name,
+			"phase", phase,
+			"configUpdateNeeded", planUpdateNeeded,
+			"rebootNeeded", planRebootNeeded)
+	}
+
+	logger.V(2).Info("nv spec validation result", "device", device.Name,
 		"configUpdateNeeded", configUpdateNeeded, "rebootNeeded", rebootNeeded, "unsupportedParams", unsupportedParams)
 	return configUpdateNeeded, rebootNeeded, unsupportedParams, nil
 }
@@ -233,23 +264,156 @@ func buildNVConfigApplyDiff(nvConfig types.NvConfigQuery, desiredConfig map[stri
 	return diff
 }
 
+func buildCombinedNVConfigApplyDiff(
+	nvConfigsForPorts map[string]types.NvConfigQuery,
+	desiredConfig map[string]string,
+	withDefault bool,
+	force bool,
+	includeUnchanged bool,
+) (map[string]string, bool) {
+	changed := make(map[string]string, len(desiredConfig))
+	hasUnsupported := false
+	for _, nvConfig := range nvConfigsForPorts {
+		diff := buildNVConfigApplyDiff(nvConfig, desiredConfig, withDefault || includeUnchanged, force)
+		for name, value := range diff.changed {
+			changed[name] = value
+		}
+		hasUnsupported = hasUnsupported || len(diff.unsupported) > 0
+	}
+	return changed, hasUnsupported
+}
+
+func (h configurationManager) applySpectrumXNVConfig(
+	ctx context.Context,
+	device *v1alpha1.NicDevice,
+	plan *spectrumx.Plan,
+	utils spectrumXNVConfigUtils,
+	nvConfigsForPorts map[string]types.NvConfigQuery,
+	desiredParams map[string]string,
+	options *types.ConfigurationOptions,
+) (*types.ConfigurationApplyResult, error) {
+	phase := spectrumXNVConfigPhaseBreakout
+	updateNeeded := false
+	rebootNeeded := false
+	typedOperations := make([]dmscli.XPathOperation, 0, len(plan.Breakout)+len(plan.PostBreakout))
+	if options.Force {
+		typedOperations = append(typedOperations, plan.Breakout...)
+		typedOperations = append(typedOperations, plan.PostBreakout...)
+	} else {
+		var err error
+		phase, updateNeeded, rebootNeeded, err = h.spectrumXNVConfigPhase(ctx, device, plan)
+		if err != nil {
+			return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
+		}
+		if options.WithDefault && phase == spectrumXNVConfigPhasePostBreakout {
+			typedOperations = append(typedOperations, plan.Breakout...)
+			typedOperations = append(typedOperations, plan.PostBreakout...)
+		} else if updateNeeded || options.WithDefault {
+			if phase == spectrumXNVConfigPhaseBreakout {
+				typedOperations = append(typedOperations, plan.Breakout...)
+			} else {
+				typedOperations = append(typedOperations, plan.PostBreakout...)
+			}
+		}
+	}
+
+	// DMS expands port-scoped typed mappings for every supplied port number in
+	// one primary-PF command. Include the complete native desired state whenever
+	// typed operations are staged so the combined operation is atomic.
+	nativeUpdateNeeded, _, _ := validateTemplateParamsApplied(nvConfigsForPorts, desiredParams)
+	batch, hasUnsupported := buildCombinedNVConfigApplyDiff(
+		nvConfigsForPorts,
+		desiredParams,
+		options.WithDefault,
+		options.Force,
+		len(typedOperations) > 0)
+	primaryPort := device.Status.Ports[0]
+	log.FromContext(ctx).V(2).Info("combined doSPCX NVConfig apply diff",
+		"device", device.Name,
+		"phase", phase,
+		"portCount", len(device.Status.Ports),
+		"withDefault", options.WithDefault,
+		"force", options.Force,
+		"nativeUpdateNeeded", nativeUpdateNeeded,
+		"nativeApplyCount", len(batch),
+		"typedOperationCount", len(typedOperations),
+		"hasUnsupported", hasUnsupported)
+	status := types.ApplyStatusNothingToDo
+	if hasUnsupported {
+		status = types.ApplyStatusPartiallyApplied
+	}
+	if len(batch) == 0 && len(typedOperations) == 0 {
+		return &types.ConfigurationApplyResult{Status: status, RebootRequired: rebootNeeded}, nil
+	}
+
+	applyStatus, err := utils.SetNvConfigParametersBatchWithXPaths(
+		ctx,
+		primaryPort,
+		len(device.Status.Ports),
+		batch,
+		typedOperations,
+		options.WithDefault,
+		options.Force)
+	if err != nil {
+		return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, fmt.Errorf(
+			"apply combined doSPCX %s NVConfig for device %q: %w",
+			phase, device.Name, err)
+	}
+	if applyStatus == types.ApplyStatusNothingToDo && !updateNeeded && !nativeUpdateNeeded {
+		return &types.ConfigurationApplyResult{Status: status, RebootRequired: rebootNeeded}, nil
+	}
+	if applyStatus == types.ApplyStatusNothingToDo {
+		return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, fmt.Errorf(
+			"apply combined doSPCX %s NVConfig for device %q did not stage the mismatched configuration",
+			phase, device.Name)
+	}
+	if applyStatus != types.ApplyStatusSuccess {
+		return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, fmt.Errorf(
+			"apply combined doSPCX %s NVConfig for device %q returned status %d",
+			phase, device.Name, applyStatus)
+	}
+	if err := h.verifySpectrumXSecondaryNVConfigStaged(
+		ctx, device, utils, desiredParams, typedOperations); err != nil {
+		return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, fmt.Errorf(
+			"verify combined doSPCX %s NVConfig for device %q: %w",
+			phase, device.Name, err)
+	}
+	if status != types.ApplyStatusPartiallyApplied {
+		status = types.ApplyStatusSuccess
+	}
+	return &types.ConfigurationApplyResult{Status: status, RebootRequired: true}, nil
+}
+
 // ApplyNVConfiguration calculates device's missing nv spec configuration and applies it to the device on the host
 // returns *ConfigurationApplyResult - result of the apply operation
 // returns error - there were errors while applying nv configuration
 func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *v1alpha1.NicDevice, options *types.ConfigurationOptions) (*types.ConfigurationApplyResult, error) {
-	log.Log.Info("configurationManager.ApplyNVConfiguration", "device", device.Name)
+	logger := log.FromContext(ctx)
+	logger.Info("configurationManager.ApplyNVConfiguration", "device", device.Name)
 
 	if device.Spec.Configuration == nil {
 		return &types.ConfigurationApplyResult{Status: types.ApplyStatusNothingToDo}, nil
 	}
-	if err := h.requirePreparedSpectrumXPlan(device, spectrumx.PlanStagePrepare); err != nil {
+	if options == nil {
+		return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, fmt.Errorf("configuration options must not be nil")
+	}
+	if err := validateSpectrumXNVConfigCompatibility(device); err != nil {
 		return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
+	}
+	var plan *spectrumx.Plan
+	var spectrumXUtils spectrumXNVConfigUtils
+	if !device.Spec.Configuration.ResetToDefault {
+		var err error
+		plan, spectrumXUtils, err = h.preparedSpectrumXNVConfig(device)
+		if err != nil {
+			return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
+		}
 	}
 
 	// 1. Query current nv config for every port.
 	nvConfigsForPorts, err := h.queryNvConfigs(ctx, device)
 	if err != nil {
-		log.Log.Error(err, "failed to query nv configs", "device", device.Name)
+		logger.Error(err, "failed to query nv configs", "device", device.Name)
 		return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
 	}
 	firstPort := device.Status.Ports[0]
@@ -266,23 +430,24 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 		return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
 	}
 
-	// 4. Combined desired params: Spectrum-X breakout + postBreakout + template + rawNvConfig (raw wins).
+	// 4. Build the existing template-derived native NVConfig layer independently
+	// from the doSPCX typed plan.
 	desiredParams, err := h.configValidation.ConstructNvParamMapFromTemplate(device, firstPortConfig)
 	if err != nil {
-		log.Log.Error(err, "failed to calculate desired nvconfig parameters", "device", device.Name)
+		logger.Error(err, "failed to calculate desired nvconfig parameters", "device", device.Name)
 		return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
 	}
 	if options.Force {
 		extrapolatePortParamsFromNumOfPF(desiredParams)
 	}
-	log.Log.V(2).Info("combined desired nv config built", "device", device.Name, "params", desiredParams, "force", options.Force)
+	logger.V(2).Info("native NVConfig desired parameters built", "device", device.Name, "params", desiredParams, "force", options.Force)
 
-	// 5. set_system_conf baseline: if the combined params do not cover all mismatched profile params
+	// 5. set_system_conf baseline: if the native params do not cover all mismatched profile params
 	//    (range-aware), the baseline itself drifted on an uncovered param — re-stage set_system_conf
 	//    before the override batch so the overrides still win in the same next-boot config.
 	systemConfApplied := false
 	if systemConfDrifted(desiredParams, systemConfMismatched) {
-		log.Log.Info("Network Bay system_conf not covered by overrides, applying set_system_conf",
+		logger.Info("Network Bay system_conf not covered by overrides, applying set_system_conf",
 			"device", device.Name, "mismatched", systemConfMismatched)
 		if err := h.setSystemConf(ctx, device, options); err != nil {
 			return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
@@ -294,29 +459,38 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 		// the baseline just overwrote.
 		nvConfigsForPorts, err = h.queryNvConfigs(ctx, device)
 		if err != nil {
-			log.Log.Error(err, "failed to re-query nv configs after set_system_conf", "device", device.Name)
+			logger.Error(err, "failed to re-query nv configs after set_system_conf", "device", device.Name)
 			return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
 		}
 	}
 
+	// Spectrum-X combines template-derived native and typed NVConfig into one
+	// primary-PF DMS action.
+	if plan != nil {
+		result, err := h.applySpectrumXNVConfig(
+			ctx, device, plan, spectrumXUtils, nvConfigsForPorts, desiredParams, options)
+		if err != nil {
+			return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
+		}
+		if systemConfApplied {
+			result.RebootRequired = true
+			if result.Status == types.ApplyStatusNothingToDo {
+				result.Status = types.ApplyStatusSuccess
+			}
+		}
+		return result, nil
+	}
+
+	// Non-Spectrum-X devices keep the existing per-PF raw apply behavior.
 	anyParamsApplied := false
 	hasUnsupportedParams := false
-
-	// 6 & 7. Apply the combined override params on every PF the device exposes.
-	//   - force=true: apply every param (mlxconfig --force accepts params not currently visible, e.g.
-	//     per-port params staged before a breakout reboot exposes their ports).
-	//   - withDefault=true: apply every param visible on this PF so DMS can reset unspecified params
-	//     to their defaults and report whether the operation requires a reset.
-	//   - otherwise: apply only the params visible on this PF whose value differs; params not yet
-	//     visible are skipped this round and picked up after a reboot exposes them (which sequences
-	//     breakout before postBreakout without --force).
 	for _, port := range device.Status.Ports {
 		nvConfig := nvConfigsForPorts[port.PCI]
 		diff := buildNVConfigApplyDiff(nvConfig, desiredParams, options.WithDefault, options.Force)
 		batch := diff.changed
 		hasUnsupportedParams = hasUnsupportedParams || len(diff.unsupported) > 0
 		target := "pci/" + port.PCI
-		log.Log.V(2).Info("nv config apply diff",
+		logger.V(2).Info("nv config apply diff",
 			"device", device.Name,
 			"target", target,
 			"withDefault", options.WithDefault,
@@ -332,10 +506,10 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 		if len(batch) == 0 {
 			continue
 		}
-		log.Log.V(2).Info("applying nv config batch", "device", device.Name, "target", target, "params", batch, "force", options.Force)
+		logger.V(2).Info("applying nv config batch", "device", device.Name, "target", target, "params", batch, "force", options.Force)
 		applyStatus, err := h.setNvConfigParametersBatch(ctx, port, batch, options.WithDefault, options.Force)
 		if err != nil {
-			log.Log.Error(err, "Failed to apply nv config parameters", "device", device.Name, "params", batch)
+			logger.Error(err, "Failed to apply nv config parameters", "device", device.Name, "params", batch)
 			return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
 		}
 		if applyStatus == types.ApplyStatusSuccess {
@@ -344,7 +518,7 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 	}
 
 	if !anyParamsApplied && !hasUnsupportedParams && !systemConfApplied {
-		log.Log.V(2).Info("nv config already up to date, nothing to apply", "device", device.Name)
+		logger.V(2).Info("nv config already up to date, nothing to apply", "device", device.Name)
 		return &types.ConfigurationApplyResult{Status: types.ApplyStatusNothingToDo}, nil
 	}
 
@@ -353,7 +527,7 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 		status = types.ApplyStatusPartiallyApplied
 	}
 	rebootRequired := anyParamsApplied || systemConfApplied
-	log.Log.Info("nv config applied", "device", device.Name, "status", status, "rebootRequired", rebootRequired)
+	logger.Info("nv config applied", "device", device.Name, "status", status, "rebootRequired", rebootRequired)
 
 	return &types.ConfigurationApplyResult{Status: status, RebootRequired: rebootRequired}, nil
 }
@@ -456,7 +630,7 @@ func (h configurationManager) ApplyRuntimeConfiguration(ctx context.Context, dev
 	if device.Spec.Configuration == nil || device.Spec.Configuration.Template == nil {
 		return &types.RuntimeConfigurationApplyResult{Status: types.ApplyStatusNothingToDo}, nil
 	}
-	if err := h.requirePreparedSpectrumXPlan(device, spectrumx.PlanStageConfigure); err != nil {
+	if _, err := h.preparedSpectrumXPlan(device, spectrumx.PlanStageConfigure); err != nil {
 		return &types.RuntimeConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
 	}
 
@@ -647,19 +821,6 @@ func spectrumXEnabled(device *v1alpha1.NicDevice) bool {
 		device.Spec.Configuration.Template.SpectrumXOptimized.Enabled
 }
 
-func (h configurationManager) requirePreparedSpectrumXPlan(device *v1alpha1.NicDevice, stage spectrumx.PlanStage) error {
-	if !spectrumXEnabled(device) {
-		return nil
-	}
-	if h.spectrumXConfigManager == nil {
-		return fmt.Errorf("matching doSPCX %s plan is required for device %q: Spectrum-X manager is not configured", stage, device.Name)
-	}
-	if _, err := h.spectrumXConfigManager.GetPreparedPlan(device, stage); err != nil {
-		return fmt.Errorf("matching doSPCX %s plan is required for device %q: %w", stage, device.Name, err)
-	}
-	return nil
-}
-
 // hasNetworkBaySpec reports whether the device has a Network Bay template configured AND was
 // detected as part of a Network Bay card. Both are required to apply / validate set_system_conf.
 // ResetToDefault takes precedence: a reset wipes nv config, so we must not also manage set_system_conf
@@ -748,5 +909,5 @@ func systemConfDrifted(overrides map[string]string, mismatched []string) bool {
 
 func NewConfigurationManager(eventRecorder record.EventRecorder, dmsManager dms.DMSManager, nvConfigUtils nvconfig.NVConfigUtils, spectrumXConfigManager spectrumx.SpectrumXManager) ConfigurationManager {
 	utils := newConfigurationUtils(dmsManager)
-	return configurationManager{configurationUtils: utils, configValidation: newConfigValidation(utils, eventRecorder, spectrumXConfigManager), nvConfigUtils: nvConfigUtils, spectrumXConfigManager: spectrumXConfigManager}
+	return configurationManager{configurationUtils: utils, configValidation: newConfigValidation(utils, eventRecorder), nvConfigUtils: nvConfigUtils, spectrumXConfigManager: spectrumXConfigManager}
 }

--- a/pkg/configuration/manager_test.go
+++ b/pkg/configuration/manager_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/Mellanox/nic-configuration-operator/api/v1alpha1"
 	"github.com/Mellanox/nic-configuration-operator/pkg/configuration/mocks"
 	"github.com/Mellanox/nic-configuration-operator/pkg/consts"
+	"github.com/Mellanox/nic-configuration-operator/pkg/dmscli"
 	"github.com/Mellanox/nic-configuration-operator/pkg/nvconfig"
 	nvconfigmocks "github.com/Mellanox/nic-configuration-operator/pkg/nvconfig/mocks"
 	"github.com/Mellanox/nic-configuration-operator/pkg/spectrumx"
@@ -35,11 +36,95 @@ import (
 
 const pciAddress = "0000:3b:00.0"
 const pciAddress2 = "0000:3b:00.1"
+const testPCIXPath = "/nvidia/pci"
 
 // legacyNVConfigUtils deliberately exposes only the public NVConfigUtils interface. It verifies
 // that ConfigurationManager supports implementations without the optional context-aware extension.
 type legacyNVConfigUtils struct {
 	nvconfig.NVConfigUtils
+}
+
+type xpathNVConfigUtils struct {
+	nvconfig.NVConfigUtils
+	validationResults []xpathValidationResult
+	validationCalls   []xpathValidationCall
+	applyResult       *xpathApplyResult
+	applyCalls        []xpathApplyCall
+}
+
+type xpathValidationResult struct {
+	updateNeeded bool
+	rebootNeeded bool
+	err          error
+}
+
+type xpathValidationCall struct {
+	ports      []v1alpha1.NicDevicePortSpec
+	operations []dmscli.XPathOperation
+}
+
+type xpathApplyResult struct {
+	status types.ApplyStatus
+	err    error
+}
+
+type xpathApplyCall struct {
+	port        v1alpha1.NicDevicePortSpec
+	portCount   int
+	params      map[string]string
+	operations  []dmscli.XPathOperation
+	withDefault bool
+	force       bool
+}
+
+func (u *xpathNVConfigUtils) SetNvConfigParametersBatchWithContext(
+	ctx context.Context,
+	port v1alpha1.NicDevicePortSpec,
+	params map[string]string,
+	withDefault bool,
+	force bool,
+) (types.ApplyStatus, error) {
+	return u.NVConfigUtils.(contextualNVConfigBatchSetter).
+		SetNvConfigParametersBatchWithContext(ctx, port, params, withDefault, force)
+}
+
+func (u *xpathNVConfigUtils) ValidateNvConfigXPaths(
+	ctx context.Context,
+	ports []v1alpha1.NicDevicePortSpec,
+	operations []dmscli.XPathOperation,
+) (bool, bool, error) {
+	if len(operations) == 0 {
+		return false, false, nil
+	}
+	if len(u.validationResults) == 0 {
+		return false, false, errors.New("unexpected XPath validation")
+	}
+	u.validationCalls = append(u.validationCalls, xpathValidationCall{ports, operations})
+	result := u.validationResults[0]
+	u.validationResults = u.validationResults[1:]
+	return result.updateNeeded, result.rebootNeeded, result.err
+}
+
+func (u *xpathNVConfigUtils) SetNvConfigParametersBatchWithXPaths(
+	ctx context.Context,
+	port v1alpha1.NicDevicePortSpec,
+	portCount int,
+	params map[string]string,
+	operations []dmscli.XPathOperation,
+	withDefault bool,
+	force bool,
+) (types.ApplyStatus, error) {
+	if u.applyResult == nil {
+		if len(operations) > 0 {
+			return types.ApplyStatusFailed, errors.New("unexpected XPath apply")
+		}
+		return u.NVConfigUtils.(contextualNVConfigBatchSetter).
+			SetNvConfigParametersBatchWithContext(ctx, port, params, withDefault, force)
+	}
+	u.applyCalls = append(u.applyCalls, xpathApplyCall{
+		port, portCount, params, operations, withDefault, force,
+	})
+	return u.applyResult.status, u.applyResult.err
 }
 
 func portSpec(pciAddr string) v1alpha1.NicDevicePortSpec {
@@ -97,6 +182,31 @@ var _ = Describe("ConfigurationManager", func() {
 			Expect(diff.changed).To(Equal(map[string]string{"MATCHING": "requested"}))
 			Expect(diff.unchanged).To(BeEmpty())
 			Expect(diff.unsupported).To(Equal([]string{"UNSUPPORTED"}))
+		})
+
+		It("combines changes found on any queried port", func() {
+			changed, hasUnsupported := buildCombinedNVConfigApplyDiff(map[string]types.NvConfigQuery{
+				"0000:3b:00.0": {
+					NextBootConfig: map[string][]string{"A": {"requested"}, "B": {"old"}},
+				},
+				"0000:3b:00.1": {
+					NextBootConfig: map[string][]string{"A": {"old"}, "B": {"requested"}},
+				},
+			}, map[string]string{"A": "requested", "B": "requested"}, false, false, false)
+
+			Expect(changed).To(Equal(map[string]string{"A": "requested", "B": "requested"}))
+			Expect(hasUnsupported).To(BeFalse())
+		})
+
+		It("includes matching raw values when a typed operation can overwrite them", func() {
+			changed, hasUnsupported := buildCombinedNVConfigApplyDiff(map[string]types.NvConfigQuery{
+				"0000:3b:00.0": {
+					NextBootConfig: map[string][]string{"RAW_OVERRIDE": {"requested"}},
+				},
+			}, map[string]string{"RAW_OVERRIDE": "requested"}, false, false, true)
+
+			Expect(changed).To(Equal(map[string]string{"RAW_OVERRIDE": "requested"}))
+			Expect(hasUnsupported).To(BeFalse())
 		})
 	})
 
@@ -1297,20 +1407,23 @@ var _ = Describe("ConfigurationManager", func() {
 	Describe("SpectrumX NV Configuration", func() {
 		var (
 			mockNVConfigUtils    *nvconfigmocks.NVConfigUtils
+			xpathUtils           *xpathNVConfigUtils
 			mockSpcXMgr          *spcxmocks.SpectrumXManager
 			mockConfigValidation mocks.ConfigValidation
 			manager              configurationManager
 			ctx                  context.Context
 			device               *v1alpha1.NicDevice
+			preparedPlan         *spectrumx.Plan
 		)
 
 		BeforeEach(func() {
 			mockNVConfigUtils = nvconfigmocks.NewNVConfigUtils(GinkgoT())
+			xpathUtils = &xpathNVConfigUtils{NVConfigUtils: mockNVConfigUtils}
 			mockSpcXMgr = spcxmocks.NewSpectrumXManager(GinkgoT())
 			mockConfigValidation = mocks.ConfigValidation{}
 			manager = configurationManager{
 				configValidation:       &mockConfigValidation,
-				nvConfigUtils:          mockNVConfigUtils,
+				nvConfigUtils:          xpathUtils,
 				spectrumXConfigManager: mockSpcXMgr,
 			}
 			ctx = context.TODO()
@@ -1326,14 +1439,16 @@ var _ = Describe("ConfigurationManager", func() {
 					Ports: []v1alpha1.NicDevicePortSpec{{PCI: pciAddress}},
 				},
 			}
+			preparedPlan = &spectrumx.Plan{}
+			mockSpcXMgr.On("GetPreparedPlan", device, spectrumx.PlanStagePrepare).
+				Return(func(*v1alpha1.NicDevice, spectrumx.PlanStage) *spectrumx.Plan {
+					return preparedPlan
+				}, nil).Maybe()
 		})
 
 		Describe("ValidateDeviceNvSpec", func() {
-			// The combined override map (breakout + postBreakout + template + raw) is built by
-			// ConstructNvParamMapFromTemplate; the manager validates the returned map against the device's
-			// next-boot config — the same source the apply path uses. These tests mock the combined map
-			// directly; the merge/expansion/priority itself is covered in the configValidation suite.
-			It("requires update+reboot when a combined param mismatches next boot", func() {
+			// The template-derived native parameter map is validated independently from the doSPCX XPath plan.
+			It("requires update+reboot when a native desired param mismatches next boot", func() {
 				mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(
 					types.NvConfigQuery{NextBootConfig: map[string][]string{"NUM_OF_PF": {"1"}}}, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
@@ -1345,7 +1460,7 @@ var _ = Describe("ConfigurationManager", func() {
 				Expect(rebootNeeded).To(BeTrue())
 			})
 
-			It("requires no update when every combined param matches next boot and current", func() {
+			It("requires no update when every native desired param matches next boot and current", func() {
 				matched := map[string][]string{"NUM_OF_PF": {"2"}, "LINK_TYPE_P1": {"2"}}
 				mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(
 					types.NvConfigQuery{NextBootConfig: matched, CurrentConfig: matched}, nil)
@@ -1375,6 +1490,35 @@ var _ = Describe("ConfigurationManager", func() {
 				Expect(rebootNeeded).To(BeTrue())
 			})
 
+			DescribeTable("validates doSPCX phases across the breakout barrier",
+				func(results []xpathValidationResult, expectedUpdate, expectedReboot bool, expectedCalls int) {
+					preparedPlan.Breakout = []dmscli.XPathOperation{{
+						Path: testPCIXPath, Values: map[string]any{"num-pfs": 2},
+					}}
+					preparedPlan.PostBreakout = []dmscli.XPathOperation{{
+						Path: "/nvidia/link/type", Values: map[string]any{"value": "ETH"},
+					}}
+					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).
+						Return(types.NvConfigQuery{}, nil)
+					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
+						Return(map[string]string{}, nil)
+					xpathUtils.validationResults = results
+
+					updateNeeded, rebootNeeded, _, err := manager.ValidateDeviceNvSpec(ctx, device)
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(updateNeeded).To(Equal(expectedUpdate))
+					Expect(rebootNeeded).To(Equal(expectedReboot))
+					Expect(xpathUtils.validationCalls).To(HaveLen(expectedCalls))
+					Expect(xpathUtils.validationCalls[0]).To(Equal(xpathValidationCall{
+						ports: []v1alpha1.NicDevicePortSpec{portSpec(pciAddress)}, operations: preparedPlan.Breakout,
+					}))
+				},
+				Entry("breakout mismatch", []xpathValidationResult{{updateNeeded: true, rebootNeeded: true}}, true, true, 1),
+				Entry("breakout pending only", []xpathValidationResult{{rebootNeeded: true}}, false, true, 1),
+				Entry("post-breakout mismatch", []xpathValidationResult{{}, {updateNeeded: true, rebootNeeded: true}}, true, true, 2),
+			)
+
 			It("returns the error when ConstructNvParamMapFromTemplate fails", func() {
 				mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(types.NvConfigQuery{}, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
@@ -1385,95 +1529,21 @@ var _ = Describe("ConfigurationManager", func() {
 				Expect(err.Error()).To(ContainSubstring("config not found"))
 			})
 
-			Context("with Network Bay system_conf", func() {
-				BeforeEach(func() {
-					device.Spec.Configuration.Template.NetworkBay = &v1alpha1.NetworkBaySpec{Conf: "conf3"}
-					device.Status.NetworkBay = &v1alpha1.NicDeviceNetworkBayStatus{Asic: 0}
-				})
+			It("rejects Network Bay before querying device state", func() {
+				device.Spec.Configuration.Template.NetworkBay = &v1alpha1.NetworkBaySpec{Conf: "conf3"}
 
-				It("does not flag drift when every system_conf mismatch is covered by a combined override param", func() {
-					matched := map[string][]string{"NUM_OF_PF": {"2"}}
-					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(
-						types.NvConfigQuery{NextBootConfig: matched, CurrentConfig: matched}, nil)
-					mockNVConfigUtils.On("ValidateSystemConf", ctx, portSpec(pciAddress), "conf3", 0).
-						Return(mismatchSystemConf("NUM_OF_PF")...)
-					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
-						Return(map[string]string{"NUM_OF_PF": "2"}, nil)
+				updateNeeded, rebootNeeded, unsupported, err := manager.ValidateDeviceNvSpec(ctx, device)
 
-					updateNeeded, rebootNeeded, _, err := manager.ValidateDeviceNvSpec(ctx, device)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(updateNeeded).To(BeFalse())
-					Expect(rebootNeeded).To(BeFalse())
-				})
-
-				It("flags drift when a system_conf mismatch is covered by no combined override param", func() {
-					matched := map[string][]string{"NUM_OF_PF": {"2"}}
-					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(
-						types.NvConfigQuery{NextBootConfig: matched, CurrentConfig: matched}, nil)
-					mockNVConfigUtils.On("ValidateSystemConf", ctx, portSpec(pciAddress), "conf3", 0).
-						Return(mismatchSystemConf("BOARD_CONFIGURATION_MODE")...)
-					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
-						Return(map[string]string{"NUM_OF_PF": "2"}, nil)
-
-					updateNeeded, rebootNeeded, _, err := manager.ValidateDeviceNvSpec(ctx, device)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(updateNeeded).To(BeTrue())
-					Expect(rebootNeeded).To(BeTrue())
-				})
-
-				It("value-checks each expanded index (covers system_conf by name, but still drifts on a wrong index)", func() {
-					// The combined map already has the range expanded to concrete indices; [2] differs from
-					// next boot, so validation must still report an update even though all four rows are covered.
-					expanded := map[string]string{
-						"MODULE_SPLIT_M0[0]": "1", "MODULE_SPLIT_M0[1]": "1",
-						"MODULE_SPLIT_M0[2]": "1", "MODULE_SPLIT_M0[3]": "1",
-					}
-					nextBoot := map[string][]string{
-						"MODULE_SPLIT_M0[0]": {"1"}, "MODULE_SPLIT_M0[1]": {"1"},
-						"MODULE_SPLIT_M0[2]": {"0"}, "MODULE_SPLIT_M0[3]": {"1"},
-					}
-					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(
-						types.NvConfigQuery{NextBootConfig: nextBoot, CurrentConfig: nextBoot}, nil)
-					mockNVConfigUtils.On("ValidateSystemConf", ctx, portSpec(pciAddress), "conf3", 0).
-						Return(mismatchSystemConf("MODULE_SPLIT_M0[0]", "MODULE_SPLIT_M0[1]", "MODULE_SPLIT_M0[2]", "MODULE_SPLIT_M0[3]")...)
-					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).Return(expanded, nil)
-
-					updateNeeded, rebootNeeded, _, err := manager.ValidateDeviceNvSpec(ctx, device)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(updateNeeded).To(BeTrue())
-					Expect(rebootNeeded).To(BeTrue())
-				})
-
-				It("converges when every expanded index already matches and covers the system_conf rows", func() {
-					matched := map[string][]string{
-						"MODULE_SPLIT_M0[0]": {"1"}, "MODULE_SPLIT_M0[1]": {"1"},
-						"MODULE_SPLIT_M0[2]": {"1"}, "MODULE_SPLIT_M0[3]": {"1"},
-					}
-					expanded := map[string]string{
-						"MODULE_SPLIT_M0[0]": "1", "MODULE_SPLIT_M0[1]": "1",
-						"MODULE_SPLIT_M0[2]": "1", "MODULE_SPLIT_M0[3]": "1",
-					}
-					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(
-						types.NvConfigQuery{NextBootConfig: matched, CurrentConfig: matched}, nil)
-					mockNVConfigUtils.On("ValidateSystemConf", ctx, portSpec(pciAddress), "conf3", 0).
-						Return(mismatchSystemConf("MODULE_SPLIT_M0[0]", "MODULE_SPLIT_M0[1]", "MODULE_SPLIT_M0[2]", "MODULE_SPLIT_M0[3]")...)
-					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).Return(expanded, nil)
-
-					updateNeeded, rebootNeeded, _, err := manager.ValidateDeviceNvSpec(ctx, device)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(updateNeeded).To(BeFalse())
-					Expect(rebootNeeded).To(BeFalse())
-				})
-
+				Expect(err).To(MatchError(ContainSubstring(
+					"networkBay cannot currently be combined with spectrumXOptimized")))
+				Expect(updateNeeded).To(BeFalse())
+				Expect(rebootNeeded).To(BeFalse())
+				Expect(unsupported).To(BeNil())
+				mockNVConfigUtils.AssertNotCalled(GinkgoT(), "QueryNvConfig", mock.Anything, mock.Anything)
 			})
 		})
 
 		Describe("ApplyNVConfiguration", func() {
-			BeforeEach(func() {
-				mockSpcXMgr.On("GetPreparedPlan", device, spectrumx.PlanStagePrepare).
-					Return(&spectrumx.Plan{}, nil).Maybe()
-			})
-
 			It("requires a matching prepare plan before querying or applying NV configuration", func() {
 				missingPlanManager := spcxmocks.NewSpectrumXManager(GinkgoT())
 				missingPlanManager.On("GetPreparedPlan", device, spectrumx.PlanStagePrepare).
@@ -1487,7 +1557,163 @@ var _ = Describe("ConfigurationManager", func() {
 				mockNVConfigUtils.AssertNotCalled(GinkgoT(), "QueryNvConfig", mock.Anything, mock.Anything)
 			})
 
-			It("force=false applies the combined params present in the query that differ", func() {
+			It("rejects a Spectrum-X apply before raw changes when typed XPath support is unavailable", func() {
+				manager.nvConfigUtils = legacyNVConfigUtils{NVConfigUtils: mockNVConfigUtils}
+
+				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
+
+				Expect(result.Status).To(Equal(types.ApplyStatusFailed))
+				Expect(err).To(MatchError(ContainSubstring("doSPCX NVConfig is not supported")))
+				mockNVConfigUtils.AssertNotCalled(GinkgoT(), "QueryNvConfig", mock.Anything, mock.Anything)
+			})
+
+			It("applies native parameters and the active doSPCX phase in one batch", func() {
+				preparedPlan.Breakout = []dmscli.XPathOperation{{
+					Path: testPCIXPath, Values: map[string]any{"num-pfs": 2, "rde-disable": true},
+				}}
+				mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(
+					types.NvConfigQuery{NextBootConfig: map[string][]string{"RAW_PARAM": {"1"}}}, nil)
+				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
+					Return(map[string]string{"RAW_PARAM": "2"}, nil)
+
+				xpathUtils.validationResults = []xpathValidationResult{{updateNeeded: true, rebootNeeded: true}}
+				xpathUtils.applyResult = &xpathApplyResult{status: types.ApplyStatusSuccess}
+
+				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Status).To(Equal(types.ApplyStatusSuccess))
+				Expect(result.RebootRequired).To(BeTrue())
+				Expect(xpathUtils.applyCalls).To(Equal([]xpathApplyCall{{
+					port: portSpec(pciAddress), portCount: 1,
+					params: map[string]string{"RAW_PARAM": "2"}, operations: preparedPlan.Breakout,
+				}}))
+			})
+
+			It("fails when a successful primary-target apply leaves native drift on a secondary PCI function", func() {
+				device.Status.Ports = append(device.Status.Ports, portSpec(pciAddress2))
+				mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(
+					types.NvConfigQuery{NextBootConfig: map[string][]string{"NUM_OF_PF": {"2"}}}, nil)
+				mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress2), []string(nil)).Return(
+					types.NvConfigQuery{NextBootConfig: map[string][]string{"NUM_OF_PF": {"1"}}}, nil)
+				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
+					Return(map[string]string{"NUM_OF_PF": "2"}, nil)
+				xpathUtils.applyResult = &xpathApplyResult{status: types.ApplyStatusSuccess}
+
+				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
+
+				Expect(result.Status).To(Equal(types.ApplyStatusFailed))
+				Expect(err).To(MatchError(ContainSubstring(
+					"did not stage native NVConfig on secondary PCI function \"0000:3b:00.1\"")))
+			})
+
+			It("fails when a successful primary-target apply leaves typed drift on a secondary PCI function", func() {
+				device.Status.Ports = append(device.Status.Ports, portSpec(pciAddress2))
+				preparedPlan.Breakout = []dmscli.XPathOperation{{
+					Path: testPCIXPath, Values: map[string]any{"num-pfs": 2},
+				}}
+				for _, port := range device.Status.Ports {
+					mockNVConfigUtils.On("QueryNvConfig", ctx, port, []string(nil)).Return(types.NvConfigQuery{}, nil)
+				}
+				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
+					Return(map[string]string{}, nil)
+				xpathUtils.validationResults = []xpathValidationResult{
+					{updateNeeded: true, rebootNeeded: true},
+					{updateNeeded: true, rebootNeeded: true},
+				}
+				xpathUtils.applyResult = &xpathApplyResult{status: types.ApplyStatusSuccess}
+
+				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
+
+				Expect(result.Status).To(Equal(types.ApplyStatusFailed))
+				Expect(err).To(MatchError(ContainSubstring(
+					"did not stage typed NVConfig on every secondary PCI function")))
+				Expect(xpathUtils.validationCalls).To(HaveLen(2))
+				Expect(xpathUtils.validationCalls[1].ports).To(Equal(
+					[]v1alpha1.NicDevicePortSpec{portSpec(pciAddress2)}))
+			})
+
+			It("rejects rawNvConfig before querying or applying device state", func() {
+				device.Spec.Configuration.Template.RawNvConfig = []v1alpha1.NvConfigParam{{
+					Name: "ROCE_ADAPTIVE_ROUTING_EN", Value: "0",
+				}}
+
+				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
+
+				Expect(result.Status).To(Equal(types.ApplyStatusFailed))
+				Expect(err).To(MatchError(ContainSubstring(
+					"rawNvConfig cannot currently be combined with spectrumXOptimized")))
+				mockNVConfigUtils.AssertNotCalled(GinkgoT(), "QueryNvConfig", mock.Anything, mock.Anything)
+			})
+
+			It("force applies the complete plan once through the primary target with every available DMS port", func() {
+				device.Status.Ports = append(device.Status.Ports, portSpec(pciAddress2))
+				preparedPlan.Breakout = []dmscli.XPathOperation{{
+					Path: testPCIXPath, Values: map[string]any{"num-pfs": 2},
+				}}
+				preparedPlan.PostBreakout = []dmscli.XPathOperation{{
+					Path: "/nvidia/link/type", Values: map[string]any{"value": "ETH"},
+				}}
+				for _, port := range device.Status.Ports {
+					mockNVConfigUtils.On("QueryNvConfig", ctx, port, []string(nil)).
+						Return(types.NvConfigQuery{}, nil)
+				}
+				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
+					Return(map[string]string{}, nil)
+				xpathUtils.applyResult = &xpathApplyResult{status: types.ApplyStatusSuccess}
+				xpathUtils.validationResults = []xpathValidationResult{{}}
+
+				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{Force: true})
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Status).To(Equal(types.ApplyStatusSuccess))
+				Expect(result.RebootRequired).To(BeTrue())
+				Expect(xpathUtils.validationCalls).To(Equal([]xpathValidationCall{{
+					ports: []v1alpha1.NicDevicePortSpec{portSpec(pciAddress2)},
+					operations: append(
+						append([]dmscli.XPathOperation{}, preparedPlan.Breakout...), preparedPlan.PostBreakout...),
+				}}))
+				Expect(xpathUtils.applyCalls).To(HaveLen(1))
+				Expect(xpathUtils.applyCalls[0].portCount).To(Equal(2))
+				Expect(xpathUtils.applyCalls[0].operations).To(Equal(
+					append(preparedPlan.Breakout, preparedPlan.PostBreakout...)))
+				Expect(xpathUtils.applyCalls[0].force).To(BeTrue())
+			})
+
+			DescribeTable("selects post-breakout operations after the barrier",
+				func(options types.ConfigurationOptions, includeBreakout bool) {
+					preparedPlan.Breakout = []dmscli.XPathOperation{{
+						Path: testPCIXPath, Values: map[string]any{"num-pfs": 2},
+					}}
+					preparedPlan.PostBreakout = []dmscli.XPathOperation{{
+						Path: "/nvidia/link/type", Values: map[string]any{"value": "ETH"},
+					}}
+					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).
+						Return(types.NvConfigQuery{}, nil)
+					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
+						Return(map[string]string{}, nil)
+					xpathUtils.validationResults = []xpathValidationResult{
+						{}, {updateNeeded: true, rebootNeeded: true},
+					}
+					xpathUtils.applyResult = &xpathApplyResult{status: types.ApplyStatusSuccess}
+
+					result, err := manager.ApplyNVConfiguration(ctx, device, &options)
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result.Status).To(Equal(types.ApplyStatusSuccess))
+					Expect(result.RebootRequired).To(BeTrue())
+					expected := preparedPlan.PostBreakout
+					if includeBreakout {
+						expected = append(preparedPlan.Breakout, preparedPlan.PostBreakout...)
+					}
+					Expect(xpathUtils.applyCalls[0].operations).To(Equal(expected))
+					Expect(xpathUtils.applyCalls[0].withDefault).To(Equal(options.WithDefault))
+				},
+				Entry("normally", types.ConfigurationOptions{}, false),
+				Entry("with defaults", types.ConfigurationOptions{WithDefault: true}, true),
+			)
+
+			It("force=false applies the native desired params present in the query that differ", func() {
 				mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(
 					types.NvConfigQuery{NextBootConfig: map[string][]string{"NUM_OF_PF": {"1"}, "LINK_TYPE_P1": {"2"}}}, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
@@ -1502,6 +1728,7 @@ var _ = Describe("ConfigurationManager", func() {
 			})
 
 			It("falls back to the public batch method when the context-aware extension is absent", func() {
+				device.Spec.Configuration.Template.SpectrumXOptimized.Enabled = false
 				manager.nvConfigUtils = legacyNVConfigUtils{NVConfigUtils: mockNVConfigUtils}
 				mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(
 					types.NvConfigQuery{NextBootConfig: map[string][]string{"NUM_OF_PF": {"1"}}}, nil)
@@ -1517,7 +1744,7 @@ var _ = Describe("ConfigurationManager", func() {
 				Expect(result.RebootRequired).To(BeTrue())
 			})
 
-			It("force=true applies all combined params in a single --force batch", func() {
+			It("force=true applies all native desired params in a single --force batch", func() {
 				mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(types.NvConfigQuery{}, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 					Return(map[string]string{"NUM_OF_PF": "2", "LINK_TYPE_P1": "2"}, nil)
@@ -1529,7 +1756,8 @@ var _ = Describe("ConfigurationManager", func() {
 				Expect(result.RebootRequired).To(BeTrue())
 			})
 
-			It("force=true applies the batch to every PF, not just the first", func() {
+			It("preserves per-PF native apply for non-Spectrum-X devices", func() {
+				device.Spec.Configuration.Template.SpectrumXOptimized.Enabled = false
 				device.Status.Ports = []v1alpha1.NicDevicePortSpec{{PCI: pciAddress}, {PCI: pciAddress2}}
 				mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(types.NvConfigQuery{}, nil)
 				mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress2), []string(nil)).Return(types.NvConfigQuery{}, nil)
@@ -1546,7 +1774,7 @@ var _ = Describe("ConfigurationManager", func() {
 				mockNVConfigUtils.AssertCalled(GinkgoT(), "SetNvConfigParametersBatchWithContext", mock.Anything, portSpec(pciAddress2), map[string]string{"NUM_OF_PF": "2"}, false, true)
 			})
 
-			It("propagates WithDefault=true to the combined batch", func() {
+			It("propagates WithDefault=true to the native batch", func() {
 				mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(
 					types.NvConfigQuery{NextBootConfig: map[string][]string{"NUM_OF_PF": {"1"}}}, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
@@ -1586,7 +1814,7 @@ var _ = Describe("ConfigurationManager", func() {
 				Expect(result.RebootRequired).To(BeFalse())
 			})
 
-			It("returns NothingToDo when the combined params already match", func() {
+			It("returns NothingToDo when the native desired params already match", func() {
 				mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(
 					types.NvConfigQuery{NextBootConfig: map[string][]string{"NUM_OF_PF": {"2"}}}, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
@@ -1608,42 +1836,6 @@ var _ = Describe("ConfigurationManager", func() {
 				Expect(result.Status).To(Equal(types.ApplyStatusFailed))
 			})
 
-			Context("with Network Bay system_conf", func() {
-				BeforeEach(func() {
-					device.Spec.Configuration.Template.NetworkBay = &v1alpha1.NetworkBaySpec{Conf: "conf3"}
-					device.Status.NetworkBay = &v1alpha1.NicDeviceNetworkBayStatus{Asic: 0}
-				})
-
-				It("applies set_system_conf when the combined params do not cover a mismatch", func() {
-					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(types.NvConfigQuery{}, nil)
-					mockNVConfigUtils.On("ValidateSystemConf", ctx, portSpec(pciAddress), "conf3", 0).
-						Return(mismatchSystemConf("BOARD_CONFIGURATION_MODE")...)
-					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
-						Return(map[string]string{"NUM_OF_PF": "2"}, nil)
-					mockNVConfigUtils.On("SetSystemConf", ctx, portSpec(pciAddress), "conf3", 0, true).Return(nil)
-					mockNVConfigUtils.On("SetNvConfigParametersBatchWithContext", mock.Anything, portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, false, true).
-						Return(types.ApplyStatusSuccess, nil)
-
-					result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{Force: true})
-					Expect(err).NotTo(HaveOccurred())
-					Expect(result.RebootRequired).To(BeTrue())
-				})
-
-				It("does not apply set_system_conf when the combined params cover all mismatches", func() {
-					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(types.NvConfigQuery{}, nil)
-					mockNVConfigUtils.On("ValidateSystemConf", ctx, portSpec(pciAddress), "conf3", 0).
-						Return(mismatchSystemConf("NUM_OF_PF")...)
-					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
-						Return(map[string]string{"NUM_OF_PF": "2"}, nil)
-					mockNVConfigUtils.On("SetNvConfigParametersBatchWithContext", mock.Anything, portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, false, true).
-						Return(types.ApplyStatusSuccess, nil)
-					mockNVConfigUtils.AssertNotCalled(GinkgoT(), "SetSystemConf", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
-
-					result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{Force: true})
-					Expect(err).NotTo(HaveOccurred())
-					Expect(result.RebootRequired).To(BeTrue())
-				})
-			})
 		})
 	})
 
@@ -1830,8 +2022,8 @@ var _ = Describe("ConfigurationManager", func() {
 			})
 		})
 
-		// Full-flow suite: real configValidation (mocked ConfigurationUtils + SpectrumXManager + NVConfigUtils)
-		// so the whole chain — system_conf validate, the rawNvConfig > Spectrum-X > template merge inside
+		// Full-flow suite: real configValidation with mocked ConfigurationUtils and NVConfigUtils
+		// so the whole chain — system_conf validate, rawNvConfig > template merge inside
 		// ConstructNvParamMapFromTemplate, coverage check, and apply — runs end to end. Each case drives BOTH
 		// ValidateDeviceNvSpec and ApplyNVConfiguration and asserts the concrete SetSystemConf /
 		// SetNvConfigParametersBatch calls. ConstructNvParamMapFromTemplate always emits SRIOV_EN=0 /
@@ -1840,7 +2032,6 @@ var _ = Describe("ConfigurationManager", func() {
 			var (
 				fullFlowHostUtils mocks.ConfigurationUtils
 				fullFlowNV        *nvconfigmocks.NVConfigUtils
-				fullFlowSpcX      *spcxmocks.SpectrumXManager
 				fullFlowManager   configurationManager
 				fullFlowCtx       context.Context
 				fullFlowDevice    *v1alpha1.NicDevice
@@ -1849,12 +2040,10 @@ var _ = Describe("ConfigurationManager", func() {
 			BeforeEach(func() {
 				fullFlowHostUtils = mocks.ConfigurationUtils{}
 				fullFlowNV = nvconfigmocks.NewNVConfigUtils(GinkgoT())
-				fullFlowSpcX = spcxmocks.NewSpectrumXManager(GinkgoT())
 				fullFlowManager = configurationManager{
-					configurationUtils:     &fullFlowHostUtils,
-					configValidation:       newConfigValidation(&fullFlowHostUtils, nil, fullFlowSpcX),
-					nvConfigUtils:          fullFlowNV,
-					spectrumXConfigManager: fullFlowSpcX,
+					configurationUtils: &fullFlowHostUtils,
+					configValidation:   newConfigValidation(&fullFlowHostUtils, nil),
+					nvConfigUtils:      fullFlowNV,
 				}
 				fullFlowCtx = context.TODO()
 				fullFlowDevice = &v1alpha1.NicDevice{
@@ -1870,8 +2059,6 @@ var _ = Describe("ConfigurationManager", func() {
 						NetworkBay: &v1alpha1.NicDeviceNetworkBayStatus{Asic: 0},
 					},
 				}
-				fullFlowSpcX.On("GetPreparedPlan", mock.Anything, spectrumx.PlanStagePrepare).
-					Return(&spectrumx.Plan{}, nil).Maybe()
 			})
 
 			// sriovStaged returns the SRIOV defaults ConstructNvParamMapFromTemplate emits for an empty
@@ -1970,98 +2157,6 @@ var _ = Describe("ConfigurationManager", func() {
 				fullFlowNV.AssertNotCalled(GinkgoT(), "SetSystemConf", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 			})
 
-			// 5) system_conf mismatch, Spectrum-X covers it and the value is already staged, no raw → converged.
-			It("5: system_conf mismatch fully covered by an already-applied Spectrum-X override converges", func() {
-				fullFlowDevice.Spec.Configuration.Template.SpectrumXOptimized = &v1alpha1.SpectrumXOptimizedSpec{Enabled: true}
-				fullFlowSpcX.On("GetBreakoutMlxConfig", fullFlowDevice).Return(map[string]string{"NUM_OF_PF": "2"}, nil)
-				fullFlowSpcX.On("GetPostBreakoutMlxConfig", fullFlowDevice).Return(nil, nil)
-				staged := sriovStaged(map[string][]string{"NUM_OF_PF": {"2"}})
-				fullFlowNV.On("QueryNvConfig", fullFlowCtx, portSpec(pciAddress), []string(nil)).Return(
-					types.NvConfigQuery{NextBootConfig: staged, CurrentConfig: staged}, nil)
-				fullFlowNV.On("ValidateSystemConf", fullFlowCtx, portSpec(pciAddress), "conf3", 0).
-					Return(mismatchSystemConf("NUM_OF_PF")...)
-
-				updateNeeded, rebootNeeded, _, err := fullFlowManager.ValidateDeviceNvSpec(fullFlowCtx, fullFlowDevice)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(updateNeeded).To(BeFalse())
-				Expect(rebootNeeded).To(BeFalse())
-
-				result, err := fullFlowManager.ApplyNVConfiguration(fullFlowCtx, fullFlowDevice, &types.ConfigurationOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(result.Status).To(Equal(types.ApplyStatusNothingToDo))
-				fullFlowNV.AssertNotCalled(GinkgoT(), "SetSystemConf", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
-				fullFlowNV.AssertNotCalled(GinkgoT(), "SetNvConfigParametersBatchWithContext", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
-			})
-
-			// 6) Spectrum-X params for the mismatched profile params are ALSO overridden by rawNvConfig (raw wins):
-			//    one already applied (NUM_OF_PF), one differs (LINK_TYPE_P1) so the raw value — not the Spectrum-X
-			//    value — is what gets applied.
-			It("6: rawNvConfig overrides Spectrum-X for the mismatched params and the raw value wins on apply", func() {
-				fullFlowDevice.Spec.Configuration.Template.SpectrumXOptimized = &v1alpha1.SpectrumXOptimizedSpec{Enabled: true}
-				fullFlowDevice.Spec.Configuration.Template.RawNvConfig = []v1alpha1.NvConfigParam{
-					{Name: "NUM_OF_PF", Value: "8"},
-					{Name: "LINK_TYPE_P1", Value: "2"},
-				}
-				fullFlowSpcX.On("GetBreakoutMlxConfig", fullFlowDevice).Return(map[string]string{"NUM_OF_PF": "2", "LINK_TYPE_P1": "1"}, nil)
-				fullFlowSpcX.On("GetPostBreakoutMlxConfig", fullFlowDevice).Return(nil, nil)
-				staged := sriovStaged(map[string][]string{"NUM_OF_PF": {"8"}, "LINK_TYPE_P1": {"1"}})
-				fullFlowNV.On("QueryNvConfig", fullFlowCtx, portSpec(pciAddress), []string(nil)).Return(
-					types.NvConfigQuery{NextBootConfig: staged, CurrentConfig: staged}, nil)
-				fullFlowNV.On("ValidateSystemConf", fullFlowCtx, portSpec(pciAddress), "conf3", 0).
-					Return(mismatchSystemConf("NUM_OF_PF", "LINK_TYPE_P1")...)
-				// Only LINK_TYPE_P1 differs from next boot; the raw value 2 wins over the Spectrum-X value 1.
-				fullFlowNV.On("SetNvConfigParametersBatchWithContext", mock.Anything, portSpec(pciAddress), map[string]string{"LINK_TYPE_P1": "2"}, false, false).
-					Return(types.ApplyStatusSuccess, nil)
-
-				updateNeeded, rebootNeeded, _, err := fullFlowManager.ValidateDeviceNvSpec(fullFlowCtx, fullFlowDevice)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(updateNeeded).To(BeTrue())
-				Expect(rebootNeeded).To(BeTrue())
-
-				result, err := fullFlowManager.ApplyNVConfiguration(fullFlowCtx, fullFlowDevice, &types.ConfigurationOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(result.Status).To(Equal(types.ApplyStatusSuccess))
-				Expect(result.RebootRequired).To(BeTrue())
-				fullFlowNV.AssertNotCalled(GinkgoT(), "SetSystemConf", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
-			})
-
-			// 7) Same as (6) but a template-derived param (NUM_OF_VFS from NumVfs) is also partly overridden by
-			//    rawNvConfig — proving raw wins over BOTH Spectrum-X (LINK_TYPE_P1) and the template (NUM_OF_VFS).
-			It("7: rawNvConfig wins over both Spectrum-X and template params in the combined apply batch", func() {
-				fullFlowDevice.Spec.Configuration.Template.NumVfs = 4 // template: SRIOV_EN=1, NUM_OF_VFS=4
-				fullFlowDevice.Spec.Configuration.Template.SpectrumXOptimized = &v1alpha1.SpectrumXOptimizedSpec{Enabled: true}
-				fullFlowDevice.Spec.Configuration.Template.RawNvConfig = []v1alpha1.NvConfigParam{
-					{Name: "NUM_OF_PF", Value: "8"},
-					{Name: "LINK_TYPE_P1", Value: "2"},
-					{Name: consts.SriovNumOfVfsParam, Value: "16"}, // raw overrides the template's NUM_OF_VFS=4
-				}
-				fullFlowSpcX.On("GetBreakoutMlxConfig", fullFlowDevice).Return(map[string]string{"NUM_OF_PF": "2", "LINK_TYPE_P1": "1"}, nil)
-				fullFlowSpcX.On("GetPostBreakoutMlxConfig", fullFlowDevice).Return(nil, nil)
-				staged := map[string][]string{
-					consts.SriovEnabledParam:  {"1"},
-					consts.SriovNumOfVfsParam: {"4"}, // template value staged; raw wants 16
-					"NUM_OF_PF":               {"8"},
-					"LINK_TYPE_P1":            {"1"}, // Spectrum-X value staged; raw wants 2
-				}
-				fullFlowNV.On("QueryNvConfig", fullFlowCtx, portSpec(pciAddress), []string(nil)).Return(
-					types.NvConfigQuery{NextBootConfig: staged, CurrentConfig: staged}, nil)
-				fullFlowNV.On("ValidateSystemConf", fullFlowCtx, portSpec(pciAddress), "conf3", 0).
-					Return(mismatchSystemConf("NUM_OF_PF", "LINK_TYPE_P1")...)
-				// Raw wins on both: LINK_TYPE_P1 over Spectrum-X (1→2) and NUM_OF_VFS over template (4→16).
-				fullFlowNV.On("SetNvConfigParametersBatchWithContext", mock.Anything, portSpec(pciAddress),
-					map[string]string{"LINK_TYPE_P1": "2", consts.SriovNumOfVfsParam: "16"}, false, false).Return(types.ApplyStatusSuccess, nil)
-
-				updateNeeded, rebootNeeded, _, err := fullFlowManager.ValidateDeviceNvSpec(fullFlowCtx, fullFlowDevice)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(updateNeeded).To(BeTrue())
-				Expect(rebootNeeded).To(BeTrue())
-
-				result, err := fullFlowManager.ApplyNVConfiguration(fullFlowCtx, fullFlowDevice, &types.ConfigurationOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(result.Status).To(Equal(types.ApplyStatusSuccess))
-				Expect(result.RebootRequired).To(BeTrue())
-				fullFlowNV.AssertNotCalled(GinkgoT(), "SetSystemConf", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
-			})
 		})
 	})
 })

--- a/pkg/configuration/spectrumx_nvconfig.go
+++ b/pkg/configuration/spectrumx_nvconfig.go
@@ -1,0 +1,193 @@
+/*
+Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configuration
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/Mellanox/nic-configuration-operator/api/v1alpha1"
+	"github.com/Mellanox/nic-configuration-operator/pkg/dmscli"
+	"github.com/Mellanox/nic-configuration-operator/pkg/spectrumx"
+	"github.com/Mellanox/nic-configuration-operator/pkg/types"
+)
+
+const (
+	spectrumXNVConfigPhaseBreakout     = "breakout"
+	spectrumXNVConfigPhasePostBreakout = "post-breakout"
+)
+
+type spectrumXNVConfigUtils interface {
+	ValidateNvConfigXPaths(
+		ctx context.Context,
+		ports []v1alpha1.NicDevicePortSpec,
+		operations []dmscli.XPathOperation,
+	) (updateNeeded, rebootNeeded bool, err error)
+	SetNvConfigParametersBatchWithXPaths(
+		ctx context.Context,
+		primaryPort v1alpha1.NicDevicePortSpec,
+		portCount int,
+		params map[string]string,
+		operations []dmscli.XPathOperation,
+		withDefault bool,
+		force bool,
+	) (types.ApplyStatus, error)
+}
+
+func (h configurationManager) preparedSpectrumXPlan(
+	device *v1alpha1.NicDevice,
+	stage spectrumx.PlanStage,
+) (*spectrumx.Plan, error) {
+	if !spectrumXEnabled(device) {
+		return nil, nil
+	}
+	if h.spectrumXConfigManager == nil {
+		return nil, fmt.Errorf(
+			"matching doSPCX %s plan is required for device %q: Spectrum-X manager is not configured",
+			stage, device.Name)
+	}
+	plan, err := h.spectrumXConfigManager.GetPreparedPlan(device, stage)
+	if err != nil {
+		return nil, fmt.Errorf("matching doSPCX %s plan is required for device %q: %w", stage, device.Name, err)
+	}
+	return plan, nil
+}
+
+func (h configurationManager) spectrumXNVConfigUtils(device *v1alpha1.NicDevice) (spectrumXNVConfigUtils, error) {
+	utils, ok := h.nvConfigUtils.(spectrumXNVConfigUtils)
+	if !ok {
+		return nil, fmt.Errorf(
+			"doSPCX NVConfig is not supported by the configured NVConfig utility for device %q", device.Name)
+	}
+	return utils, nil
+}
+
+func (h configurationManager) preparedSpectrumXNVConfig(
+	device *v1alpha1.NicDevice,
+) (*spectrumx.Plan, spectrumXNVConfigUtils, error) {
+	plan, err := h.preparedSpectrumXPlan(device, spectrumx.PlanStagePrepare)
+	if err != nil || plan == nil {
+		return plan, nil, err
+	}
+	utils, err := h.spectrumXNVConfigUtils(device)
+	return plan, utils, err
+}
+
+// validateSpectrumXNVConfigCompatibility rejects combinations whose native
+// NVConfig ownership cannot yet be reconciled with typed doSPCX operations.
+//
+// TODO(dospcx-nvconfig): HIGH PRIORITY -- restore rawNvConfig and Network Bay
+// support ASAP once DMS can validate their combined native/typed state.
+func validateSpectrumXNVConfigCompatibility(device *v1alpha1.NicDevice) error {
+	if !spectrumXEnabled(device) || device.Spec.Configuration.ResetToDefault {
+		return nil
+	}
+	template := device.Spec.Configuration.Template
+	if len(template.RawNvConfig) > 0 {
+		return types.IncorrectSpecError(
+			"rawNvConfig cannot currently be combined with spectrumXOptimized")
+	}
+	if template.NetworkBay != nil {
+		return types.IncorrectSpecError(
+			"networkBay cannot currently be combined with spectrumXOptimized")
+	}
+	return nil
+}
+
+func (h configurationManager) spectrumXNVConfigPhase(
+	ctx context.Context,
+	device *v1alpha1.NicDevice,
+	plan *spectrumx.Plan,
+) (phase string, updateNeeded, rebootNeeded bool, err error) {
+	utils, err := h.spectrumXNVConfigUtils(device)
+	if err != nil {
+		return "", false, false, err
+	}
+	validate := func(phase string, operations []dmscli.XPathOperation) (string, bool, bool, error) {
+		log.FromContext(ctx).V(2).Info("validating doSPCX NVConfig phase",
+			"device", device.Name,
+			"phase", phase,
+			"operations", len(operations),
+			"ports", len(device.Status.Ports))
+		updateNeeded, rebootNeeded, err := utils.ValidateNvConfigXPaths(
+			ctx, device.Status.Ports, operations)
+		if err != nil {
+			return "", false, false, fmt.Errorf(
+				"validate doSPCX %s NVConfig for device %q: %w", phase, device.Name, err)
+		}
+		return phase, updateNeeded, rebootNeeded, nil
+	}
+
+	if len(plan.Breakout) > 0 {
+		phase, updateNeeded, rebootNeeded, err = validate(spectrumXNVConfigPhaseBreakout, plan.Breakout)
+		if err != nil || rebootNeeded {
+			return phase, updateNeeded, rebootNeeded, err
+		}
+	}
+	return validate(spectrumXNVConfigPhasePostBreakout, plan.PostBreakout)
+}
+
+// verifySpectrumXSecondaryNVConfigStaged prevents a successful primary-target
+// apply from hiding drift on split PCI functions. DMS currently executes one
+// mlxconfig command on the primary BDF, so its success response alone cannot
+// prove that every secondary function's pending state converged.
+func (h configurationManager) verifySpectrumXSecondaryNVConfigStaged(
+	ctx context.Context,
+	device *v1alpha1.NicDevice,
+	utils spectrumXNVConfigUtils,
+	desiredParams map[string]string,
+	typedOperations []dmscli.XPathOperation,
+) error {
+	if len(device.Status.Ports) < 2 {
+		return nil
+	}
+	secondaryPorts := device.Status.Ports[1:]
+	logger := log.FromContext(ctx)
+	logger.V(2).Info("verifying doSPCX NVConfig pending state on secondary PCI functions",
+		"device", device.Name,
+		"secondaryFunctions", len(secondaryPorts),
+		"nativeParameters", len(desiredParams),
+		"typedOperations", len(typedOperations))
+
+	if len(typedOperations) > 0 {
+		updateNeeded, _, err := utils.ValidateNvConfigXPaths(ctx, secondaryPorts, typedOperations)
+		if err != nil {
+			return fmt.Errorf("verify typed NVConfig on secondary PCI functions: %w", err)
+		}
+		if updateNeeded {
+			return fmt.Errorf("DMS primary-target apply did not stage typed NVConfig on every secondary PCI function")
+		}
+	}
+	if len(desiredParams) == 0 {
+		return nil
+	}
+
+	for _, port := range secondaryPorts {
+		nvConfig, err := h.nvConfigUtils.QueryNvConfig(ctx, port, nil)
+		if err != nil {
+			return fmt.Errorf("verify native NVConfig on secondary PCI function %q: %w", port.PCI, err)
+		}
+		updateNeeded, _, _ := validateTemplateParamsApplied(
+			map[string]types.NvConfigQuery{port.PCI: nvConfig}, desiredParams)
+		if updateNeeded {
+			return fmt.Errorf(
+				"DMS primary-target apply did not stage native NVConfig on secondary PCI function %q", port.PCI)
+		}
+	}
+	return nil
+}

--- a/pkg/nvconfig/utils.go
+++ b/pkg/nvconfig/utils.go
@@ -19,6 +19,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"reflect"
 	"regexp"
 	"sort"
 	"strings"
@@ -34,7 +35,8 @@ import (
 )
 
 const (
-	arrayPrefix = "Array"
+	arrayPrefix        = "Array"
+	xPathPendingSuffix = "-pending"
 )
 
 func parseMLXConfigValue(value string, valueInBracketsRegex *regexp.Regexp) []string {
@@ -67,7 +69,7 @@ type NVConfigUtils interface {
 	// ValidateSystemConf reports whether the device's applied configuration matches the named system
 	// configuration for the given ASIC via `mlxconfig -d <device> -y validate_system_conf <conf>[<asic>]`.
 	// It returns the overall match bit plus the names of the mismatched params (the MISMATCH rows), so
-	// callers that allow explicit overrides (e.g. rawNvConfig / Spectrum-X) on top of a named system conf
+	// callers that allow explicit rawNvConfig overrides on top of a named system conf
 	// can decide whether a reported mismatch is an intentional override or real drift requiring re-apply.
 	ValidateSystemConf(ctx context.Context, port v1alpha1.NicDevicePortSpec, conf string, asic int) (bool, []string, error)
 }
@@ -230,17 +232,10 @@ func (h *nvConfigUtils) SetNvConfigParametersBatchWithContext(
 	withDefault bool,
 	force bool,
 ) (types.ApplyStatus, error) {
-	if len(params) == 0 {
-		return types.ApplyStatusNothingToDo, nil
-	}
-	if h.execInterface == nil {
-		return types.ApplyStatusFailed, fmt.Errorf("command executor must not be nil")
-	}
+	return h.setNvConfigParametersBatchWithXPaths(ctx, port, nil, params, nil, withDefault, force)
+}
 
-	target := "pci/" + port.PCI
-	log.Log.Info("ConfigurationUtils.SetNvConfigParametersBatch()", "pciAddr", port.PCI, "target", target, "params", params, "withDefault", withDefault, "force", force)
-
-	// Build a sorted raw list to preserve deterministic batch construction.
+func sortedRawNVConfigParams(params map[string]string) []dmscli.NVConfigParam {
 	paramNames := make([]string, 0, len(params))
 	for name := range params {
 		paramNames = append(paramNames, name)
@@ -251,18 +246,53 @@ func (h *nvConfigUtils) SetNvConfigParametersBatchWithContext(
 	for _, name := range paramNames {
 		raw = append(raw, dmscli.NVConfigParam{Param: name, Value: params[name]})
 	}
+	return raw
+}
+
+func (h *nvConfigUtils) setNvConfigParametersBatchWithXPaths(
+	ctx context.Context,
+	primaryPort v1alpha1.NicDevicePortSpec,
+	ports []int,
+	params map[string]string,
+	operations []dmscli.XPathOperation,
+	withDefault bool,
+	force bool,
+) (types.ApplyStatus, error) {
+	if len(params) == 0 && len(operations) == 0 {
+		return types.ApplyStatusNothingToDo, nil
+	}
+	if h.execInterface == nil {
+		return types.ApplyStatusFailed, fmt.Errorf("command executor must not be nil")
+	}
+
+	target := "pci/" + primaryPort.PCI
+	logger := logr.FromContextOrDiscard(ctx)
+	logger.Info("applying NVConfig through DMS",
+		"pciAddr", primaryPort.PCI,
+		"target", target,
+		"ports", ports,
+		"nativeParameterCount", len(params),
+		"typedOperationCount", len(operations),
+		"withDefault", withDefault,
+		"force", force)
+	logger.V(2).Info("DMS NVConfig apply payload",
+		"target", target,
+		"nativeParameters", params,
+		"typedOperations", operations)
 
 	result, err := dmscli.ApplyNVConfig(ctx, h.execInterface, dmscli.ApplyNVConfigRequest{
 		Target:      target,
-		Raw:         raw,
+		Ports:       ports,
+		Typed:       operations,
+		Raw:         sortedRawNVConfigParams(params),
 		WithDefault: withDefault,
 		Force:       force,
 	})
 	if err != nil {
-		log.Log.Error(err, "SetNvConfigParametersBatch(): DMS NVConfig apply failed", "target", target)
+		logger.Error(err, "DMS NVConfig apply failed", "target", target)
 		return types.ApplyStatusFailed, err
 	}
-	log.Log.V(2).Info("DMS NVConfig apply succeeded",
+	logger.V(2).Info("DMS NVConfig apply succeeded",
 		"target", target,
 		"primaryTarget", result.PrimaryTarget,
 		"compiledCount", result.CompiledCount,
@@ -274,6 +304,196 @@ func (h *nvConfigUtils) SetNvConfigParametersBatchWithContext(
 		return types.ApplyStatusSuccess, nil
 	}
 	return types.ApplyStatusNothingToDo, nil
+}
+
+// ValidateNvConfigXPaths checks current and pending typed NVConfig values on
+// every PCI function. Split functions expose their NVConfig as port 1.
+func (h *nvConfigUtils) ValidateNvConfigXPaths(
+	ctx context.Context,
+	ports []v1alpha1.NicDevicePortSpec,
+	operations []dmscli.XPathOperation,
+) (updateNeeded, rebootNeeded bool, err error) {
+	if len(operations) == 0 {
+		return false, false, nil
+	}
+	logger := logr.FromContextOrDiscard(ctx)
+	queries := xpathQueries(operations)
+	queryBatches := xpathQueryBatches(queries)
+	logger.V(2).Info("validating doSPCX NVConfig on all device ports",
+		"ports", len(ports),
+		"operations", len(operations),
+		"queryPaths", len(queries),
+		"batchesPerPort", len(queryBatches))
+	for _, port := range ports {
+		target := "pci/" + port.PCI + "?port=1"
+		logger.V(2).Info("querying doSPCX NVConfig state for device port",
+			"pciAddr", port.PCI,
+			"target", target,
+			"batches", len(queryBatches))
+		result := &dmscli.QueryXPathsResult{Status: "ok", Values: map[string]map[string]any{}}
+		for batchIndex, queryBatch := range queryBatches {
+			logger.V(2).Info("querying doSPCX NVConfig batch",
+				"target", target,
+				"batch", batchIndex+1,
+				"totalBatches", len(queryBatches),
+				"paths", len(queryBatch))
+			batchResult, queryErr := dmscli.QueryXPaths(ctx, h.execInterface, target, queryBatch)
+			if queryErr != nil {
+				return false, false, fmt.Errorf("query NVConfig XPaths on target %q: %w", target, queryErr)
+			}
+			for path, values := range batchResult.Values {
+				result.Values[path] = values
+			}
+		}
+		portUpdateNeeded, portRebootNeeded, matchErr := matchXPathValues(result, operations)
+		if matchErr != nil {
+			return false, false, fmt.Errorf("validate NVConfig XPaths on target %q: %w", target, matchErr)
+		}
+		updateNeeded = updateNeeded || portUpdateNeeded
+		rebootNeeded = rebootNeeded || portRebootNeeded
+		logger.V(2).Info("doSPCX NVConfig validation complete for device port",
+			"pciAddr", port.PCI,
+			"target", target,
+			"configUpdateNeeded", portUpdateNeeded,
+			"rebootNeeded", portRebootNeeded)
+	}
+	logger.V(2).Info("doSPCX NVConfig validation complete for all device ports",
+		"ports", len(ports),
+		"configUpdateNeeded", updateNeeded,
+		"rebootNeeded", rebootNeeded)
+	return updateNeeded, rebootNeeded, nil
+}
+
+func xpathQueries(operations []dmscli.XPathOperation) []dmscli.XPathQuery {
+	queries := make([]dmscli.XPathQuery, 0, len(operations))
+	indices := map[string]int{}
+	leaves := map[string]map[string]struct{}{}
+	for _, operation := range operations {
+		if _, found := leaves[operation.Path]; !found {
+			indices[operation.Path] = len(queries)
+			leaves[operation.Path] = map[string]struct{}{}
+			queries = append(queries, dmscli.XPathQuery{Path: operation.Path})
+		}
+		for leaf := range operation.Values {
+			leaves[operation.Path][leaf] = struct{}{}
+			leaves[operation.Path][leaf+xPathPendingSuffix] = struct{}{}
+		}
+	}
+	for path, pathLeaves := range leaves {
+		query := &queries[indices[path]]
+		for leaf := range pathLeaves {
+			query.Leaves = append(query.Leaves, leaf)
+		}
+		sort.Strings(query.Leaves)
+	}
+	return queries
+}
+
+// TODO(dospcx-nvconfig): Remove the individual breakout-lane queries once
+// dms-cli preserves indexed XPath keys in batched JSON GET responses. Today
+// paths ending in port/[1] and port/[255] both return as .../module/port and
+// overwrite each other in the response object.
+func xpathQueryBatches(queries []dmscli.XPathQuery) [][]dmscli.XPathQuery {
+	batched := make([]dmscli.XPathQuery, 0, len(queries))
+	individual := make([][]dmscli.XPathQuery, 0)
+	for _, query := range queries {
+		if strings.HasPrefix(query.Path, "/nvidia/link/breakout/") {
+			individual = append(individual, []dmscli.XPathQuery{query})
+			continue
+		}
+		batched = append(batched, query)
+	}
+	if len(batched) == 0 {
+		return individual
+	}
+	return append([][]dmscli.XPathQuery{batched}, individual...)
+}
+
+func matchXPathValues(result *dmscli.QueryXPathsResult, operations []dmscli.XPathOperation) (updateNeeded, rebootNeeded bool, err error) {
+	if result == nil {
+		return false, false, fmt.Errorf("DMS returned a nil XPath query result")
+	}
+	for _, operation := range operations {
+		values, found := result.Values[operation.Path]
+		if !found {
+			return false, false, fmt.Errorf("DMS response does not contain XPath %q", operation.Path)
+		}
+		for leaf, desired := range operation.Values {
+			current, found := values[leaf]
+			if !found {
+				return false, false, fmt.Errorf("DMS response does not contain XPath leaf %q/%s", operation.Path, leaf)
+			}
+			pendingLeaf := leaf + xPathPendingSuffix
+			pending, found := values[pendingLeaf]
+			if !found {
+				return false, false, fmt.Errorf("DMS response does not contain XPath leaf %q/%s", operation.Path, pendingLeaf)
+			}
+			currentMatches := xpathValuesEqual(current, desired)
+			pendingMatches := xpathValuesEqual(pending, desired)
+			updateNeeded = updateNeeded || !pendingMatches
+			rebootNeeded = rebootNeeded || !currentMatches || !pendingMatches
+		}
+	}
+	return updateNeeded, rebootNeeded, nil
+}
+
+func xpathValuesEqual(actual, desired any) bool {
+	normalizedActual := normalizeXPathValue(actual)
+	normalizedDesired := normalizeXPathValue(desired)
+	if _, desiredIsList := normalizedDesired.([]any); desiredIsList {
+		if actualString, actualIsString := normalizedActual.(string); actualIsString {
+			parts := strings.Split(actualString, ",")
+			actualList := make([]any, len(parts))
+			for index, part := range parts {
+				actualList[index] = normalizeXPathValue(part)
+			}
+			normalizedActual = actualList
+		}
+	}
+	return reflect.DeepEqual(normalizedActual, normalizedDesired)
+}
+
+func normalizeXPathValue(value any) any {
+	if value == nil {
+		return nil
+	}
+	reflected := reflect.ValueOf(value)
+	if reflected.Kind() == reflect.Array || reflected.Kind() == reflect.Slice {
+		result := make([]any, reflected.Len())
+		for index := 0; index < reflected.Len(); index++ {
+			result[index] = normalizeXPathValue(reflected.Index(index).Interface())
+		}
+		return result
+	}
+
+	formatted := strings.ToLower(strings.TrimSpace(fmt.Sprint(value)))
+	formatted = strings.TrimSuffix(formatted, "_value")
+	return strings.TrimPrefix(formatted, "device_")
+}
+
+// SetNvConfigParametersBatchWithXPaths applies native parameters and typed
+// XPath operations through one primary-target dms-cli invocation.
+//
+// TODO(dospcx-nvconfig): HIGH PRIORITY -- pass the discovered BDF set once
+// /nvidia/nvconfig/apply supports multi-target execution. The current DMS API
+// uses ports only to expand {port} in native parameter names and runs one
+// mlxconfig command on the primary BDF, so it cannot fan out to split PCI
+// functions represented as separate NicDevice ports.
+func (h *nvConfigUtils) SetNvConfigParametersBatchWithXPaths(
+	ctx context.Context,
+	primaryPort v1alpha1.NicDevicePortSpec,
+	portCount int,
+	params map[string]string,
+	operations []dmscli.XPathOperation,
+	withDefault bool,
+	force bool,
+) (types.ApplyStatus, error) {
+	ports := make([]int, portCount)
+	for index := range ports {
+		ports[index] = index + 1
+	}
+	return h.setNvConfigParametersBatchWithXPaths(
+		ctx, primaryPort, ports, params, operations, withDefault, force)
 }
 
 // systemConfToken builds the `<conf>[<asic>]` argument for set/validate_system_conf, e.g. conf3[0].

--- a/pkg/nvconfig/utils_test.go
+++ b/pkg/nvconfig/utils_test.go
@@ -726,4 +726,170 @@ Result: Device configuration does NOT match the system configuration.
 			Expect(err).To(MatchError("command executor must not be nil"))
 		})
 	})
+
+	Describe("typed NVConfig XPaths", func() {
+		const pciAddress = "0000:3b:00.0"
+		operations := []dmscli.XPathOperation{{
+			Path: "/nvidia/pci", Values: map[string]any{"num-pfs": 2},
+		}}
+
+		DescribeTable("normalizes equivalent values",
+			func(actual, desired any) { Expect(xpathValuesEqual(actual, desired)).To(BeTrue()) },
+			Entry("enum case", "ETH", "eth"),
+			Entry("enum suffix", "ENABLED_VALUE", "enabled"),
+			Entry("device prefix", "DEVICE_DEFAULT", "default"),
+			Entry("number", json.Number("48"), 48),
+			Entry("negative number", json.Number("-1"), -1),
+			Entry("list", []any{json.Number("0"), json.Number("1")}, []int{0, 1}),
+			Entry("comma-separated leaf list", "0,1,2,3", []int{0, 1, 2, 3}),
+		)
+
+		It("deduplicates repeated paths and leaves for one query", func() {
+			queries := xpathQueries(append(operations, dmscli.XPathOperation{
+				Path: "/nvidia/pci", Values: map[string]any{"num-pfs": 2, "rde-disable": true},
+			}))
+
+			Expect(queries).To(Equal([]dmscli.XPathQuery{{
+				Path: "/nvidia/pci",
+				Leaves: []string{
+					"num-pfs", "num-pfs-pending", "rde-disable", "rde-disable-pending",
+				},
+			}}))
+		})
+
+		It("distinguishes pending drift from current-only drift", func() {
+			result := &dmscli.QueryXPathsResult{Values: map[string]map[string]any{
+				"/nvidia/pci": {"num-pfs": 1, "num-pfs-pending": 2},
+			}}
+
+			updateNeeded, rebootNeeded, err := matchXPathValues(result, operations)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updateNeeded).To(BeFalse())
+			Expect(rebootNeeded).To(BeTrue())
+		})
+
+		It("rejects a response missing a requested pending value", func() {
+			result := &dmscli.QueryXPathsResult{Values: map[string]map[string]any{
+				"/nvidia/pci": {"num-pfs": 2},
+			}}
+
+			_, _, err := matchXPathValues(result, operations)
+
+			Expect(err).To(MatchError(ContainSubstring("num-pfs-pending")))
+		})
+
+		It("validates every available PCI function as port 1", func() {
+			var commandArgs [][]string
+			command := func(_ string, args ...string) exec.Cmd {
+				commandArgs = append(commandArgs, append([]string(nil), args...))
+				cmd := &execTesting.FakeCmd{}
+				cmd.RunScript = append(cmd.RunScript, func() ([]byte, []byte, error) {
+					return []byte(`{"num-pfs":2,"num-pfs-pending":2}`), nil, nil
+				})
+				return cmd
+			}
+			h := &nvConfigUtils{execInterface: &execTesting.FakeExec{
+				CommandScript: []execTesting.FakeCommandAction{command, command},
+			}}
+
+			updateNeeded, rebootNeeded, err := h.ValidateNvConfigXPaths(
+				context.Background(),
+				[]v1alpha1.NicDevicePortSpec{nvconfigPort(pciAddress), nvconfigPort("0000:3b:00.1")},
+				operations)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updateNeeded).To(BeFalse())
+			Expect(rebootNeeded).To(BeFalse())
+			Expect(commandArgs[0][0:4]).To(Equal([]string{"--json", "-t", "pci/" + pciAddress + "?port=1", "/nvidia/pci"}))
+			Expect(commandArgs[1][0:4]).To(Equal([]string{"--json", "-t", "pci/0000:3b:00.1?port=1", "/nvidia/pci"}))
+		})
+
+		It("queries indexed breakout lanes separately from the remaining XPaths", func() {
+			var commandArgs [][]string
+			outputs := [][]byte{
+				[]byte(`{"num-pfs":2,"num-pfs-pending":2}`),
+				[]byte(`{"lanes":"0,1,2,3,4,5,6,7","lanes-pending":"0,1,2,3,4,5,6,7"}`),
+				[]byte(`{"lanes":"8,9,10,11,12,13,14,15","lanes-pending":"8,9,10,11,12,13,14,15"}`),
+			}
+			commands := make([]execTesting.FakeCommandAction, len(outputs))
+			for index := range outputs {
+				output := outputs[index]
+				commands[index] = func(_ string, args ...string) exec.Cmd {
+					commandArgs = append(commandArgs, append([]string(nil), args...))
+					cmd := &execTesting.FakeCmd{}
+					cmd.RunScript = append(cmd.RunScript, func() ([]byte, []byte, error) {
+						return output, nil, nil
+					})
+					return cmd
+				}
+			}
+			h := &nvConfigUtils{execInterface: &execTesting.FakeExec{CommandScript: commands}}
+			lane1 := "/nvidia/link/breakout/module/[0]/port/[1]"
+			lane255 := "/nvidia/link/breakout/module/[0]/port/[255]"
+			planOperations := []dmscli.XPathOperation{
+				{Path: "/nvidia/pci", Values: map[string]any{"num-pfs": 2}},
+				{Path: lane1, Values: map[string]any{"lanes": []int{0, 1, 2, 3, 4, 5, 6, 7}}},
+				{Path: lane255, Values: map[string]any{"lanes": []int{8, 9, 10, 11, 12, 13, 14, 15}}},
+			}
+
+			updateNeeded, rebootNeeded, err := h.ValidateNvConfigXPaths(
+				context.Background(), []v1alpha1.NicDevicePortSpec{nvconfigPort(pciAddress)}, planOperations)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updateNeeded).To(BeFalse())
+			Expect(rebootNeeded).To(BeFalse())
+			Expect(commandArgs).To(HaveLen(3))
+			Expect(commandArgs[0]).To(Equal([]string{
+				"--json", "-t", "pci/" + pciAddress + "?port=1",
+				"/nvidia/pci", "num-pfs", "num-pfs-pending",
+			}))
+			Expect(commandArgs[1]).To(Equal([]string{
+				"--json", "-t", "pci/" + pciAddress + "?port=1",
+				lane1, "lanes", "lanes-pending",
+			}))
+			Expect(commandArgs[2]).To(Equal([]string{
+				"--json", "-t", "pci/" + pciAddress + "?port=1",
+				lane255, "lanes", "lanes-pending",
+			}))
+		})
+
+		It("applies raw and typed NVConfig together with all-port fanout and flags", func() {
+			var commandArgs []string
+			cmd := &execTesting.FakeCmd{}
+			cmd.RunScript = append(cmd.RunScript, func() ([]byte, []byte, error) {
+				return []byte(`{"status":"ok","requires-reset":true}`), nil, nil
+			})
+			h := &nvConfigUtils{execInterface: &execTesting.FakeExec{
+				CommandScript: []execTesting.FakeCommandAction{func(_ string, args ...string) exec.Cmd {
+					commandArgs = append([]string(nil), args...)
+					return cmd
+				}},
+			}}
+
+			status, err := h.SetNvConfigParametersBatchWithXPaths(
+				context.Background(),
+				nvconfigPort(pciAddress),
+				2,
+				map[string]string{"RAW_PARAM": "raw-value"},
+				operations,
+				true,
+				true)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).To(Equal(types.ApplyStatusSuccess))
+			Expect(commandArgs[0:4]).To(Equal([]string{"--json", "-t", "pci/" + pciAddress, "--input"}))
+			Expect(commandArgs[5]).To(Equal("/nvidia/nvconfig/apply"))
+
+			var payload dmscli.ApplyNVConfigRequest
+			Expect(json.Unmarshal([]byte(commandArgs[4]), &payload)).To(Succeed())
+			Expect(payload.Ports).To(Equal([]int{1, 2}))
+			Expect(payload.Typed).To(Equal([]dmscli.XPathOperation{{
+				Path: "/nvidia/pci", Values: map[string]any{"num-pfs": float64(2)},
+			}}))
+			Expect(payload.Raw).To(Equal([]dmscli.NVConfigParam{{Param: "RAW_PARAM", Value: "raw-value"}}))
+			Expect(payload.WithDefault).To(BeTrue())
+			Expect(payload.Force).To(BeTrue())
+		})
+	})
 })


### PR DESCRIPTION
## Summary

- keep the existing mlxconfig query and template/raw validation path
- query the active doSPCX prepare phase separately through DMS on each logical port of the primary PCI target
- preserve the breakout reboot barrier before validating or applying post-breakout operations
- apply raw NVConfig and the active doSPCX XPath phase in one DMS NVConfig action through the primary PF
- include every available logical port in the DMS ports payload; DMS compiles typed mappings first and explicit raw parameters take precedence
- preserve with-default and force on the combined action, while leaving non-Spectrum-X per-PF behavior unchanged
- expose the combined XPath support as an additive optional NVConfig utility interface for library compatibility
- report node-scoped plan preparation failures on affected NicDevice conditions

## Validation

- go test ./pkg/dmscli ./pkg/nvconfig ./pkg/configuration -count=1
- go test -race ./pkg/dmscli ./pkg/nvconfig ./pkg/configuration -count=1
- focused controller specs for plan failure status and firmware-maintenance behavior
- make lint
- go build ./...

The full local controller suite reached 102/103 twice and failed in two different pre-existing asynchronous firmware-status tests. Both failing specs pass when run independently; CI remains the authoritative full-suite run.