### PR TITLE
feat: apply Network Bay profiles as mlxconfig parameters

### DIFF
--- a/api/v1alpha1/nicconfigurationtemplate_types.go
+++ b/api/v1alpha1/nicconfigurationtemplate_types.go
@@ -162,9 +162,9 @@ type NvConfigParam struct {
 // must be configured as a pair. Allowed only when nicSelector.nicType == "1025"
 // (ConnectX-9), enforced by CEL on NicConfigurationTemplateSpec.
 type NetworkBaySpec struct {
-	// Conf is the <conf_name> argument passed to `mlxconfig set_system_conf`.
-	// The per-ASIC index is appended automatically by the daemon based on the
-	// device's detected Network Bay ASIC index, e.g. set_system_conf <conf>[0].
+	// Conf is the mlxconfig system configuration profile name. The daemon resolves
+	// the profile parameters for the device's detected Network Bay ASIC and manages
+	// them through the regular mlxconfig validation and apply flow.
 	Conf string `json:"conf"`
 }
 
@@ -193,16 +193,14 @@ type ConfigurationTemplateSpec struct {
 	RuntimePerformanceOptimized *RuntimePerformanceOptimizedSpec `json:"runtimePerformanceOptimized,omitempty"`
 	// Spectrum-X optimization settings. Works only with linkType==Ethernet && numVfs==1. RawNvConfig parameters, if provided, are merged as overrides on top of Spectrum-X calculated params.
 	SpectrumXOptimized *SpectrumXOptimizedSpec `json:"spectrumXOptimized,omitempty"`
-	// NetworkBay configures a ConnectX-9 Network Bay card (per-ASIC set_system_conf). Allowed only for ConnectX-9 (nicType 1025).
+	// NetworkBay configures a ConnectX-9 Network Bay card from a per-ASIC mlxconfig system profile. Allowed only for ConnectX-9 (nicType 1025).
 	// +optional
 	NetworkBay *NetworkBaySpec `json:"networkBay,omitempty"`
 	// List of arbitrary nv config parameters
 	// +kubebuilder:validation:MaxItems=128
 	RawNvConfig []NvConfigParam `json:"rawNvConfig,omitempty"`
-	// Force passes `--force` to mlxconfig set commands. When set, the daemon
-	// applies the nv config batch and set_system_conf with --force, letting
-	// mlxconfig accept a batch it would otherwise refuse due to implicit
-	// parameter dependencies.
+	// Force passes `--force` to mlxconfig set commands, letting mlxconfig accept
+	// a batch it would otherwise refuse due to implicit parameter dependencies.
 	// +optional
 	// +kubebuilder:default:=false
 	Force bool `json:"force,omitempty"`

--- a/config/crd/bases/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
+++ b/config/crd/bases/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
@@ -95,10 +95,8 @@ spec:
                   force:
                     default: false
                     description: |-
-                      Force passes `--force` to mlxconfig set commands. When set, the daemon
-                      applies the nv config batch and set_system_conf with --force, letting
-                      mlxconfig accept a batch it would otherwise refuse due to implicit
-                      parameter dependencies.
+                      Force passes `--force` to mlxconfig set commands, letting mlxconfig accept
+                      a batch it would otherwise refuse due to implicit parameter dependencies.
                     type: boolean
                   gpuDirectOptimized:
                     description: GPU Direct optimization settings
@@ -123,14 +121,14 @@ spec:
                     type: string
                   networkBay:
                     description: NetworkBay configures a ConnectX-9 Network Bay card
-                      (per-ASIC set_system_conf). Allowed only for ConnectX-9 (nicType
-                      1025).
+                      from a per-ASIC mlxconfig system profile. Allowed only for ConnectX-9
+                      (nicType 1025).
                     properties:
                       conf:
                         description: |-
-                          Conf is the <conf_name> argument passed to `mlxconfig set_system_conf`.
-                          The per-ASIC index is appended automatically by the daemon based on the
-                          device's detected Network Bay ASIC index, e.g. set_system_conf <conf>[0].
+                          Conf is the mlxconfig system configuration profile name. The daemon resolves
+                          the profile parameters for the device's detected Network Bay ASIC and manages
+                          them through the regular mlxconfig validation and apply flow.
                         type: string
                     required:
                     - conf

--- a/config/crd/bases/configuration.net.nvidia.com_nicdevices.yaml
+++ b/config/crd/bases/configuration.net.nvidia.com_nicdevices.yaml
@@ -61,10 +61,8 @@ spec:
                       force:
                         default: false
                         description: |-
-                          Force passes `--force` to mlxconfig set commands. When set, the daemon
-                          applies the nv config batch and set_system_conf with --force, letting
-                          mlxconfig accept a batch it would otherwise refuse due to implicit
-                          parameter dependencies.
+                          Force passes `--force` to mlxconfig set commands, letting mlxconfig accept
+                          a batch it would otherwise refuse due to implicit parameter dependencies.
                         type: boolean
                       gpuDirectOptimized:
                         description: GPU Direct optimization settings
@@ -89,14 +87,14 @@ spec:
                         type: string
                       networkBay:
                         description: NetworkBay configures a ConnectX-9 Network Bay
-                          card (per-ASIC set_system_conf). Allowed only for ConnectX-9
-                          (nicType 1025).
+                          card from a per-ASIC mlxconfig system profile. Allowed only
+                          for ConnectX-9 (nicType 1025).
                         properties:
                           conf:
                             description: |-
-                              Conf is the <conf_name> argument passed to `mlxconfig set_system_conf`.
-                              The per-ASIC index is appended automatically by the daemon based on the
-                              device's detected Network Bay ASIC index, e.g. set_system_conf <conf>[0].
+                              Conf is the mlxconfig system configuration profile name. The daemon resolves
+                              the profile parameters for the device's detected Network Bay ASIC and manages
+                              them through the regular mlxconfig validation and apply flow.
                             type: string
                         required:
                         - conf

--- a/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
+++ b/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
@@ -95,10 +95,8 @@ spec:
                   force:
                     default: false
                     description: |-
-                      Force passes `--force` to mlxconfig set commands. When set, the daemon
-                      applies the nv config batch and set_system_conf with --force, letting
-                      mlxconfig accept a batch it would otherwise refuse due to implicit
-                      parameter dependencies.
+                      Force passes `--force` to mlxconfig set commands, letting mlxconfig accept
+                      a batch it would otherwise refuse due to implicit parameter dependencies.
                     type: boolean
                   gpuDirectOptimized:
                     description: GPU Direct optimization settings
@@ -123,14 +121,14 @@ spec:
                     type: string
                   networkBay:
                     description: NetworkBay configures a ConnectX-9 Network Bay card
-                      (per-ASIC set_system_conf). Allowed only for ConnectX-9 (nicType
-                      1025).
+                      from a per-ASIC mlxconfig system profile. Allowed only for ConnectX-9
+                      (nicType 1025).
                     properties:
                       conf:
                         description: |-
-                          Conf is the <conf_name> argument passed to `mlxconfig set_system_conf`.
-                          The per-ASIC index is appended automatically by the daemon based on the
-                          device's detected Network Bay ASIC index, e.g. set_system_conf <conf>[0].
+                          Conf is the mlxconfig system configuration profile name. The daemon resolves
+                          the profile parameters for the device's detected Network Bay ASIC and manages
+                          them through the regular mlxconfig validation and apply flow.
                         type: string
                     required:
                     - conf

--- a/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicdevices.yaml
+++ b/deployment/nic-configuration-operator-chart/crds/configuration.net.nvidia.com_nicdevices.yaml
@@ -61,10 +61,8 @@ spec:
                       force:
                         default: false
                         description: |-
-                          Force passes `--force` to mlxconfig set commands. When set, the daemon
-                          applies the nv config batch and set_system_conf with --force, letting
-                          mlxconfig accept a batch it would otherwise refuse due to implicit
-                          parameter dependencies.
+                          Force passes `--force` to mlxconfig set commands, letting mlxconfig accept
+                          a batch it would otherwise refuse due to implicit parameter dependencies.
                         type: boolean
                       gpuDirectOptimized:
                         description: GPU Direct optimization settings
@@ -89,14 +87,14 @@ spec:
                         type: string
                       networkBay:
                         description: NetworkBay configures a ConnectX-9 Network Bay
-                          card (per-ASIC set_system_conf). Allowed only for ConnectX-9
-                          (nicType 1025).
+                          card from a per-ASIC mlxconfig system profile. Allowed only
+                          for ConnectX-9 (nicType 1025).
                         properties:
                           conf:
                             description: |-
-                              Conf is the <conf_name> argument passed to `mlxconfig set_system_conf`.
-                              The per-ASIC index is appended automatically by the daemon based on the
-                              device's detected Network Bay ASIC index, e.g. set_system_conf <conf>[0].
+                              Conf is the mlxconfig system configuration profile name. The daemon resolves
+                              the profile parameters for the device's detected Network Bay ASIC and manages
+                              them through the regular mlxconfig validation and apply flow.
                             type: string
                         required:
                         - conf

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -68,7 +68,7 @@ params.</p></td>
 <td><code>networkBay</code><br />
 <em><a href="#NetworkBaySpec">NetworkBaySpec</a></em></td>
 <td><em>(Optional)</em>
-<p>NetworkBay configures a ConnectX-9 Network Bay card (per-ASIC set_system_conf). Allowed only for ConnectX-9 (nicType 1025).</p></td>
+<p>NetworkBay configures a ConnectX-9 Network Bay card from a per-ASIC mlxconfig system profile. Allowed only for ConnectX-9 (nicType 1025).</p></td>
 </tr>
 <tr>
 <td><code>rawNvConfig</code><br />
@@ -79,8 +79,7 @@ params.</p></td>
 <td><code>force</code><br />
 <em>bool</em></td>
 <td><em>(Optional)</em>
-<p>Force passes <code>--force</code> to mlxconfig set commands. When set, the daemon applies the nv config batch and set_system_conf with –force, letting mlxconfig accept a batch it would otherwise
-refuse due to implicit parameter dependencies.</p></td>
+<p>Force passes <code>--force</code> to mlxconfig set commands, letting mlxconfig accept a batch it would otherwise refuse due to implicit parameter dependencies.</p></td>
 </tr>
 </tbody>
 </table>
@@ -206,8 +205,8 @@ Allowed only when nicSelector.nicType == “1025” (ConnectX-9), enforced by CE
 <tr>
 <td><code>conf</code><br />
 <em>string</em></td>
-<td><p>Conf is the argument passed to <code>mlxconfig set_system_conf</code>. The per-ASIC index is appended automatically by the daemon based on the device’s detected Network Bay ASIC index, e.g.
-set_system_conf [0].</p></td>
+<td><p>Conf is the mlxconfig system configuration profile name. The daemon resolves the profile parameters for the device’s detected Network Bay ASIC and manages them through the regular mlxconfig
+validation and apply flow.</p></td>
 </tr>
 </tbody>
 </table>
@@ -1368,4 +1367,4 @@ SpectrumXOptimizedSpec enables Spectrum-X specific optimizations
 
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-*Generated with `gen-crd-api-reference-docs` on git commit `85f5e0d`.*
+*Generated with `gen-crd-api-reference-docs` on git commit `e579f52`.*

--- a/docs/network-bay-testing.md
+++ b/docs/network-bay-testing.md
@@ -328,7 +328,11 @@ status:
     type: ConfigUpdateInProgress
 ```
 
-## Allows to change system_conf type
+## Allows changing the system profile
+
+The daemon resolves the selected profile with `mlxconfig -d <device> show_system_conf`, selects the
+detected ASIC's parameter list, and applies any differences through its regular `mlxconfig set`
+batch. It does not invoke `set_system_conf` during reconciliation.
 
 ```
 apiVersion: configuration.net.nvidia.com/v1alpha1

--- a/docs/nic-configuration-library.md
+++ b/docs/nic-configuration-library.md
@@ -164,15 +164,15 @@ func NewConfigurationManager(
 #### NV Configuration Flow
 
 1. **Query** current NV config via `nvConfigUtils.QueryNvConfig()`
-2. **Network Bay `set_system_conf` (baseline, applied first)** — for ConnectX-9 Network Bay devices (`template.networkBay` set and `status.networkBay` detected), the per-ASIC `set_system_conf <conf>[<asic>]` is applied **before** the regular / Spectrum-X params so those layer on top of it (override priority: `rawNvConfig` > Spectrum-X > system_conf). Drift is detected per-param via `nvconfig.ValidateSystemConf()`, which returns the overall match bit plus the names of the mismatched params; the manager ignores MISMATCH rows for params owned by a higher-priority layer (matched by exact per-index key — `rawNvConfig` index-range syntax like `MODULE_SPLIT_M0[0..3]` is rejected by CRD validation, so keys are always concrete); a change requires a reboot. Skipped for devices with `ResetToDefault`
-3. **Diff** desired vs current parameters. Params not present in the device's next-boot config are unsupported on this device (e.g. hidden because `ADVANCED_PCI_SETTINGS` is off) and are skipped — the operator does **not** auto-manage `ADVANCED_PCI_SETTINGS`; drive it explicitly via `template.rawNvConfig` if needed
-4. **Batch set** via `nvConfigUtils.SetNvConfigParametersBatch()` — single `mlxconfig set` call (`--force` added when `ConfigurationOptions.Force=true`). Apply reports `ApplyStatusPartiallyApplied` when any desired param was skipped as unsupported. With `ConfigurationOptions.WithDefault=true`, the batch setter parses `mlxconfig` output and returns `ApplyStatusNothingToDo` when the command succeeds but no params are changed.
+2. **Resolve and merge the Network Bay profile** — for ConnectX-9 Network Bay devices (`template.networkBay` set and `status.networkBay` detected), run `show_system_conf`, select the named profile and detected ASIC, and expand range assignments such as `MODULE_SPLIT_M0[4..15]=FF` into concrete keys. These parameters are the lowest-priority layer in the normal desired map: system profile < Spectrum-X < template < `rawNvConfig`. Skipped for devices with `ResetToDefault`.
+3. **Diff** all desired parameters against every target's current and next-boot config. Value comparison is case-insensitive and normalizes decimal, `0x`-prefixed hexadecimal, and bare hexadecimal profile values. Params absent from a target's next-boot config are unsupported on that target (e.g. hidden because `ADVANCED_PCI_SETTINGS` is off) and are skipped — the operator does **not** auto-manage `ADVANCED_PCI_SETTINGS`; drive it explicitly via `template.rawNvConfig` if needed.
+4. **Batch set** via `nvConfigUtils.SetNvConfigParametersBatch()` — profile and explicit parameters are sent together through the existing per-target `mlxconfig set` flow (`--force` added when `ConfigurationOptions.Force=true`). Apply reports `ApplyStatusPartiallyApplied` when any desired param was skipped as unsupported. With `ConfigurationOptions.WithDefault=true`, the batch setter parses `mlxconfig` output and returns `ApplyStatusNothingToDo` when the command succeeds but no params are changed.
 5. **Optional reset** — `mlxfwreset` unless `ConfigurationOptions.SkipReset=true`
 
 **`ConfigurationOptions`:**
 - `SkipReset` — skip `mlxfwreset` after applying NV config
 - `WithDefault` — add `--with_default` to `mlxconfig set`
-- `Force` — add `--force` to `mlxconfig set` and `set_system_conf` (lets mlxconfig accept a batch it would otherwise refuse due to implicit parameter dependencies). When `NUM_OF_PF` and a `_P1` value are present, force mode copies that value to missing higher ports up to the requested PF count before applying; explicit per-port values are preserved.
+- `Force` — add `--force` to `mlxconfig set` (lets mlxconfig accept a batch it would otherwise refuse due to implicit parameter dependencies). When `NUM_OF_PF` and a `_P1` value are present, force mode copies that value to missing higher ports up to the requested PF count before applying; explicit per-port values are preserved.
 
 #### Runtime Configuration Flow
 
@@ -380,6 +380,12 @@ type NVConfigUtils interface {
     // decide which mismatches are intentional overrides rather than drift.
     ValidateSystemConf(ctx context.Context, port v1alpha1.NicDevicePortSpec, conf string, asic int) (bool, []string, error)
 }
+
+// Optional capability implemented by the built-in NVConfigUtils implementation and used by the
+// configuration manager for Network Bay templates.
+type SystemConfParamsProvider interface {
+    GetSystemConfParams(ctx context.Context, port v1alpha1.NicDevicePortSpec, conf string, asic int) (map[string]string, error)
+}
 ```
 
 **Constructor:**
@@ -395,12 +401,13 @@ mlxconfig -d <device> -e --with_default -y [--force] set PARAM1=VAL1 PARAM2=VAL2
 Parameter names are sorted for deterministic command generation.
 `<device>` is `port.FwctlDevice` when discovered, otherwise `port.PCI`.
 
-**System conf command format (ConnectX-9 Network Bay):**
+**System profile command format (ConnectX-9 Network Bay):**
 ```
+mlxconfig -d <device> show_system_conf
 mlxconfig -d <device> -y [--force] set_system_conf <conf>[<asic>]
 mlxconfig -d <device> -y validate_system_conf <conf>[<asic>]
 ```
-`ValidateSystemConf` parses the per-param `OK:` / `MISMATCH:` rows plus the `SKIPPED (failed to query:)` list and the trailing `Result:` line, returning the overall match bit and the mismatched param names. The configuration manager uses the mismatched names to treat MISMATCH rows for `rawNvConfig`- or Spectrum-X-owned params as intentional overrides (priority `rawNvConfig` > Spectrum-X > system_conf) rather than drift.
+The configuration manager uses `GetSystemConfParams` to parse `show_system_conf`, select `<conf>` and the detected ASIC, expand ranged parameter names, and merge the result into the regular desired parameter map. `SetSystemConf` and `ValidateSystemConf` remain available for compatibility, but are not used by the manager.
 
 ---
 

--- a/pkg/configuration/configvalidation.go
+++ b/pkg/configuration/configvalidation.go
@@ -35,7 +35,7 @@ type configValidation interface {
 	// ConstructNvParamMapFromTemplate builds the full set of desired nvconfig parameters for a device by
 	// combining, in increasing priority order, the Spectrum-X profile (breakout + postBreakout, when
 	// enabled), the spec template params, and rawNvConfig (raw wins on key collisions). For Network Bay
-	// devices these params override the set_system_conf baseline. Operates under the assumption that spec
+	// devices these params override the named system profile layer. Operates under the assumption that spec
 	// validation was already carried out.
 	ConstructNvParamMapFromTemplate(
 		device *v1alpha1.NicDevice, nvConfigQuery types.NvConfigQuery) (map[string]string, error)
@@ -101,7 +101,7 @@ func (v *configValidationImpl) ConstructNvParamMapFromTemplate(
 	}
 
 	// Link type is only managed when the template specifies it. For Network Bay devices the
-	// template must not set linkType (enforced by CEL); the link type is owned by set_system_conf,
+	// template must not set linkType (enforced by CEL); the link type is owned by the system profile,
 	// so the operator must not emit LINK_TYPE_P* here or it would fight the system configuration.
 	if template.LinkType != "" {
 		// Link type change is not allowed on some devices

--- a/pkg/configuration/configvalidation_test.go
+++ b/pkg/configuration/configvalidation_test.go
@@ -135,7 +135,7 @@ var _ = Describe("ConfigValidationImpl", func() {
 			}
 
 			// Firmware exposes LINK_TYPE slots, but the template does not set linkType, so the
-			// operator must not emit LINK_TYPE_P* (set_system_conf owns the link type).
+			// operator must not emit LINK_TYPE_P* (the system profile owns the link type).
 			query := types.NewNvConfigQuery()
 			query.DefaultConfig = map[string][]string{
 				consts.LinkTypeP1Param: {"2"},

--- a/pkg/configuration/manager.go
+++ b/pkg/configuration/manager.go
@@ -18,7 +18,7 @@ package configuration
 import (
 	"context"
 	"fmt"
-	"slices"
+	"math/big"
 	"sort"
 	"strconv"
 	"strings"
@@ -63,6 +63,7 @@ type configurationManager struct {
 	configurationUtils     ConfigurationUtils
 	configValidation       configValidation
 	nvConfigUtils          nvconfig.NVConfigUtils
+	systemConfParams       nvconfig.SystemConfParamsProvider
 	spectrumXConfigManager spectrumx.SpectrumXManager
 }
 
@@ -102,41 +103,21 @@ func (h configurationManager) ValidateDeviceNvSpec(ctx context.Context, device *
 		return resetNeeded, rebootNeeded, nil, nil
 	}
 
-	// 3. Network Bay system_conf: the params that don't match the requested named profile (empty for
-	//    non-Network-Bay devices). set_system_conf is the lowest-priority baseline.
-	systemConfMismatched, err := h.systemConfMismatchedParams(ctx, device)
-	if err != nil {
-		return false, false, nil, err
-	}
-	if len(systemConfMismatched) > 0 {
-		log.Log.V(2).Info("system_conf params mismatched against the profile", "device", device.Name, "params", systemConfMismatched)
-	}
-
-	// 4. Combined override config (Spectrum-X breakout + postBreakout + template + rawNvConfig, raw wins).
-	//    Validated against the device's next boot, exactly like the apply path — so a value already staged
-	//    for next boot but not yet rebooted reports reboot-required instead of looping.
-	overrides, err := h.configValidation.ConstructNvParamMapFromTemplate(device, firstPortConfig)
+	// 3. Build the complete desired configuration. For Network Bay devices the named system profile is
+	//    the lowest-priority layer; Spectrum-X, template, and rawNvConfig values override it.
+	desiredParams, err := h.constructDesiredNvParams(ctx, device, firstPortConfig)
 	if err != nil {
 		log.Log.Error(err, "failed to calculate desired nvconfig parameters", "device", device.Name)
 		return false, false, nil, err
 	}
-	log.Log.V(2).Info("validating combined nv config", "device", device.Name, "params", overrides)
+	log.Log.V(2).Info("validating combined nv config", "device", device.Name, "params", desiredParams)
 
-	configUpdateNeeded, rebootNeeded, unsupportedParams := validateTemplateParamsApplied(nvConfigsForPorts, overrides)
+	configUpdateNeeded, rebootNeeded, unsupportedParams := validateTemplateParamsApplied(nvConfigsForPorts, desiredParams)
 	if configUpdateNeeded {
 		log.Log.Info("nv config not yet applied to next boot", "device", device.Name)
 	}
 	if len(unsupportedParams) > 0 {
 		log.Log.Info("some nv config params are unsupported on this device and will be skipped", "device", device.Name, "params", unsupportedParams)
-	}
-
-	// 5. system_conf coverage: a mismatched profile param not covered (range-aware) by the override config
-	//    means the baseline itself drifted and set_system_conf must be re-applied (reboot-required).
-	if systemConfDrifted(overrides, systemConfMismatched) {
-		log.Log.Info("Network Bay system_conf drifted, set_system_conf re-apply required",
-			"device", device.Name, "mismatched", systemConfMismatched)
-		configUpdateNeeded = true
-		rebootNeeded = true
 	}
 
 	log.Log.V(2).Info("nv spec validation result", "device", device.Name,
@@ -164,13 +145,13 @@ func validateTemplateParamsApplied(nvConfigsForPorts map[string]types.NvConfigQu
 				unsupportedSet[parameter] = struct{}{}
 				continue
 			}
-			if !slices.Contains(nextValues, strings.ToLower(desiredValue)) {
+			if !mlxConfigValueMatches(nextValues, desiredValue) {
 				configUpdateNeeded = true
 				rebootNeeded = true
 				continue
 			}
 			currentValues, foundInCurrent := nvConfig.CurrentConfig[parameter]
-			if !foundInCurrent || !slices.Contains(currentValues, strings.ToLower(desiredValue)) {
+			if !foundInCurrent || !mlxConfigValueMatches(currentValues, desiredValue) {
 				rebootNeeded = true
 			}
 		}
@@ -212,14 +193,9 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 		return h.applyResetToDefault(device, firstPort, firstPortConfig)
 	}
 
-	// 3. Network Bay system_conf: the params that don't match the requested named profile.
-	systemConfMismatched, err := h.systemConfMismatchedParams(ctx, device)
-	if err != nil {
-		return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
-	}
-
-	// 4. Combined desired params: Spectrum-X breakout + postBreakout + template + rawNvConfig (raw wins).
-	desiredParams, err := h.configValidation.ConstructNvParamMapFromTemplate(device, firstPortConfig)
+	// 3. Build the complete desired configuration. The Network Bay profile, when present, is folded into
+	//    the same map as every other mlxconfig parameter and follows the same per-target apply behavior.
+	desiredParams, err := h.constructDesiredNvParams(ctx, device, firstPortConfig)
 	if err != nil {
 		log.Log.Error(err, "failed to calculate desired nvconfig parameters", "device", device.Name)
 		return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
@@ -229,32 +205,10 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 	}
 	log.Log.V(2).Info("combined desired nv config built", "device", device.Name, "params", desiredParams, "force", options.Force)
 
-	// 5. set_system_conf baseline: if the combined params do not cover all mismatched profile params
-	//    (range-aware), the baseline itself drifted on an uncovered param — re-stage set_system_conf
-	//    before the override batch so the overrides still win in the same next-boot config.
-	systemConfApplied := false
-	if systemConfDrifted(desiredParams, systemConfMismatched) {
-		log.Log.Info("Network Bay system_conf not covered by overrides, applying set_system_conf",
-			"device", device.Name, "mismatched", systemConfMismatched)
-		if err := h.setSystemConf(ctx, device, options); err != nil {
-			return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
-		}
-		systemConfApplied = true
-
-		// set_system_conf restages the whole profile, so the pre-call query is now stale. Re-query so the
-		// override batch below diffs against the restaged next-boot config and does not skip an override
-		// the baseline just overwrote.
-		nvConfigsForPorts, err = h.queryNvConfigs(ctx, device)
-		if err != nil {
-			log.Log.Error(err, "failed to re-query nv configs after set_system_conf", "device", device.Name)
-			return &types.ConfigurationApplyResult{Status: types.ApplyStatusFailed}, err
-		}
-	}
-
 	anyParamsApplied := false
 	hasUnsupportedParams := false
 
-	// 6 & 7. Apply the combined override params on every PF the device exposes.
+	// 4. Apply the combined desired params on every PF the device exposes.
 	//   - force=true: apply every param (mlxconfig --force accepts params not currently visible, e.g.
 	//     per-port params staged before a breakout reboot exposes their ports).
 	//   - force=false: apply only the params visible on this PF whose value differs; params not yet
@@ -278,7 +232,7 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 				}
 				// WithDefault still requires the param to exist in the query, but applies it even
 				// when next-boot already contains the desired value.
-				if options.WithDefault || !slices.Contains(nextValues, value) {
+				if options.WithDefault || !mlxConfigValueMatches(nextValues, value) {
 					batch[param] = value
 				}
 			}
@@ -297,7 +251,7 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 		}
 	}
 
-	if !anyParamsApplied && !hasUnsupportedParams && !systemConfApplied {
+	if !anyParamsApplied && !hasUnsupportedParams {
 		log.Log.V(2).Info("nv config already up to date, nothing to apply", "device", device.Name)
 		return &types.ConfigurationApplyResult{Status: types.ApplyStatusNothingToDo}, nil
 	}
@@ -306,7 +260,7 @@ func (h configurationManager) ApplyNVConfiguration(ctx context.Context, device *
 	if hasUnsupportedParams {
 		status = types.ApplyStatusPartiallyApplied
 	}
-	rebootRequired := anyParamsApplied || systemConfApplied
+	rebootRequired := anyParamsApplied
 	log.Log.Info("nv config applied", "device", device.Name, "status", status, "rebootRequired", rebootRequired)
 
 	return &types.ConfigurationApplyResult{Status: status, RebootRequired: rebootRequired}, nil
@@ -339,21 +293,6 @@ func extrapolatePortParamsFromNumOfPF(params map[string]string) {
 			}
 		}
 	}
-}
-
-// setSystemConf stages the requested Network Bay set_system_conf for the device's ASIC (the
-// lowest-priority baseline). Callers stage it before the override params.
-func (h configurationManager) setSystemConf(ctx context.Context, device *v1alpha1.NicDevice, options *types.ConfigurationOptions) error {
-	conf := device.Spec.Configuration.Template.NetworkBay.Conf
-	asic := device.Status.NetworkBay.Asic
-	port := device.Status.Ports[0]
-
-	log.Log.Info("applying Network Bay system_conf", "device", device.Name, "conf", conf, "asic", asic)
-	if err := h.nvConfigUtils.SetSystemConf(ctx, port, conf, asic, options.Force); err != nil {
-		log.Log.Error(err, "failed to apply system_conf", "device", device.Name)
-		return err
-	}
-	return nil
 }
 
 // applyResetToDefault resets NV config to defaults, preserving BF3 operation mode
@@ -586,10 +525,8 @@ func spectrumXEnabled(device *v1alpha1.NicDevice) bool {
 }
 
 // hasNetworkBaySpec reports whether the device has a Network Bay template configured AND was
-// detected as part of a Network Bay card. Both are required to apply / validate set_system_conf.
-// ResetToDefault takes precedence: a reset wipes nv config, so we must not also manage set_system_conf
-// for the same device — otherwise apply would stage set_system_conf and the reset would wipe it on
-// every reconcile, looping forever.
+// detected as part of a Network Bay card. Both are required to resolve its system configuration
+// profile. ResetToDefault takes precedence over profile management.
 func hasNetworkBaySpec(device *v1alpha1.NicDevice) bool {
 	return device.Spec.Configuration != nil &&
 		!device.Spec.Configuration.ResetToDefault &&
@@ -599,30 +536,46 @@ func hasNetworkBaySpec(device *v1alpha1.NicDevice) bool {
 		len(device.Status.Ports) > 0
 }
 
-// systemConfMismatchedParams returns the names of params whose applied value does not match the
-// requested Network Bay system_conf (the MISMATCH rows of validate_system_conf), in source order.
-// Returns nil for non-Network-Bay devices. SKIPPED rows are informational and excluded.
-func (h configurationManager) systemConfMismatchedParams(ctx context.Context, device *v1alpha1.NicDevice) ([]string, error) {
+// constructDesiredNvParams merges the named Network Bay system profile below the existing desired
+// parameter layers. All returned keys are concrete mlxconfig parameters, including expanded array
+// ranges from the system profile.
+func (h configurationManager) constructDesiredNvParams(
+	ctx context.Context, device *v1alpha1.NicDevice, query types.NvConfigQuery) (map[string]string, error) {
+	desiredParams := map[string]string{}
+
+	profileParams, err := h.getSystemConfParams(ctx, device)
+	if err != nil {
+		return nil, err
+	}
+	mergeParams(desiredParams, profileParams)
+
+	overrides, err := h.configValidation.ConstructNvParamMapFromTemplate(device, query)
+	if err != nil {
+		return nil, err
+	}
+	mergeParams(desiredParams, overrides)
+
+	return desiredParams, nil
+}
+
+func (h configurationManager) getSystemConfParams(ctx context.Context, device *v1alpha1.NicDevice) (map[string]string, error) {
 	if !hasNetworkBaySpec(device) {
 		return nil, nil
+	}
+	if h.systemConfParams == nil {
+		return nil, fmt.Errorf("nvconfig utility does not support system configuration profile resolution")
 	}
 
 	conf := device.Spec.Configuration.Template.NetworkBay.Conf
 	asic := device.Status.NetworkBay.Asic
 	port := device.Status.Ports[0]
 
-	matches, mismatched, err := h.nvConfigUtils.ValidateSystemConf(ctx, port, conf, asic)
+	params, err := h.systemConfParams.GetSystemConfParams(ctx, port, conf, asic)
 	if err != nil {
-		log.Log.Error(err, "failed to validate system_conf", "device", device.Name)
+		log.Log.Error(err, "failed to resolve system configuration profile", "device", device.Name, "conf", conf, "asic", asic)
 		return nil, err
 	}
-
-	// Fail closed: a non-matching result with no recognized MISMATCH rows would otherwise look identical
-	// to a matching profile and silently skip set_system_conf. Surface it so the reconcile retries instead.
-	if !matches && len(mismatched) == 0 {
-		return nil, fmt.Errorf("device %s system_conf %q reports a mismatch but no mismatched params were parsed", device.Name, conf)
-	}
-	return mismatched, nil
+	return params, nil
 }
 
 func (h configurationManager) queryNvConfigs(ctx context.Context, device *v1alpha1.NicDevice) (map[string]types.NvConfigQuery, error) {
@@ -658,20 +611,49 @@ func getRawNvConfigParams(device *v1alpha1.NicDevice) map[string]string {
 	return params
 }
 
-// systemConfDrifted reports whether any mismatched system_conf param is left uncovered by the override
-// config. overrides and the mismatched names are both concrete per-index keys (e.g. MODULE_SPLIT_M0[2]),
-// so coverage is an exact name lookup — an override of a profile param suppresses its mismatch row. An
-// empty mismatched slice is never drift.
-func systemConfDrifted(overrides map[string]string, mismatched []string) bool {
-	for _, param := range mismatched {
-		if _, ok := overrides[param]; !ok {
+func mlxConfigValueMatches(values []string, desired string) bool {
+	for _, value := range values {
+		if mlxConfigValuesEqual(value, desired) {
 			return true
 		}
 	}
 	return false
 }
 
+func mlxConfigValuesEqual(actual, desired string) bool {
+	actual = strings.TrimSpace(actual)
+	desired = strings.TrimSpace(desired)
+	if strings.EqualFold(actual, desired) {
+		return true
+	}
+
+	actualNumber, actualIsNumber := parseMlxConfigNumber(actual)
+	desiredNumber, desiredIsNumber := parseMlxConfigNumber(desired)
+	return actualIsNumber && desiredIsNumber && actualNumber.Cmp(desiredNumber) == 0
+}
+
+func parseMlxConfigNumber(value string) (*big.Int, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil, false
+	}
+
+	base := 10
+	digits := value
+	if strings.HasPrefix(strings.ToLower(digits), "0x") {
+		base = 16
+		digits = digits[2:]
+	} else if strings.ContainsAny(digits, "abcdefABCDEF") {
+		// System configuration profiles use bare hexadecimal values such as FF.
+		base = 16
+	}
+
+	number, ok := new(big.Int).SetString(digits, base)
+	return number, ok
+}
+
 func NewConfigurationManager(eventRecorder record.EventRecorder, dmsManager dms.DMSManager, nvConfigUtils nvconfig.NVConfigUtils, spectrumXConfigManager spectrumx.SpectrumXManager) ConfigurationManager {
 	utils := newConfigurationUtils(dmsManager)
-	return configurationManager{configurationUtils: utils, configValidation: newConfigValidation(utils, eventRecorder, spectrumXConfigManager), nvConfigUtils: nvConfigUtils, spectrumXConfigManager: spectrumXConfigManager}
+	systemConfParams, _ := nvConfigUtils.(nvconfig.SystemConfParamsProvider)
+	return configurationManager{configurationUtils: utils, configValidation: newConfigValidation(utils, eventRecorder, spectrumXConfigManager), nvConfigUtils: nvConfigUtils, systemConfParams: systemConfParams, spectrumXConfigManager: spectrumXConfigManager}
 }

--- a/pkg/configuration/manager_test.go
+++ b/pkg/configuration/manager_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/Mellanox/nic-configuration-operator/api/v1alpha1"
 	"github.com/Mellanox/nic-configuration-operator/pkg/configuration/mocks"
 	"github.com/Mellanox/nic-configuration-operator/pkg/consts"
+	"github.com/Mellanox/nic-configuration-operator/pkg/nvconfig"
 	nvconfigmocks "github.com/Mellanox/nic-configuration-operator/pkg/nvconfig/mocks"
 	spcxmocks "github.com/Mellanox/nic-configuration-operator/pkg/spectrumx/mocks"
 	"github.com/Mellanox/nic-configuration-operator/pkg/types"
@@ -38,19 +39,31 @@ func portSpec(pciAddr string) v1alpha1.NicDevicePortSpec {
 	return v1alpha1.NicDevicePortSpec{PCI: pciAddr}
 }
 
-// okSystemConf stubs a matching validate_system_conf result (no mismatched params). Spread into a
-// mock .Return(...) call: mockNV.On("ValidateSystemConf", ...).Return(okSystemConf()...).
-func okSystemConf() []interface{} {
-	return []interface{}{true, []string(nil), nil}
+type systemConfParamsProviderMock struct {
+	mock.Mock
 }
 
-// mismatchSystemConf stubs a non-matching validate_system_conf result with the given MISMATCH params.
-// Spread into a mock .Return(...) call: .Return(mismatchSystemConf("NUM_OF_PF")...).
-func mismatchSystemConf(mismatchedParams ...string) []interface{} {
-	return []interface{}{false, mismatchedParams, nil}
+var _ nvconfig.SystemConfParamsProvider = (*systemConfParamsProviderMock)(nil)
+
+func (m *systemConfParamsProviderMock) GetSystemConfParams(
+	ctx context.Context, port v1alpha1.NicDevicePortSpec, conf string, asic int) (map[string]string, error) {
+	args := m.Called(ctx, port, conf, asic)
+	params, _ := args.Get(0).(map[string]string)
+	return params, args.Error(1)
 }
 
 var _ = Describe("ConfigurationManager", func() {
+	DescribeTable("compares normalized mlxconfig values",
+		func(actual, desired string, expected bool) {
+			Expect(mlxConfigValuesEqual(actual, desired)).To(Equal(expected))
+		},
+		Entry("case-insensitive symbolic values", "ETH", "eth", true),
+		Entry("prefixed and bare hexadecimal values", "0xFF", "FF", true),
+		Entry("hexadecimal and decimal values", "0x02", "2", true),
+		Entry("decimal values with leading zeroes", "004", "4", true),
+		Entry("different values", "1", "2", false),
+	)
+
 	Describe("extrapolatePortParamsFromNumOfPF", func() {
 		It("copies P1 values to missing ports while preserving explicit overrides", func() {
 			params := map[string]string{"NUM_OF_PF": "3", "LINK_TYPE_P1": "2", "LINK_TYPE_P3": "1"}
@@ -1214,6 +1227,7 @@ var _ = Describe("ConfigurationManager", func() {
 	Describe("SpectrumX NV Configuration", func() {
 		var (
 			mockNVConfigUtils    *nvconfigmocks.NVConfigUtils
+			mockSystemConfParams *systemConfParamsProviderMock
 			mockSpcXMgr          *spcxmocks.SpectrumXManager
 			mockConfigValidation mocks.ConfigValidation
 			manager              configurationManager
@@ -1223,11 +1237,13 @@ var _ = Describe("ConfigurationManager", func() {
 
 		BeforeEach(func() {
 			mockNVConfigUtils = nvconfigmocks.NewNVConfigUtils(GinkgoT())
+			mockSystemConfParams = &systemConfParamsProviderMock{}
 			mockSpcXMgr = spcxmocks.NewSpectrumXManager(GinkgoT())
 			mockConfigValidation = mocks.ConfigValidation{}
 			manager = configurationManager{
 				configValidation:       &mockConfigValidation,
 				nvConfigUtils:          mockNVConfigUtils,
+				systemConfParams:       mockSystemConfParams,
 				spectrumXConfigManager: mockSpcXMgr,
 			}
 			ctx = context.TODO()
@@ -1302,18 +1318,18 @@ var _ = Describe("ConfigurationManager", func() {
 				Expect(err.Error()).To(ContainSubstring("config not found"))
 			})
 
-			Context("with Network Bay system_conf", func() {
+			Context("with a Network Bay system profile", func() {
 				BeforeEach(func() {
 					device.Spec.Configuration.Template.NetworkBay = &v1alpha1.NetworkBaySpec{Conf: "conf3"}
 					device.Status.NetworkBay = &v1alpha1.NicDeviceNetworkBayStatus{Asic: 0}
 				})
 
-				It("does not flag drift when every system_conf mismatch is covered by a combined override param", func() {
+				It("lets an explicit parameter override the system profile value", func() {
 					matched := map[string][]string{"NUM_OF_PF": {"2"}}
 					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(
 						types.NvConfigQuery{NextBootConfig: matched, CurrentConfig: matched}, nil)
-					mockNVConfigUtils.On("ValidateSystemConf", ctx, portSpec(pciAddress), "conf3", 0).
-						Return(mismatchSystemConf("NUM_OF_PF")...)
+					mockSystemConfParams.On("GetSystemConfParams", ctx, portSpec(pciAddress), "conf3", 0).
+						Return(map[string]string{"NUM_OF_PF": "4"}, nil)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 						Return(map[string]string{"NUM_OF_PF": "2"}, nil)
 
@@ -1323,12 +1339,12 @@ var _ = Describe("ConfigurationManager", func() {
 					Expect(rebootNeeded).To(BeFalse())
 				})
 
-				It("flags drift when a system_conf mismatch is covered by no combined override param", func() {
-					matched := map[string][]string{"NUM_OF_PF": {"2"}}
+				It("flags a system profile parameter whose value differs", func() {
+					matched := map[string][]string{"NUM_OF_PF": {"2"}, "BOARD_CONFIGURATION_MODE": {"1"}}
 					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(
 						types.NvConfigQuery{NextBootConfig: matched, CurrentConfig: matched}, nil)
-					mockNVConfigUtils.On("ValidateSystemConf", ctx, portSpec(pciAddress), "conf3", 0).
-						Return(mismatchSystemConf("BOARD_CONFIGURATION_MODE")...)
+					mockSystemConfParams.On("GetSystemConfParams", ctx, portSpec(pciAddress), "conf3", 0).
+						Return(map[string]string{"BOARD_CONFIGURATION_MODE": "0"}, nil)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 						Return(map[string]string{"NUM_OF_PF": "2"}, nil)
 
@@ -1338,7 +1354,7 @@ var _ = Describe("ConfigurationManager", func() {
 					Expect(rebootNeeded).To(BeTrue())
 				})
 
-				It("value-checks each expanded index (covers system_conf by name, but still drifts on a wrong index)", func() {
+				It("value-checks each expanded profile index", func() {
 					// The combined map already has the range expanded to concrete indices; [2] differs from
 					// next boot, so validation must still report an update even though all four rows are covered.
 					expanded := map[string]string{
@@ -1351,8 +1367,8 @@ var _ = Describe("ConfigurationManager", func() {
 					}
 					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(
 						types.NvConfigQuery{NextBootConfig: nextBoot, CurrentConfig: nextBoot}, nil)
-					mockNVConfigUtils.On("ValidateSystemConf", ctx, portSpec(pciAddress), "conf3", 0).
-						Return(mismatchSystemConf("MODULE_SPLIT_M0[0]", "MODULE_SPLIT_M0[1]", "MODULE_SPLIT_M0[2]", "MODULE_SPLIT_M0[3]")...)
+					mockSystemConfParams.On("GetSystemConfParams", ctx, portSpec(pciAddress), "conf3", 0).
+						Return(expanded, nil)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).Return(expanded, nil)
 
 					updateNeeded, rebootNeeded, _, err := manager.ValidateDeviceNvSpec(ctx, device)
@@ -1361,7 +1377,7 @@ var _ = Describe("ConfigurationManager", func() {
 					Expect(rebootNeeded).To(BeTrue())
 				})
 
-				It("converges when every expanded index already matches and covers the system_conf rows", func() {
+				It("converges when every expanded profile index already matches", func() {
 					matched := map[string][]string{
 						"MODULE_SPLIT_M0[0]": {"1"}, "MODULE_SPLIT_M0[1]": {"1"},
 						"MODULE_SPLIT_M0[2]": {"1"}, "MODULE_SPLIT_M0[3]": {"1"},
@@ -1372,8 +1388,8 @@ var _ = Describe("ConfigurationManager", func() {
 					}
 					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(
 						types.NvConfigQuery{NextBootConfig: matched, CurrentConfig: matched}, nil)
-					mockNVConfigUtils.On("ValidateSystemConf", ctx, portSpec(pciAddress), "conf3", 0).
-						Return(mismatchSystemConf("MODULE_SPLIT_M0[0]", "MODULE_SPLIT_M0[1]", "MODULE_SPLIT_M0[2]", "MODULE_SPLIT_M0[3]")...)
+					mockSystemConfParams.On("GetSystemConfParams", ctx, portSpec(pciAddress), "conf3", 0).
+						Return(expanded, nil)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).Return(expanded, nil)
 
 					updateNeeded, rebootNeeded, _, err := manager.ValidateDeviceNvSpec(ctx, device)
@@ -1491,20 +1507,20 @@ var _ = Describe("ConfigurationManager", func() {
 				Expect(result.Status).To(Equal(types.ApplyStatusFailed))
 			})
 
-			Context("with Network Bay system_conf", func() {
+			Context("with a Network Bay system profile", func() {
 				BeforeEach(func() {
 					device.Spec.Configuration.Template.NetworkBay = &v1alpha1.NetworkBaySpec{Conf: "conf3"}
 					device.Status.NetworkBay = &v1alpha1.NicDeviceNetworkBayStatus{Asic: 0}
 				})
 
-				It("applies set_system_conf when the combined params do not cover a mismatch", func() {
+				It("folds profile parameters into the regular force batch", func() {
 					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(types.NvConfigQuery{}, nil)
-					mockNVConfigUtils.On("ValidateSystemConf", ctx, portSpec(pciAddress), "conf3", 0).
-						Return(mismatchSystemConf("BOARD_CONFIGURATION_MODE")...)
+					mockSystemConfParams.On("GetSystemConfParams", ctx, portSpec(pciAddress), "conf3", 0).
+						Return(map[string]string{"BOARD_CONFIGURATION_MODE": "0"}, nil)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 						Return(map[string]string{"NUM_OF_PF": "2"}, nil)
-					mockNVConfigUtils.On("SetSystemConf", ctx, portSpec(pciAddress), "conf3", 0, true).Return(nil)
-					mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, false, true).
+					mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress),
+						map[string]string{"BOARD_CONFIGURATION_MODE": "0", "NUM_OF_PF": "2"}, false, true).
 						Return(types.ApplyStatusSuccess, nil)
 
 					result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{Force: true})
@@ -1512,15 +1528,14 @@ var _ = Describe("ConfigurationManager", func() {
 					Expect(result.RebootRequired).To(BeTrue())
 				})
 
-				It("does not apply set_system_conf when the combined params cover all mismatches", func() {
+				It("lets an explicit value replace a profile value in the regular batch", func() {
 					mockNVConfigUtils.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(types.NvConfigQuery{}, nil)
-					mockNVConfigUtils.On("ValidateSystemConf", ctx, portSpec(pciAddress), "conf3", 0).
-						Return(mismatchSystemConf("NUM_OF_PF")...)
+					mockSystemConfParams.On("GetSystemConfParams", ctx, portSpec(pciAddress), "conf3", 0).
+						Return(map[string]string{"NUM_OF_PF": "4"}, nil)
 					mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, mock.Anything).
 						Return(map[string]string{"NUM_OF_PF": "2"}, nil)
 					mockNVConfigUtils.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "2"}, false, true).
 						Return(types.ApplyStatusSuccess, nil)
-					mockNVConfigUtils.AssertNotCalled(GinkgoT(), "SetSystemConf", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 
 					result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{Force: true})
 					Expect(err).NotTo(HaveOccurred())
@@ -1530,11 +1545,12 @@ var _ = Describe("ConfigurationManager", func() {
 		})
 	})
 
-	Describe("Network Bay system_conf", func() {
+	Describe("Network Bay system profile", func() {
 		var (
 			mockHostUtils        mocks.ConfigurationUtils
 			mockConfigValidation mocks.ConfigValidation
 			mockNV               *nvconfigmocks.NVConfigUtils
+			mockSystemConf       *systemConfParamsProviderMock
 			manager              configurationManager
 			ctx                  context.Context
 			device               *v1alpha1.NicDevice
@@ -1545,10 +1561,12 @@ var _ = Describe("ConfigurationManager", func() {
 			mockHostUtils = mocks.ConfigurationUtils{}
 			mockConfigValidation = mocks.ConfigValidation{}
 			mockNV = nvconfigmocks.NewNVConfigUtils(GinkgoT())
+			mockSystemConf = &systemConfParamsProviderMock{}
 			manager = configurationManager{
 				configurationUtils: &mockHostUtils,
 				configValidation:   &mockConfigValidation,
 				nvConfigUtils:      mockNV,
+				systemConfParams:   mockSystemConf,
 			}
 			ctx = context.TODO()
 
@@ -1574,11 +1592,11 @@ var _ = Describe("ConfigurationManager", func() {
 		})
 
 		Describe("ValidateDeviceNvSpec", func() {
-			It("requires update+reboot when system_conf has an unexplained mismatch", func() {
-				// system_conf mismatched params are gathered first, then checked against the desired
-				// (template + rawNvConfig) config — empty here, so BOARD_CONFIGURATION_MODE is uncovered drift.
-				mockNV.On("ValidateSystemConf", ctx, portSpec(pciAddress), "conf3", 0).
-					Return(mismatchSystemConf("BOARD_CONFIGURATION_MODE")...)
+			It("requires update+reboot when a profile parameter differs", func() {
+				nvConfig.CurrentConfig["BOARD_CONFIGURATION_MODE"] = []string{"1"}
+				nvConfig.NextBootConfig["BOARD_CONFIGURATION_MODE"] = []string{"1"}
+				mockSystemConf.On("GetSystemConfParams", ctx, portSpec(pciAddress), "conf3", 0).
+					Return(map[string]string{"BOARD_CONFIGURATION_MODE": "0"}, nil)
 				mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(nvConfig, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 					Return(map[string]string{}, nil)
@@ -1589,19 +1607,20 @@ var _ = Describe("ConfigurationManager", func() {
 				Expect(reboot).To(BeTrue())
 			})
 
-			It("fails closed when validate_system_conf reports a mismatch but no MISMATCH rows are parsed", func() {
+			It("returns an error when the profile cannot be resolved", func() {
 				mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(nvConfig, nil)
-				// Result says NOT match, but no recognized MISMATCH rows — must not look like a match.
-				mockNV.On("ValidateSystemConf", ctx, portSpec(pciAddress), "conf3", 0).
-					Return(false, []string(nil), nil)
+				mockSystemConf.On("GetSystemConfParams", ctx, portSpec(pciAddress), "conf3", 0).
+					Return(nil, errors.New("profile not found"))
 
 				_, _, _, err := manager.ValidateDeviceNvSpec(ctx, device)
-				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError("profile not found"))
 			})
 
-			It("requires nothing when both regular config and system_conf match", func() {
-				mockNV.On("ValidateSystemConf", ctx, portSpec(pciAddress), "conf3", 0).
-					Return(okSystemConf()...)
+			It("requires nothing when a hexadecimal profile value matches after normalization", func() {
+				nvConfig.CurrentConfig["MODULE_SPLIT_M0[4]"] = []string{"0xFF"}
+				nvConfig.NextBootConfig["MODULE_SPLIT_M0[4]"] = []string{"0xFF"}
+				mockSystemConf.On("GetSystemConfParams", ctx, portSpec(pciAddress), "conf3", 0).
+					Return(map[string]string{"MODULE_SPLIT_M0[4]": "FF"}, nil)
 				mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(nvConfig, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 					Return(map[string]string{}, nil)
@@ -1612,17 +1631,15 @@ var _ = Describe("ConfigurationManager", func() {
 				Expect(reboot).To(BeFalse())
 			})
 
-			It("ignores a system_conf mismatch that rawNvConfig deliberately overrides", func() {
-				// NUM_OF_PF is part of conf3 but the template overrides it, so the reported MISMATCH
-				// is intentional. system_conf must not flag drift; the regular validation handles the value.
+			It("uses a rawNvConfig value instead of the profile value", func() {
 				device.Spec.Configuration.Template.RawNvConfig = []v1alpha1.NvConfigParam{{Name: "NUM_OF_PF", Value: "8"}}
 				portConfig := types.NvConfigQuery{
 					CurrentConfig:  map[string][]string{"NUM_OF_PF": {"8"}},
 					NextBootConfig: map[string][]string{"NUM_OF_PF": {"8"}},
 					DefaultConfig:  map[string][]string{"NUM_OF_PF": {"1"}},
 				}
-				mockNV.On("ValidateSystemConf", ctx, portSpec(pciAddress), "conf3", 0).
-					Return(mismatchSystemConf("NUM_OF_PF")...)
+				mockSystemConf.On("GetSystemConfParams", ctx, portSpec(pciAddress), "conf3", 0).
+					Return(map[string]string{"NUM_OF_PF": "4"}, nil)
 				mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(portConfig, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, portConfig).
 					Return(map[string]string{"NUM_OF_PF": "8"}, nil)
@@ -1633,32 +1650,30 @@ var _ = Describe("ConfigurationManager", func() {
 				Expect(reboot).To(BeFalse())
 			})
 
-			It("does not manage system_conf when ResetToDefault is set (avoids a reboot loop)", func() {
-				// ResetToDefault wipes nv config, so set_system_conf must not be validated/applied for the
-				// same device — otherwise it would re-stage and get wiped every reconcile. validate_system_conf
-				// must not be called; the reset validation path runs instead.
+			It("does not resolve the profile when ResetToDefault is set", func() {
 				device.Spec.Configuration.ResetToDefault = true
 				mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(nvConfig, nil)
 				mockConfigValidation.On("ValidateResetToDefault", nvConfig).Return(false, false, nil)
-				mockNV.AssertNotCalled(GinkgoT(), "ValidateSystemConf", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 
 				configUpdate, reboot, _, err := manager.ValidateDeviceNvSpec(ctx, device)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(configUpdate).To(BeFalse())
 				Expect(reboot).To(BeFalse())
+				mockSystemConf.AssertNotCalled(GinkgoT(), "GetSystemConfParams", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 			})
 		})
 
 		Describe("ApplyNVConfiguration", func() {
-			// Apply checks system_conf coverage: it stages set_system_conf only when the combined override
-			// params do not cover every mismatched profile param.
-			It("stages set_system_conf when the combined params do not cover a mismatch", func() {
+			It("applies a profile parameter through the regular mlxconfig batch", func() {
+				nvConfig.CurrentConfig["BOARD_CONFIGURATION_MODE"] = []string{"1"}
+				nvConfig.NextBootConfig["BOARD_CONFIGURATION_MODE"] = []string{"1"}
 				mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(nvConfig, nil)
-				mockNV.On("ValidateSystemConf", ctx, portSpec(pciAddress), "conf3", 0).
-					Return(mismatchSystemConf("BOARD_CONFIGURATION_MODE")...)
+				mockSystemConf.On("GetSystemConfParams", ctx, portSpec(pciAddress), "conf3", 0).
+					Return(map[string]string{"BOARD_CONFIGURATION_MODE": "0"}, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 					Return(map[string]string{}, nil)
-				mockNV.On("SetSystemConf", ctx, portSpec(pciAddress), "conf3", 0, false).Return(nil)
+				mockNV.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"BOARD_CONFIGURATION_MODE": "0"}, false, false).
+					Return(types.ApplyStatusSuccess, nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 				Expect(err).NotTo(HaveOccurred())
@@ -1666,77 +1681,102 @@ var _ = Describe("ConfigurationManager", func() {
 				Expect(result.RebootRequired).To(BeTrue())
 			})
 
-			It("passes --force to set_system_conf when Force is set", func() {
+			It("applies profile parameters to every target using the general target scope", func() {
+				device.Status.Ports = []v1alpha1.NicDevicePortSpec{{PCI: pciAddress}, {PCI: pciAddress2}}
+				portConfig := types.NvConfigQuery{
+					CurrentConfig:  map[string][]string{"BOARD_CONFIGURATION_MODE": {"1"}},
+					NextBootConfig: map[string][]string{"BOARD_CONFIGURATION_MODE": {"1"}},
+				}
+				mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(portConfig, nil)
+				mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress2), []string(nil)).Return(portConfig, nil)
+				mockSystemConf.On("GetSystemConfParams", ctx, portSpec(pciAddress), "conf3", 0).
+					Return(map[string]string{"BOARD_CONFIGURATION_MODE": "0"}, nil)
+				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, portConfig).
+					Return(map[string]string{}, nil)
+				mockNV.On("SetNvConfigParametersBatch", portSpec(pciAddress),
+					map[string]string{"BOARD_CONFIGURATION_MODE": "0"}, false, false).Return(types.ApplyStatusSuccess, nil)
+				mockNV.On("SetNvConfigParametersBatch", portSpec(pciAddress2),
+					map[string]string{"BOARD_CONFIGURATION_MODE": "0"}, false, false).Return(types.ApplyStatusSuccess, nil)
+
+				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Status).To(Equal(types.ApplyStatusSuccess))
+				Expect(result.RebootRequired).To(BeTrue())
+			})
+
+			It("passes force to the regular batch containing profile parameters", func() {
 				mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(nvConfig, nil)
-				mockNV.On("ValidateSystemConf", ctx, portSpec(pciAddress), "conf3", 0).
-					Return(mismatchSystemConf("BOARD_CONFIGURATION_MODE")...)
+				mockSystemConf.On("GetSystemConfParams", ctx, portSpec(pciAddress), "conf3", 0).
+					Return(map[string]string{"BOARD_CONFIGURATION_MODE": "0"}, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, nvConfig).
 					Return(map[string]string{}, nil)
-				mockNV.On("SetSystemConf", ctx, portSpec(pciAddress), "conf3", 0, true).Return(nil)
+				mockNV.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"BOARD_CONFIGURATION_MODE": "0"}, false, true).
+					Return(types.ApplyStatusSuccess, nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{Force: true})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.RebootRequired).To(BeTrue())
 			})
 
-			It("stages set_system_conf before the regular nv param batch", func() {
+			It("combines profile and explicit parameters in one batch", func() {
 				portConfig := types.NvConfigQuery{
-					CurrentConfig:  map[string][]string{"param1": {"value1"}},
-					NextBootConfig: map[string][]string{"param1": {"value1"}},
+					CurrentConfig:  map[string][]string{"param1": {"value1"}, "BOARD_CONFIGURATION_MODE": {"1"}},
+					NextBootConfig: map[string][]string{"param1": {"value1"}, "BOARD_CONFIGURATION_MODE": {"1"}},
 					DefaultConfig:  map[string][]string{"param1": {"default1"}},
 				}
 				mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(portConfig, nil)
-				mockNV.On("ValidateSystemConf", ctx, portSpec(pciAddress), "conf3", 0).
-					Return(mismatchSystemConf("BOARD_CONFIGURATION_MODE")...)
+				mockSystemConf.On("GetSystemConfParams", ctx, portSpec(pciAddress), "conf3", 0).
+					Return(map[string]string{"BOARD_CONFIGURATION_MODE": "0"}, nil)
 				mockConfigValidation.On("ConstructNvParamMapFromTemplate", device, portConfig).
 					Return(map[string]string{"param1": "value2"}, nil)
-				setSystemConfCall := mockNV.On("SetSystemConf", ctx, portSpec(pciAddress), "conf3", 0, false).Return(nil)
-				// set_system_conf is the baseline and must be staged before the override batch.
-				mockNV.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"param1": "value2"}, false, false).
-					Return(types.ApplyStatusSuccess, nil).NotBefore(setSystemConfCall)
+				mockNV.On("SetNvConfigParametersBatch", portSpec(pciAddress),
+					map[string]string{"BOARD_CONFIGURATION_MODE": "0", "param1": "value2"}, false, false).
+					Return(types.ApplyStatusSuccess, nil)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.RebootRequired).To(BeTrue())
 			})
 
-			It("resets and never touches system_conf when ResetToDefault is set", func() {
-				// Guards against the reset/set_system_conf reboot loop: reset runs, set_system_conf does not.
+			It("resets without resolving the profile when ResetToDefault is set", func() {
 				device.Spec.Configuration.ResetToDefault = true
 				mockNV.On("QueryNvConfig", ctx, portSpec(pciAddress), []string(nil)).Return(nvConfig, nil)
 				mockNV.On("ResetNvConfig", portSpec(pciAddress)).Return(nil)
-				mockNV.AssertNotCalled(GinkgoT(), "SetSystemConf", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 
 				result, err := manager.ApplyNVConfiguration(ctx, device, &types.ConfigurationOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.RebootRequired).To(BeTrue())
+				mockSystemConf.AssertNotCalled(GinkgoT(), "GetSystemConfParams", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 			})
 		})
 
 		// Full-flow suite: real configValidation (mocked ConfigurationUtils + SpectrumXManager + NVConfigUtils)
-		// so the whole chain — system_conf validate, the rawNvConfig > Spectrum-X > template merge inside
-		// ConstructNvParamMapFromTemplate, coverage check, and apply — runs end to end. Each case drives BOTH
-		// ValidateDeviceNvSpec and ApplyNVConfiguration and asserts the concrete SetSystemConf /
+		// so the whole chain — system profile resolution, priority merging, validation, and apply — runs end
+		// to end. Each case drives both ValidateDeviceNvSpec and ApplyNVConfiguration and asserts the concrete
 		// SetNvConfigParametersBatch calls. ConstructNvParamMapFromTemplate always emits SRIOV_EN=0 /
 		// NUM_OF_VFS=0 for an empty template, so every fixture stages those to keep them out of the assertions.
-		Describe("Network Bay system_conf full flow (validate + apply)", func() {
+		Describe("Network Bay system profile full flow (validate + apply)", func() {
 			var (
-				fullFlowHostUtils mocks.ConfigurationUtils
-				fullFlowNV        *nvconfigmocks.NVConfigUtils
-				fullFlowSpcX      *spcxmocks.SpectrumXManager
-				fullFlowManager   configurationManager
-				fullFlowCtx       context.Context
-				fullFlowDevice    *v1alpha1.NicDevice
+				fullFlowHostUtils  mocks.ConfigurationUtils
+				fullFlowNV         *nvconfigmocks.NVConfigUtils
+				fullFlowSystemConf *systemConfParamsProviderMock
+				fullFlowSpcX       *spcxmocks.SpectrumXManager
+				fullFlowManager    configurationManager
+				fullFlowCtx        context.Context
+				fullFlowDevice     *v1alpha1.NicDevice
 			)
 
 			BeforeEach(func() {
 				fullFlowHostUtils = mocks.ConfigurationUtils{}
 				fullFlowNV = nvconfigmocks.NewNVConfigUtils(GinkgoT())
+				fullFlowSystemConf = &systemConfParamsProviderMock{}
 				fullFlowSpcX = spcxmocks.NewSpectrumXManager(GinkgoT())
 				fullFlowManager = configurationManager{
 					configurationUtils:     &fullFlowHostUtils,
 					configValidation:       newConfigValidation(&fullFlowHostUtils, nil, fullFlowSpcX),
 					nvConfigUtils:          fullFlowNV,
+					systemConfParams:       fullFlowSystemConf,
 					spectrumXConfigManager: fullFlowSpcX,
 				}
 				fullFlowCtx = context.TODO()
@@ -1765,12 +1805,13 @@ var _ = Describe("ConfigurationManager", func() {
 				return m
 			}
 
-			// 1) system_conf valid, no overrides → nothing to do, no set_system_conf.
-			It("1: valid system_conf with no overrides converges without applying anything", func() {
+			// 1) Empty profile layer and no overrides beyond staged defaults: nothing to do.
+			It("1: a profile with no additional params converges without applying anything", func() {
 				staged := sriovStaged(nil)
 				fullFlowNV.On("QueryNvConfig", fullFlowCtx, portSpec(pciAddress), []string(nil)).Return(
 					types.NvConfigQuery{NextBootConfig: staged, CurrentConfig: staged}, nil)
-				fullFlowNV.On("ValidateSystemConf", fullFlowCtx, portSpec(pciAddress), "conf3", 0).Return(okSystemConf()...)
+				fullFlowSystemConf.On("GetSystemConfParams", fullFlowCtx, portSpec(pciAddress), "conf3", 0).
+					Return(map[string]string{}, nil)
 
 				updateNeeded, rebootNeeded, _, err := fullFlowManager.ValidateDeviceNvSpec(fullFlowCtx, fullFlowDevice)
 				Expect(err).NotTo(HaveOccurred())
@@ -1781,18 +1822,18 @@ var _ = Describe("ConfigurationManager", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.Status).To(Equal(types.ApplyStatusNothingToDo))
 				Expect(result.RebootRequired).To(BeFalse())
-				fullFlowNV.AssertNotCalled(GinkgoT(), "SetSystemConf", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 				fullFlowNV.AssertNotCalled(GinkgoT(), "SetNvConfigParametersBatch", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 			})
 
-			// 2) system_conf mismatch, no overrides → set_system_conf re-applied.
-			It("2: system_conf mismatch with no overrides re-applies set_system_conf", func() {
-				staged := sriovStaged(nil)
+			// 2) A differing profile value is staged through the ordinary mlxconfig batch.
+			It("2: a differing profile value is applied through the regular batch", func() {
+				staged := sriovStaged(map[string][]string{"BOARD_CONFIGURATION_MODE": {"1"}})
 				fullFlowNV.On("QueryNvConfig", fullFlowCtx, portSpec(pciAddress), []string(nil)).Return(
 					types.NvConfigQuery{NextBootConfig: staged, CurrentConfig: staged}, nil)
-				fullFlowNV.On("ValidateSystemConf", fullFlowCtx, portSpec(pciAddress), "conf3", 0).
-					Return(mismatchSystemConf("BOARD_CONFIGURATION_MODE")...)
-				fullFlowNV.On("SetSystemConf", fullFlowCtx, portSpec(pciAddress), "conf3", 0, false).Return(nil)
+				fullFlowSystemConf.On("GetSystemConfParams", fullFlowCtx, portSpec(pciAddress), "conf3", 0).
+					Return(map[string]string{"BOARD_CONFIGURATION_MODE": "0"}, nil)
+				fullFlowNV.On("SetNvConfigParametersBatch", portSpec(pciAddress),
+					map[string]string{"BOARD_CONFIGURATION_MODE": "0"}, false, false).Return(types.ApplyStatusSuccess, nil)
 
 				updateNeeded, rebootNeeded, _, err := fullFlowManager.ValidateDeviceNvSpec(fullFlowCtx, fullFlowDevice)
 				Expect(err).NotTo(HaveOccurred())
@@ -1803,17 +1844,16 @@ var _ = Describe("ConfigurationManager", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.Status).To(Equal(types.ApplyStatusSuccess))
 				Expect(result.RebootRequired).To(BeTrue())
-				fullFlowNV.AssertNotCalled(GinkgoT(), "SetNvConfigParametersBatch", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 			})
 
-			// 3) system_conf mismatch, rawNvConfig covers it and the value is already staged → converged.
-			It("3: system_conf mismatch fully covered by an already-applied rawNvConfig override converges", func() {
+			// 3) rawNvConfig replaces a profile value and is already staged: converged.
+			It("3: an already-applied rawNvConfig override replaces the profile value", func() {
 				fullFlowDevice.Spec.Configuration.Template.RawNvConfig = []v1alpha1.NvConfigParam{{Name: "NUM_OF_PF", Value: "8"}}
 				staged := sriovStaged(map[string][]string{"NUM_OF_PF": {"8"}})
 				fullFlowNV.On("QueryNvConfig", fullFlowCtx, portSpec(pciAddress), []string(nil)).Return(
 					types.NvConfigQuery{NextBootConfig: staged, CurrentConfig: staged}, nil)
-				fullFlowNV.On("ValidateSystemConf", fullFlowCtx, portSpec(pciAddress), "conf3", 0).
-					Return(mismatchSystemConf("NUM_OF_PF")...)
+				fullFlowSystemConf.On("GetSystemConfParams", fullFlowCtx, portSpec(pciAddress), "conf3", 0).
+					Return(map[string]string{"NUM_OF_PF": "4"}, nil)
 
 				updateNeeded, rebootNeeded, _, err := fullFlowManager.ValidateDeviceNvSpec(fullFlowCtx, fullFlowDevice)
 				Expect(err).NotTo(HaveOccurred())
@@ -1823,19 +1863,17 @@ var _ = Describe("ConfigurationManager", func() {
 				result, err := fullFlowManager.ApplyNVConfiguration(fullFlowCtx, fullFlowDevice, &types.ConfigurationOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.Status).To(Equal(types.ApplyStatusNothingToDo))
-				fullFlowNV.AssertNotCalled(GinkgoT(), "SetSystemConf", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 				fullFlowNV.AssertNotCalled(GinkgoT(), "SetNvConfigParametersBatch", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 			})
 
-			// 4) system_conf mismatch covered by rawNvConfig by name, but the override value is not yet staged →
-			//    no set_system_conf, but the rawNvConfig param is applied.
-			It("4: rawNvConfig covers the mismatch by name but differs in value — applies the raw param, not set_system_conf", func() {
+			// 4) A rawNvConfig value wins over the profile and is applied when not yet staged.
+			It("4: a differing rawNvConfig override is applied instead of the profile value", func() {
 				fullFlowDevice.Spec.Configuration.Template.RawNvConfig = []v1alpha1.NvConfigParam{{Name: "NUM_OF_PF", Value: "8"}}
 				staged := sriovStaged(map[string][]string{"NUM_OF_PF": {"1"}})
 				fullFlowNV.On("QueryNvConfig", fullFlowCtx, portSpec(pciAddress), []string(nil)).Return(
 					types.NvConfigQuery{NextBootConfig: staged, CurrentConfig: staged}, nil)
-				fullFlowNV.On("ValidateSystemConf", fullFlowCtx, portSpec(pciAddress), "conf3", 0).
-					Return(mismatchSystemConf("NUM_OF_PF")...)
+				fullFlowSystemConf.On("GetSystemConfParams", fullFlowCtx, portSpec(pciAddress), "conf3", 0).
+					Return(map[string]string{"NUM_OF_PF": "4"}, nil)
 				fullFlowNV.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"NUM_OF_PF": "8"}, false, false).
 					Return(types.ApplyStatusSuccess, nil)
 
@@ -1848,19 +1886,18 @@ var _ = Describe("ConfigurationManager", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.Status).To(Equal(types.ApplyStatusSuccess))
 				Expect(result.RebootRequired).To(BeTrue())
-				fullFlowNV.AssertNotCalled(GinkgoT(), "SetSystemConf", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 			})
 
-			// 5) system_conf mismatch, Spectrum-X covers it and the value is already staged, no raw → converged.
-			It("5: system_conf mismatch fully covered by an already-applied Spectrum-X override converges", func() {
+			// 5) Spectrum-X replaces a profile value and is already staged: converged.
+			It("5: an already-applied Spectrum-X value replaces the profile value", func() {
 				fullFlowDevice.Spec.Configuration.Template.SpectrumXOptimized = &v1alpha1.SpectrumXOptimizedSpec{Enabled: true}
 				fullFlowSpcX.On("GetBreakoutMlxConfig", fullFlowDevice).Return(map[string]string{"NUM_OF_PF": "2"}, nil)
 				fullFlowSpcX.On("GetPostBreakoutMlxConfig", fullFlowDevice).Return(nil, nil)
 				staged := sriovStaged(map[string][]string{"NUM_OF_PF": {"2"}})
 				fullFlowNV.On("QueryNvConfig", fullFlowCtx, portSpec(pciAddress), []string(nil)).Return(
 					types.NvConfigQuery{NextBootConfig: staged, CurrentConfig: staged}, nil)
-				fullFlowNV.On("ValidateSystemConf", fullFlowCtx, portSpec(pciAddress), "conf3", 0).
-					Return(mismatchSystemConf("NUM_OF_PF")...)
+				fullFlowSystemConf.On("GetSystemConfParams", fullFlowCtx, portSpec(pciAddress), "conf3", 0).
+					Return(map[string]string{"NUM_OF_PF": "4"}, nil)
 
 				updateNeeded, rebootNeeded, _, err := fullFlowManager.ValidateDeviceNvSpec(fullFlowCtx, fullFlowDevice)
 				Expect(err).NotTo(HaveOccurred())
@@ -1870,7 +1907,6 @@ var _ = Describe("ConfigurationManager", func() {
 				result, err := fullFlowManager.ApplyNVConfiguration(fullFlowCtx, fullFlowDevice, &types.ConfigurationOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.Status).To(Equal(types.ApplyStatusNothingToDo))
-				fullFlowNV.AssertNotCalled(GinkgoT(), "SetSystemConf", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 				fullFlowNV.AssertNotCalled(GinkgoT(), "SetNvConfigParametersBatch", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 			})
 
@@ -1888,8 +1924,8 @@ var _ = Describe("ConfigurationManager", func() {
 				staged := sriovStaged(map[string][]string{"NUM_OF_PF": {"8"}, "LINK_TYPE_P1": {"1"}})
 				fullFlowNV.On("QueryNvConfig", fullFlowCtx, portSpec(pciAddress), []string(nil)).Return(
 					types.NvConfigQuery{NextBootConfig: staged, CurrentConfig: staged}, nil)
-				fullFlowNV.On("ValidateSystemConf", fullFlowCtx, portSpec(pciAddress), "conf3", 0).
-					Return(mismatchSystemConf("NUM_OF_PF", "LINK_TYPE_P1")...)
+				fullFlowSystemConf.On("GetSystemConfParams", fullFlowCtx, portSpec(pciAddress), "conf3", 0).
+					Return(map[string]string{"NUM_OF_PF": "4", "LINK_TYPE_P1": "3"}, nil)
 				// Only LINK_TYPE_P1 differs from next boot; the raw value 2 wins over the Spectrum-X value 1.
 				fullFlowNV.On("SetNvConfigParametersBatch", portSpec(pciAddress), map[string]string{"LINK_TYPE_P1": "2"}, false, false).
 					Return(types.ApplyStatusSuccess, nil)
@@ -1903,7 +1939,6 @@ var _ = Describe("ConfigurationManager", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.Status).To(Equal(types.ApplyStatusSuccess))
 				Expect(result.RebootRequired).To(BeTrue())
-				fullFlowNV.AssertNotCalled(GinkgoT(), "SetSystemConf", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 			})
 
 			// 7) Same as (6) but a template-derived param (NUM_OF_VFS from NumVfs) is also partly overridden by
@@ -1926,8 +1961,8 @@ var _ = Describe("ConfigurationManager", func() {
 				}
 				fullFlowNV.On("QueryNvConfig", fullFlowCtx, portSpec(pciAddress), []string(nil)).Return(
 					types.NvConfigQuery{NextBootConfig: staged, CurrentConfig: staged}, nil)
-				fullFlowNV.On("ValidateSystemConf", fullFlowCtx, portSpec(pciAddress), "conf3", 0).
-					Return(mismatchSystemConf("NUM_OF_PF", "LINK_TYPE_P1")...)
+				fullFlowSystemConf.On("GetSystemConfParams", fullFlowCtx, portSpec(pciAddress), "conf3", 0).
+					Return(map[string]string{"NUM_OF_PF": "4", "LINK_TYPE_P1": "3"}, nil)
 				// Raw wins on both: LINK_TYPE_P1 over Spectrum-X (1→2) and NUM_OF_VFS over template (4→16).
 				fullFlowNV.On("SetNvConfigParametersBatch", portSpec(pciAddress),
 					map[string]string{"LINK_TYPE_P1": "2", consts.SriovNumOfVfsParam: "16"}, false, false).Return(types.ApplyStatusSuccess, nil)
@@ -1941,7 +1976,6 @@ var _ = Describe("ConfigurationManager", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.Status).To(Equal(types.ApplyStatusSuccess))
 				Expect(result.RebootRequired).To(BeTrue())
-				fullFlowNV.AssertNotCalled(GinkgoT(), "SetSystemConf", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 			})
 		})
 	})

--- a/pkg/nvconfig/systemconf.go
+++ b/pkg/nvconfig/systemconf.go
@@ -1,0 +1,166 @@
+/*
+2026 NVIDIA CORPORATION & AFFILIATES
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nvconfig
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/Mellanox/nic-configuration-operator/api/v1alpha1"
+)
+
+const (
+	maxSystemConfOutputSize = 1024 * 1024
+	maxSystemConfRangeSize  = 4096
+)
+
+var systemConfAsicHeader = regexp.MustCompile(`^ASIC\[([0-9]+)\]\s+Description:$`)
+var systemConfParamRange = regexp.MustCompile(`^(.+)\[([0-9]+)\.\.([0-9]+)\]$`)
+
+// SystemConfParamsProvider resolves a named mlxconfig system configuration into ordinary
+// mlxconfig parameter assignments for one ASIC.
+type SystemConfParamsProvider interface {
+	GetSystemConfParams(ctx context.Context, port v1alpha1.NicDevicePortSpec, conf string, asic int) (map[string]string, error)
+}
+
+var _ SystemConfParamsProvider = (*nvConfigUtils)(nil)
+
+// GetSystemConfParams queries the profiles available to a device and returns the selected ASIC's
+// assignments. Array ranges are expanded so callers can merge individual keys with explicit values.
+func (h *nvConfigUtils) GetSystemConfParams(
+	ctx context.Context, port v1alpha1.NicDevicePortSpec, conf string, asic int) (map[string]string, error) {
+	targetDevice := resolveDevice(port)
+	log.Log.Info("ConfigurationUtils.GetSystemConfParams()", "pciAddr", port.PCI, "targetDevice", targetDevice, "conf", conf, "asic", asic)
+
+	output, err := h.execInterface.CommandContext(ctx, "mlxconfig", "-d", targetDevice, "show_system_conf").CombinedOutput()
+	log.Log.V(2).Info("command output", "command", "mlxconfig show_system_conf", "pciAddr", port.PCI, "targetDevice", targetDevice, "output", string(output))
+	if err != nil {
+		log.Log.Error(err, "GetSystemConfParams(): Failed to run mlxconfig", "pciAddr", port.PCI, "targetDevice", targetDevice)
+		return nil, fmt.Errorf("failed to show mlxconfig system configurations: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+
+	params, err := parseShowSystemConf(output, conf, asic)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve system configuration %s[%d]: %w", conf, asic, err)
+	}
+	return params, nil
+}
+
+func parseShowSystemConf(output []byte, conf string, asic int) (map[string]string, error) {
+	params := map[string]string{}
+	foundConf := false
+	foundAsic := false
+	selectedConf := false
+	selectedAsic := false
+
+	scanner := bufio.NewScanner(strings.NewReader(string(output)))
+	scanner.Buffer(make([]byte, 64*1024), maxSystemConfOutputSize)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "Configuration name:") {
+			details := strings.TrimSpace(strings.TrimPrefix(line, "Configuration name:"))
+			fields := strings.Fields(details)
+			selectedConf = len(fields) > 0 && fields[0] == conf
+			selectedAsic = false
+			foundConf = foundConf || selectedConf
+			continue
+		}
+
+		if matches := systemConfAsicHeader.FindStringSubmatch(line); len(matches) == 2 {
+			selectedAsic = false
+			if !selectedConf {
+				continue
+			}
+			asicNumber, err := strconv.Atoi(matches[1])
+			if err != nil {
+				return nil, fmt.Errorf("invalid ASIC number %q: %w", matches[1], err)
+			}
+			selectedAsic = asicNumber == asic
+			foundAsic = foundAsic || selectedAsic
+			continue
+		}
+
+		if !selectedAsic || !strings.Contains(line, "=") {
+			continue
+		}
+		for _, assignment := range strings.Fields(line) {
+			name, value, ok := strings.Cut(assignment, "=")
+			if !ok || name == "" || value == "" {
+				return nil, fmt.Errorf("invalid parameter assignment %q", assignment)
+			}
+			if err := addSystemConfParam(params, name, value); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to scan show_system_conf output: %w", err)
+	}
+	if !foundConf {
+		return nil, fmt.Errorf("configuration %q was not found", conf)
+	}
+	if !foundAsic {
+		return nil, fmt.Errorf("ASIC %d was not found for configuration %q", asic, conf)
+	}
+	if len(params) == 0 {
+		return nil, fmt.Errorf("configuration %q ASIC %d contains no parameters", conf, asic)
+	}
+	return params, nil
+}
+
+func addSystemConfParam(params map[string]string, name, value string) error {
+	matches := systemConfParamRange.FindStringSubmatch(name)
+	if len(matches) == 0 {
+		return addUniqueSystemConfParam(params, name, value)
+	}
+
+	start, err := strconv.Atoi(matches[2])
+	if err != nil {
+		return fmt.Errorf("invalid range start in parameter %q: %w", name, err)
+	}
+	end, err := strconv.Atoi(matches[3])
+	if err != nil {
+		return fmt.Errorf("invalid range end in parameter %q: %w", name, err)
+	}
+	if end < start {
+		return fmt.Errorf("invalid descending range in parameter %q", name)
+	}
+	if end-start+1 > maxSystemConfRangeSize {
+		return fmt.Errorf("range in parameter %q exceeds maximum size %d", name, maxSystemConfRangeSize)
+	}
+
+	for index := start; index <= end; index++ {
+		concreteName := fmt.Sprintf("%s[%d]", matches[1], index)
+		if err := addUniqueSystemConfParam(params, concreteName, value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func addUniqueSystemConfParam(params map[string]string, name, value string) error {
+	if _, exists := params[name]; exists {
+		return fmt.Errorf("duplicate parameter %q", name)
+	}
+	params[name] = value
+	return nil
+}

--- a/pkg/nvconfig/systemconf_test.go
+++ b/pkg/nvconfig/systemconf_test.go
@@ -1,0 +1,142 @@
+/*
+2026 NVIDIA CORPORATION & AFFILIATES
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nvconfig
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	execUtils "k8s.io/utils/exec"
+	execTesting "k8s.io/utils/exec/testing"
+
+	"github.com/Mellanox/nic-configuration-operator/api/v1alpha1"
+)
+
+var _ = Describe("system configuration profiles", func() {
+	const showSystemConfOutput = `System configurations available for ConnectX9 devices:
+
+Configuration name: conf2 - Single port
+Description: another profile
+----------------------------------------------------------------
+    ASIC[0] Description:
+        BOARD_CONFIGURATION_MODE=1 NUM_OF_PF=1
+
+Configuration name: conf3 - Dual ASIC Network Bay
+Description: selected profile
+----------------------------------------------------------------
+    ASIC[0] Description:
+        BOARD_CONFIGURATION_MODE=0 MODULE_SPLIT_M0[0]=1 MODULE_SPLIT_M0[4..6]=FF LINK_TYPE_P1=2
+    ASIC[1] Description:
+        BOARD_CONFIGURATION_MODE=1 MODULE_SPLIT_M1[0..1]=7
+`
+
+	Describe("parseShowSystemConf", func() {
+		It("selects the requested profile and ASIC and expands ranged parameters", func() {
+			params, err := parseShowSystemConf([]byte(showSystemConfOutput), "conf3", 0)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(params).To(Equal(map[string]string{
+				"BOARD_CONFIGURATION_MODE": "0",
+				"MODULE_SPLIT_M0[0]":       "1",
+				"MODULE_SPLIT_M0[4]":       "FF",
+				"MODULE_SPLIT_M0[5]":       "FF",
+				"MODULE_SPLIT_M0[6]":       "FF",
+				"LINK_TYPE_P1":             "2",
+			}))
+		})
+
+		It("selects a different ASIC independently", func() {
+			params, err := parseShowSystemConf([]byte(showSystemConfOutput), "conf3", 1)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(params).To(Equal(map[string]string{
+				"BOARD_CONFIGURATION_MODE": "1",
+				"MODULE_SPLIT_M1[0]":       "7",
+				"MODULE_SPLIT_M1[1]":       "7",
+			}))
+		})
+
+		It("returns an error when the profile is absent", func() {
+			_, err := parseShowSystemConf([]byte(showSystemConfOutput), "conf99", 0)
+			Expect(err).To(MatchError(ContainSubstring(`configuration "conf99" was not found`)))
+		})
+
+		It("returns an error when the ASIC is absent", func() {
+			_, err := parseShowSystemConf([]byte(showSystemConfOutput), "conf3", 2)
+			Expect(err).To(MatchError(ContainSubstring(`ASIC 2 was not found`)))
+		})
+
+		It("rejects descending ranges", func() {
+			output := "Configuration name: conf3 - profile\nASIC[0] Description:\nPARAM[3..1]=FF\n"
+			_, err := parseShowSystemConf([]byte(output), "conf3", 0)
+			Expect(err).To(MatchError(ContainSubstring("invalid descending range")))
+		})
+
+		It("rejects duplicate concrete parameters", func() {
+			output := "Configuration name: conf3 - profile\nASIC[0] Description:\nPARAM[0..1]=1 PARAM[1]=2\n"
+			_, err := parseShowSystemConf([]byte(output), "conf3", 0)
+			Expect(err).To(MatchError(ContainSubstring(`duplicate parameter "PARAM[1]"`)))
+		})
+	})
+
+	Describe("GetSystemConfParams", func() {
+		var (
+			h        *nvConfigUtils
+			fakeExec *execTesting.FakeExec
+		)
+
+		BeforeEach(func() {
+			fakeExec = &execTesting.FakeExec{}
+			h = &nvConfigUtils{execInterface: fakeExec}
+		})
+
+		It("runs show_system_conf against the fwctl target", func() {
+			cmd := &execTesting.FakeCmd{}
+			cmd.CombinedOutputScript = append(cmd.CombinedOutputScript, func() ([]byte, []byte, error) {
+				return []byte(showSystemConfOutput), nil, nil
+			})
+			fakeExec.CommandScript = []execTesting.FakeCommandAction{
+				func(name string, args ...string) execUtils.Cmd {
+					Expect(name).To(Equal("mlxconfig"))
+					Expect(args).To(Equal([]string{"-d", "/dev/fwctl/fwctl2", "show_system_conf"}))
+					return cmd
+				},
+			}
+			port := v1alpha1.NicDevicePortSpec{PCI: "0000:0b:00.0", FwctlDevice: "/dev/fwctl/fwctl2"}
+
+			params, err := h.GetSystemConfParams(context.TODO(), port, "conf3", 1)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(params).To(HaveKeyWithValue("MODULE_SPLIT_M1[1]", "7"))
+		})
+
+		It("includes command output when mlxconfig fails", func() {
+			cmd := &execTesting.FakeCmd{}
+			cmd.CombinedOutputScript = append(cmd.CombinedOutputScript, func() ([]byte, []byte, error) {
+				return []byte("device unsupported"), nil, fmt.Errorf("exit status 1")
+			})
+			fakeExec.CommandScript = []execTesting.FakeCommandAction{
+				func(_ string, _ ...string) execUtils.Cmd { return cmd },
+			}
+
+			_, err := h.GetSystemConfParams(context.TODO(), nvconfigPort("0000:0b:00.0"), "conf3", 0)
+
+			Expect(err).To(MatchError(ContainSubstring("device unsupported")))
+		})
+	})
+})

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -96,7 +96,7 @@ type FirmwareInstallOptions struct {
 type ConfigurationOptions struct {
 	SkipReset   bool // Skip mlxfwreset after NV config apply
 	WithDefault bool // Add --with_default flag to mlxconfig set
-	Force       bool // Add --force flag to mlxconfig set / set_system_conf
+	Force       bool // Add --force flag to mlxconfig set
 }
 
 // DesiredRuntimeConfig holds the desired runtime configuration for a NIC device


### PR DESCRIPTION
## Summary

- resolve the selected Network Bay profile and ASIC with `mlxconfig show_system_conf`
- expand ranged assignments and merge profile parameters below Spectrum-X, template, and raw overrides
- validate and apply the merged parameters through the existing per-target mlxconfig flow with normalized value comparisons
- update tests, CRDs, and documentation for the new behavior

## Testing

- `make test`
- `go build ./...`
- `make lint`